### PR TITLE
Add CI workflow with Node 20/22 matrix and shellcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20', '22']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js ${{ matrix.node }}
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund || npm install --no-audit --no-fund
+
+      - name: Syntax check
+        run: node --check extension/extension.mjs && node --check extension/handler.mjs
+
+      - name: Run tests
+        run: npm test
+
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Run shellcheck
+        run: shellcheck install.sh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 > Ralph Wiggum-style autonomous iterative loop for **GitHub Copilot CLI**, implemented as an in-session extension.
 
+[![CI](https://github.com/kloba/copilot-ralph-extension/actions/workflows/ci.yml/badge.svg)](https://github.com/kloba/copilot-ralph-extension/actions/workflows/ci.yml)
 [![Inspired by](https://img.shields.io/badge/inspired_by-Anthropic_Ralph_Wiggum-blue)](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum)
 
 **Contents:** [What is Ralph?](#what-is-ralph-wiggum) · [What's different](#whats-different-here) · [Install](#install) · [Usage](#usage) · [Self-improve](#self-improve-self_improve-tool) · [Grow-project](#grow-project-grow_project-tool) · [How it works](#how-it-works) · [Commit attribution](#commit-attribution) · [Troubleshooting](#troubleshooting) · [Limitations](#limitations) · [Requirements](#requirements) · [Changelog](#changelog)


### PR DESCRIPTION
Adds GitHub Actions CI on every push/PR to `main`.

## Changes
- New `.github/workflows/ci.yml` with two jobs:
  - **test** — `ubuntu-latest`, Node 20 + Node 22 matrix, runs `node --check` on extension files and `npm test`
  - **shellcheck** — lints `install.sh`
- Actions pinned by SHA with trailing version comment
- Workflow-level `permissions: contents: read` (least privilege)
- CI status badge added to README

## Acceptance criteria
- [x] Workflow runs on `push` to main and `pull_request` to main
- [x] Uses `ubuntu-latest` (GitHub-hosted), never self-hosted
- [x] Actions pinned by SHA, not floating tags
- [x] `permissions: contents: read` at workflow level
- [x] Status badge in README

Fixes #9