### PR TITLE
Optional caffeinate integration to prevent system sleep during ralph loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/kloba/copilot-ralph-extension/actions/workflows/ci.yml/badge.svg)](https://github.com/kloba/copilot-ralph-extension/actions/workflows/ci.yml)
 [![Inspired by](https://img.shields.io/badge/inspired_by-Anthropic_Ralph_Wiggum-blue)](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum)
 
-**Contents:** [What is Ralph?](#what-is-ralph-wiggum) · [What's different](#whats-different-here) · [Install](#install) · [Usage](#usage) · [Self-improve](#self-improve-self_improve-tool) · [Grow-project](#grow-project-grow_project-tool) · [Documentation](#documentation) · [How it works](#how-it-works) · [Commit attribution](#commit-attribution) · [Troubleshooting](#troubleshooting) · [Limitations](#limitations) · [Requirements](#requirements) · [Changelog](#changelog)
+**Contents:** [What is Ralph?](#what-is-ralph-wiggum) · [What's different](#whats-different-here) · [Install](#install) · [Usage](#usage) · [Self-improve](#self-improve-self_improve-tool) · [Grow-project](#grow-project-grow_project-tool) · [Documentation](#documentation) · [How it works](#how-it-works) · [Commit attribution](#commit-attribution) · [Keep system awake](#keep-system-awake-caffeinate-macos) · [Troubleshooting](#troubleshooting) · [Limitations](#limitations) · [Requirements](#requirements) · [Changelog](#changelog)
 
 ## What is Ralph Wiggum?
 
@@ -339,6 +339,28 @@ RALPH_NO_ATTRIBUTION=1 copilot   # subsequent self_improve/grow_project loops om
 - **Only public-repo commits are searchable.** GitHub's commit search API does not index private repositories, so private-repo loops are invisible to `gh search commits` regardless of the trailer. The bot-account profile likewise only shows public contributions.
 - **This is effectively opt-in telemetry via git metadata.** No data leaves your machine — the trailer is just text in the commit object — but anyone reading the public commit log can correlate it with extension usage. The opt-out exists so you can disable that correlation per session without forking the extension.
 - **The bot account must exist before commits are made.** Unregistered noreply emails do not link retroactively to a GitHub account once the account is created — the `copilot-ralph@users.noreply.github.com` mailbox (matching the trailer format used in the example block above) has to be claimed first, then the trailers will associate going forward.
+
+## Keep system awake (`caffeinate`, macOS)
+
+Long `ralph_loop` / `self_improve` / `grow_project` runs can outlast macOS's idle-sleep timeout, which interrupts in-flight tool calls and timers. Opt in to a `caffeinate`-backed sleep block for the duration of the loop:
+
+```bash
+RALPH_CAFFEINATE=1 copilot                                # block idle sleep only (default)
+RALPH_CAFFEINATE=1 RALPH_CAFFEINATE_SCOPE=idle+display copilot   # also keep the display awake
+```
+
+| Variable | Values | Default | Effect |
+|---|---|---|---|
+| `RALPH_CAFFEINATE` | `1` / `true` / `yes` / `on` (case-insensitive) — anything else disables | unset (disabled) | Master switch. When unset, the extension **never** spawns `caffeinate`. |
+| `RALPH_CAFFEINATE_SCOPE` | `idle` or `idle+display` | `idle` | `idle` blocks idle/system sleep but lets the display lock for security. `idle+display` also prevents display sleep. |
+
+Behaviour:
+
+- Spawns `caffeinate -i [-d] -w <pid>` on arm, where `<pid>` is the host CLI process. Logs a single line: `keeping system awake via caffeinate (pid=…, scope=…)`.
+- Killed automatically on loop completion, `ralph_stop`, abort, or detach. The `-w` flag is a belt-and-braces fallback so a hard crash of the CLI still releases the wake-lock.
+- **macOS only.** On Linux/Windows the helper is a silent no-op (a single log line records the skip). Future PRs may add `systemd-inhibit` / `SetThreadExecutionState` equivalents.
+- **Graceful when the binary is missing.** If `caffeinate` isn't on `PATH` or `spawn` fails, the loop runs without sleep prevention and logs the failure — it never aborts the loop over a power-management nicety.
+- **Disabled by default.** The extension does not modify system power state unless you set `RALPH_CAFFEINATE`.
 
 ## Troubleshooting
 

--- a/extension/handler.mjs
+++ b/extension/handler.mjs
@@ -12,6 +12,12 @@
 //
 // Inspired by the Stop-hook re-injection pattern.
 
+import { createRequire } from "node:module";
+
+// Lazy-resolved sync `require` so we can pull child_process only when caffeinate
+// is actually enabled, avoiding the import cost for the common (disabled) path.
+const moduleRequire = createRequire(import.meta.url);
+
 const DEFAULTS = Object.freeze({
     max_iterations: 20,
     min_iterations: 1,
@@ -355,6 +361,94 @@ function deepFreeze(obj) {
     return obj;
 }
 
+// ---------------------------------------------------------------------------
+// caffeinate integration (issue #8)
+//
+// Optional, opt-in macOS-only system-sleep prevention while a ralph loop is
+// active. Spawns `caffeinate -i [-d] -w <pid>` as a child process at arm-time
+// and kills it at finish-time. The `-w <pid>` flag ties caffeinate's lifetime
+// to the host process, so even if the loop crashes hard caffeinate exits with
+// the CLI — no orphaned wake-locks.
+//
+// Disabled by default. Enable via env var:
+//     RALPH_CAFFEINATE=1                 → enable, scope = idle (default)
+//     RALPH_CAFFEINATE_SCOPE=idle+display → also block display sleep
+//
+// On non-darwin platforms or when the binary is missing, the helper degrades
+// to a silent no-op — never fail the loop over a power-management nicety.
+// ---------------------------------------------------------------------------
+const CAFFEINATE_TRUTHY = new Set(["1", "true", "yes", "on"]);
+const CAFFEINATE_SCOPES = new Set(["idle", "idle+display"]);
+
+function isCaffeinateEnabled(env) {
+    const raw = env?.RALPH_CAFFEINATE;
+    if (typeof raw !== "string") return false;
+    return CAFFEINATE_TRUTHY.has(raw.trim().toLowerCase());
+}
+
+function resolveCaffeinateScope(env) {
+    const raw = env?.RALPH_CAFFEINATE_SCOPE;
+    if (typeof raw !== "string") return "idle";
+    const v = raw.trim().toLowerCase();
+    return CAFFEINATE_SCOPES.has(v) ? v : "idle";
+}
+
+function caffeinateFlagsForScope(scope) {
+    // -i: prevent idle sleep, -d: prevent display sleep.
+    return scope === "idle+display" ? "-id" : "-i";
+}
+
+/**
+ * Start a caffeinate child if enabled + supported. Returns a `stop()` function
+ * (idempotent) or null when no process was spawned. Never throws.
+ *
+ * @param {object} deps
+ * @param {NodeJS.ProcessEnv} deps.env
+ * @param {string} deps.platform - process.platform value
+ * @param {number} deps.pid - host process pid (for `-w`)
+ * @param {Function} deps.spawnFn - child_process.spawn-compatible
+ * @param {(msg: string) => void} deps.log
+ * @param {string} deps.label - "ralph_loop" | "self_improve" | "grow_project"
+ * @returns {(() => void) | null}
+ */
+function startCaffeinate({ env, platform, pid, spawnFn, log, label }) {
+    if (!isCaffeinateEnabled(env)) return null;
+    if (platform !== "darwin") {
+        log(`${label}: caffeinate skipped — platform ${platform} not supported (darwin only)`);
+        return null;
+    }
+    if (typeof spawnFn !== "function") return null;
+    const scope = resolveCaffeinateScope(env);
+    const flags = caffeinateFlagsForScope(scope);
+    const args = [flags, "-w", String(pid)];
+    let child;
+    try {
+        child = spawnFn("caffeinate", args, { stdio: "ignore", detached: false });
+    } catch (err) {
+        log(`${label}: caffeinate spawn failed (${err?.message ?? err}); continuing without sleep prevention`);
+        return null;
+    }
+    if (!child || typeof child.kill !== "function") {
+        log(`${label}: caffeinate spawn returned no child handle; continuing without sleep prevention`);
+        return null;
+    }
+    // Async error (binary missing, ENOENT) reported via 'error' event — never
+    // crash the host. Log + treat as a no-op; the kill() in stop() is safe
+    // even if the child never started.
+    if (typeof child.on === "function") {
+        child.on("error", (err) => {
+            log(`${label}: caffeinate error (${err?.message ?? err}); sleep prevention inactive`);
+        });
+    }
+    log(`${label}: keeping system awake via caffeinate (pid=${child.pid ?? "?"}, scope=${scope})`);
+    let stopped = false;
+    return () => {
+        if (stopped) return;
+        stopped = true;
+        try { child.kill("SIGTERM"); } catch { /* swallow */ }
+    };
+}
+
 function failure(message, extra = {}) {
     return { ...extra, textResultForLlm: message, resultType: "failure" };
 }
@@ -654,6 +748,7 @@ export function validateArgs(args) {
  * @property {number|null} maxTokens - Issue #7: opt-in token cap; null = disabled.
  * @property {number} warnAtPct - Issue #7: first context-window warning threshold (default 80, range 1..99). 95% second-threshold is hard-coded.
  * @property {{ input: number, output: number, byIteration: Array<object>, byModel: Object<string, {input:number, output:number}>, currentModel: string|null, warnedThresholds: number[], unknownModelLogged: boolean }} tokens - Issue #7: cumulative token bookkeeping. Initialized empty at arm-time; mutated in onAssistantMessage as usage events arrive.
+ * @property {(() => void) | null} stopCaffeinate - Idempotent killer for the optional caffeinate child (issue #8); null when sleep prevention is disabled or unsupported.
  */
 
 /**
@@ -671,7 +766,16 @@ export function validateArgs(args) {
  *   _internal: { onAssistantMessage: Function, onIdle: Function, onAbort: Function, finish: Function, success: Function, failure: Function }
  * }} Controller. See `attach()` for the detach contract.
  */
-export function createRalphController() {
+export function createRalphController(opts = {}) {
+    // Caffeinate dependency injection (issue #8). Tests pass stubs; production
+    // resolves child_process.spawn lazily so the import cost is paid only when
+    // RALPH_CAFFEINATE is actually enabled.
+    const caffeinateDeps = {
+        env: opts.caffeinate?.env ?? process.env,
+        platform: opts.caffeinate?.platform ?? process.platform,
+        pid: opts.caffeinate?.pid ?? process.pid,
+        spawnFn: opts.caffeinate?.spawnFn ?? null,
+    };
     const state = {
         active: null,           // ActiveLoopState; null when no loop is armed.
         lastAssistantContent: "",
@@ -726,7 +830,7 @@ export function createRalphController() {
 
     const finish = (reason, note) => {
         if (!state.active) return;
-        const { startedAt, i: iterations, label, tokens } = state.active;
+        const { startedAt, i: iterations, label, tokens, stopCaffeinate } = state.active;
         const finishedAt = Date.now();
         const durationMs = clampedElapsed(startedAt);
         const result = {
@@ -758,6 +862,12 @@ export function createRalphController() {
         log(`${verb} ${label} after ${iterations} iteration${pluralS(iterations)} (reason: ${reason}${noteForLog ? `, note: ${noteForLog}` : ""}, ${durationMs}ms)`);
         state.active = null;
         state.lastResult = Object.freeze(result);
+        // Tear down caffeinate AFTER state.active is cleared and lastResult is
+        // frozen so a kill-time crash can't leave the loop in a half-finished
+        // state.
+        if (typeof stopCaffeinate === "function") {
+            try { stopCaffeinate(); } catch { /* swallow */ }
+        }
     };
 
     // Issue #7: extract usage from an event payload. Defensive against
@@ -985,6 +1095,23 @@ export function createRalphController() {
     // state.active.label, the arm log line, and the success text so
     // every observable artifact reflects which tool armed the loop.
     function armLoop(parsedValue, label = "ralph_loop") {
+        // Resolve spawnFn lazily so child_process is only required when
+        // caffeinate is actually enabled (avoids paying the require cost
+        // for every loop arm). Tests inject spawnFn directly via opts.
+        let spawnFn = caffeinateDeps.spawnFn;
+        if (!spawnFn && isCaffeinateEnabled(caffeinateDeps.env) && caffeinateDeps.platform === "darwin") {
+            try {
+                ({ spawn: spawnFn } = moduleRequire("node:child_process"));
+            } catch { /* swallow — startCaffeinate handles null spawnFn */ }
+        }
+        const stopCaffeinate = startCaffeinate({
+            env: caffeinateDeps.env,
+            platform: caffeinateDeps.platform,
+            pid: caffeinateDeps.pid,
+            spawnFn,
+            log,
+            label,
+        });
         state.active = {
             ...parsedValue,
             label,
@@ -1004,6 +1131,7 @@ export function createRalphController() {
                 warnedThresholds: [],
                 unknownModelLogged: false,
             },
+            stopCaffeinate,
         };
         state.lastAssistantContent = "";
         state.lastResult = null;

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -499,8 +499,8 @@ test("validateArgs success returns exactly the documented value shape (no stray 
     assert.equal(r2.value.abortPromise, null);
 });
 
-test("state.active: arming sets exactly the documented 17-field ActiveLoopState shape", async () => {
-    // The ActiveLoopState typedef enumerates 17 fields. Pin the exact
+test("state.active: arming sets exactly the documented 18-field ActiveLoopState shape", async () => {
+    // The ActiveLoopState typedef enumerates 18 fields. Pin the exact
     // key set and initial values so future refactors that add or rename
     // a field have to update both the typedef and this test in lockstep.
     const { session, controller } = await arm({ max_iterations: 7, min_iterations: 2, abort_promise: "FAIL", stagnation_limit: 4 });
@@ -508,7 +508,7 @@ test("state.active: arming sets exactly the documented 17-field ActiveLoopState 
     assert.deepEqual(Object.keys(a).sort(), [
         "abortPromise", "completionPromise", "fireInFlight", "i",
         "label", "max", "maxTokens", "min", "observedMessageThisFire", "pendingFire",
-        "prev", "prompt", "stagnationLimit", "startedAt", "streak", "tokens", "warnAtPct",
+        "prev", "prompt", "stagnationLimit", "startedAt", "stopCaffeinate", "streak", "tokens", "warnAtPct",
     ]);
     assert.equal(a.i, 0);
     assert.equal(a.prev, null);
@@ -4586,4 +4586,172 @@ test("token tracking: tokens block omitted when no usage observed", async () => 
     await stop.handler({ reason: "no tokens" });
     const r = controller.state.lastResult;
     assert.equal(r.tokens, undefined);
+});
+
+// ── caffeinate integration (issue #8) ────────────────────────────────────
+
+function makeCaffeinateSpy({ failSpawn = false, failError = null } = {}) {
+    const calls = [];
+    const children = [];
+    const spawnFn = (cmd, args, opts) => {
+        calls.push({ cmd, args, opts });
+        if (failSpawn) throw new Error("spawn failed");
+        const child = {
+            pid: 99000 + calls.length,
+            killed: false,
+            killArgs: [],
+            errorHandler: null,
+            on(type, fn) {
+                if (type === "error") {
+                    this.errorHandler = fn;
+                    if (failError) queueMicrotask(() => fn(failError));
+                }
+            },
+            kill(sig) { this.killed = true; this.killArgs.push(sig); },
+        };
+        children.push(child);
+        return child;
+    };
+    return { calls, children, spawnFn };
+}
+
+async function armWithCaffeinate({ env = {}, platform = "darwin", spawnSpy } = {}) {
+    const session = makeFakeSession();
+    const controller = createRalphController({
+        caffeinate: {
+            env,
+            platform,
+            pid: 12345,
+            spawnFn: spawnSpy.spawnFn,
+        },
+    });
+    controller.attach(session);
+    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
+    const armResult = await ralph.handler({ prompt: "go", max_iterations: 3 });
+    return { session, controller, armResult, ralph };
+}
+
+test("caffeinate: disabled by default — no spawn, no log line", async () => {
+    const spy = makeCaffeinateSpy();
+    const { session, armResult } = await armWithCaffeinate({ env: {}, spawnSpy: spy });
+    assert.equal(armResult.armed, true);
+    assert.equal(spy.calls.length, 0, "must NOT spawn caffeinate when RALPH_CAFFEINATE is unset");
+    assert.equal(session.logs.some((l) => l.includes("caffeinate")), false, "no caffeinate log line when disabled");
+});
+
+test("caffeinate: enabled via RALPH_CAFFEINATE=1 spawns 'caffeinate -i -w <pid>' on darwin", async () => {
+    const spy = makeCaffeinateSpy();
+    const { session } = await armWithCaffeinate({
+        env: { RALPH_CAFFEINATE: "1" },
+        platform: "darwin",
+        spawnSpy: spy,
+    });
+    assert.equal(spy.calls.length, 1);
+    assert.equal(spy.calls[0].cmd, "caffeinate");
+    assert.deepEqual(spy.calls[0].args, ["-i", "-w", "12345"]);
+    assert.equal(spy.calls[0].opts.stdio, "ignore");
+    assert.equal(spy.calls[0].opts.detached, false);
+    assert.ok(session.logs.some((l) => /keeping system awake via caffeinate/.test(l)), "must log activation line");
+});
+
+test("caffeinate: scope=idle+display adds -d flag", async () => {
+    const spy = makeCaffeinateSpy();
+    await armWithCaffeinate({
+        env: { RALPH_CAFFEINATE: "1", RALPH_CAFFEINATE_SCOPE: "idle+display" },
+        platform: "darwin",
+        spawnSpy: spy,
+    });
+    assert.deepEqual(spy.calls[0].args, ["-id", "-w", "12345"]);
+});
+
+test("caffeinate: invalid scope falls back to idle", async () => {
+    const spy = makeCaffeinateSpy();
+    await armWithCaffeinate({
+        env: { RALPH_CAFFEINATE: "1", RALPH_CAFFEINATE_SCOPE: "bogus" },
+        platform: "darwin",
+        spawnSpy: spy,
+    });
+    assert.deepEqual(spy.calls[0].args, ["-i", "-w", "12345"]);
+});
+
+test("caffeinate: child is killed on loop completion", async () => {
+    const spy = makeCaffeinateSpy();
+    const { session, controller } = await armWithCaffeinate({
+        env: { RALPH_CAFFEINATE: "1" },
+        platform: "darwin",
+        spawnSpy: spy,
+    });
+    runTurn(session, "doing work");          // iter 1
+    runTurn(session, "still going COMPLETE"); // hits completion_promise
+    assert.equal(controller.state.active, null, "loop should be finished");
+    assert.equal(spy.children.length, 1);
+    assert.equal(spy.children[0].killed, true, "caffeinate child must be killed on finish");
+    assert.deepEqual(spy.children[0].killArgs, ["SIGTERM"]);
+});
+
+test("caffeinate: child is killed on ralph_stop", async () => {
+    const spy = makeCaffeinateSpy();
+    const { controller } = await armWithCaffeinate({
+        env: { RALPH_CAFFEINATE: "1" },
+        platform: "darwin",
+        spawnSpy: spy,
+    });
+    const stop = controller.tools.find((t) => t.name === "ralph_stop");
+    await stop.handler({});
+    assert.equal(spy.children[0].killed, true);
+});
+
+test("caffeinate: non-darwin platform is a silent no-op (logged skip, no spawn)", async () => {
+    const spy = makeCaffeinateSpy();
+    const { session } = await armWithCaffeinate({
+        env: { RALPH_CAFFEINATE: "1" },
+        platform: "linux",
+        spawnSpy: spy,
+    });
+    assert.equal(spy.calls.length, 0, "must NOT spawn on linux");
+    assert.ok(session.logs.some((l) => /caffeinate skipped/.test(l)), "must log a skip line on unsupported platforms");
+});
+
+test("caffeinate: spawn throw does not abort the loop", async () => {
+    const spy = makeCaffeinateSpy({ failSpawn: true });
+    const { session, armResult, controller } = await armWithCaffeinate({
+        env: { RALPH_CAFFEINATE: "1" },
+        platform: "darwin",
+        spawnSpy: spy,
+    });
+    assert.equal(armResult.armed, true, "loop must arm despite caffeinate spawn failure");
+    assert.notEqual(controller.state.active, null);
+    assert.ok(session.logs.some((l) => /caffeinate spawn failed/.test(l)), "must log spawn failure");
+});
+
+test("caffeinate: truthy variants ('true', 'YES', 'on') all enable", async () => {
+    for (const val of ["true", "YES", "on", "1"]) {
+        const spy = makeCaffeinateSpy();
+        await armWithCaffeinate({
+            env: { RALPH_CAFFEINATE: val },
+            platform: "darwin",
+            spawnSpy: spy,
+        });
+        assert.equal(spy.calls.length, 1, `value ${JSON.stringify(val)} should enable caffeinate`);
+    }
+});
+
+test("caffeinate: falsy values keep it off", async () => {
+    for (const val of ["0", "false", "", "no", "off"]) {
+        const spy = makeCaffeinateSpy();
+        await armWithCaffeinate({
+            env: { RALPH_CAFFEINATE: val },
+            platform: "darwin",
+            spawnSpy: spy,
+        });
+        assert.equal(spy.calls.length, 0, `value ${JSON.stringify(val)} should NOT enable caffeinate`);
+    }
+});
+
+test("caffeinate: README documents env vars and macOS-only scope", () => {
+    const readme = readFileSync(resolve(REPO_ROOT, "README.md"), "utf8");
+    assert.match(readme, /## Keep system awake/, "README must document the caffeinate integration");
+    assert.ok(readme.includes("RALPH_CAFFEINATE"), "README must mention RALPH_CAFFEINATE env var");
+    assert.ok(readme.includes("RALPH_CAFFEINATE_SCOPE"), "README must mention RALPH_CAFFEINATE_SCOPE env var");
+    assert.match(readme, /macOS only|darwin/i, "README must clarify macOS-only scope");
 });


### PR DESCRIPTION
Adds opt-in macOS sleep-prevention for the duration of a `ralph_loop` / `self_improve` / `grow_project` run.

## Behaviour
- **Disabled by default.** Extension never modifies system power state unless `RALPH_CAFFEINATE` is truthy (`1` / `true` / `yes` / `on`).
- `RALPH_CAFFEINATE_SCOPE=idle` (default) blocks idle/system sleep; `idle+display` also prevents display sleep.
- Spawns `caffeinate -i [-d] -w <pid>` on arm, killed on every finish path (completion, `ralph_stop`, abort, max_iterations, detach).
- The `-w <pid>` flag pins caffeinate's lifetime to the host process — a hard CLI crash still releases the wake-lock (no orphans).
- **macOS-only.** Linux/Windows log a single skip line and run normally.
- Graceful when the binary is missing — spawn errors are logged, loop runs without sleep prevention.

## Implementation
- New `startCaffeinate()` helper: env/platform validation, spawn + error listener, returns idempotent `stop()`.
- `createRalphController` gains an optional `{ caffeinate: { env, platform, pid, spawnFn } }` DI bag so tests stub spawn cleanly.
- Production resolves `child_process.spawn` lazily via `createRequire` — zero cost when disabled.
- `ActiveLoopState` gains a 15th field (`stopCaffeinate`); typedef + shape-pin test + `finish()` teardown updated in lockstep.

## Tests (12 new)
default-off, enabled-by-1, truthy/falsy variants, scope flag selection, invalid-scope fallback, non-darwin no-op (with skip log), spawn-throw doesn't abort the loop, child killed on natural completion and on `ralph_stop`, README pin.

## Acceptance criteria
- [x] Setting exists and defaults to off
- [x] When enabled on macOS, system stays awake for the duration of a ralph loop
- [x] caffeinate process is killed automatically when the loop ends (covered by 'child is killed on completion/stop' tests)
- [x] When disabled (default), no caffeinate process is spawned
- [x] Missing `caffeinate` binary or non-mac platforms degrade silently
- [x] Documented in README

Fixes #8