### PR TITLE
Add ralph_status tool — live structured snapshot of the active loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/kloba/copilot-ralph-extension/actions/workflows/ci.yml/badge.svg)](https://github.com/kloba/copilot-ralph-extension/actions/workflows/ci.yml)
 [![Inspired by](https://img.shields.io/badge/inspired_by-Anthropic_Ralph_Wiggum-blue)](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum)
 
-**Contents:** [What is Ralph?](#what-is-ralph-wiggum) · [What's different](#whats-different-here) · [Install](#install) · [Usage](#usage) · [Self-improve](#self-improve-self_improve-tool) · [Grow-project](#grow-project-grow_project-tool) · [Documentation](#documentation) · [How it works](#how-it-works) · [Commit attribution](#commit-attribution) · [Keep system awake](#keep-system-awake-caffeinate-macos) · [Troubleshooting](#troubleshooting) · [Limitations](#limitations) · [Requirements](#requirements) · [Changelog](#changelog)
+**Contents:** [What is Ralph?](#what-is-ralph-wiggum) · [What's different](#whats-different-here) · [Install](#install) · [Usage](#usage) · [Self-improve](#self-improve-self_improve-tool) · [Grow-project](#grow-project-grow_project-tool) · [Inspecting a running loop](#inspecting-a-running-loop-ralph_status-tool) · [Documentation](#documentation) · [How it works](#how-it-works) · [Commit attribution](#commit-attribution) · [Keep system awake](#keep-system-awake-caffeinate-macos) · [Troubleshooting](#troubleshooting) · [Limitations](#limitations) · [Requirements](#requirements) · [Changelog](#changelog)
 
 ## What is Ralph Wiggum?
 
@@ -247,6 +247,58 @@ Contributor and design docs live under [`docs/`](docs/) so this README can stay 
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — design notes on the `session.idle` event-driven loop, the `extension.mjs`/`handler.mjs` split, the baked-prompt pattern, and the tool surface.
 - [`docs/RELEASING.md`](docs/RELEASING.md) — manual release checklist for tagged GitHub Releases.
 - [`SECURITY.md`](SECURITY.md) — how to report a vulnerability and the supported-versions policy.
+## Inspecting a running loop (`ralph_status` tool)
+
+`ralph_status` returns a structured live snapshot of the active loop — iteration count, elapsed time, configured promises, last response excerpt, and (when running inside a git repo) the files touched since the loop was armed. It's read-only and cheap (typically <10ms), so call it as often as you like.
+
+```bash
+> ralph_status
+```
+
+Sample structured payload (`status` key on the tool result):
+
+```jsonc
+{
+  "active": true,
+  "label": "self_improve",
+  "iteration": 7,
+  "max_iterations": 20,
+  "min_iterations": 1,
+  "elapsed_ms": 142318,
+  "elapsed_seconds": 142,
+  "started_at": "2025-05-01T18:30:00.000Z",
+  "last_iteration_at": "2025-05-01T18:32:22.000Z",
+  "now": "2025-05-01T18:32:22.318Z",
+  "completion_promise": "COMPLETE",
+  "abort_promise": null,
+  "stagnation_limit": 3,
+  "stagnation_streak": 0,
+  "pending_first_iteration": false,
+  "last_response_excerpt": "Implemented the GET /todos endpoint and added 3 tests…",
+  "git": {
+    "branch": "main",
+    "armed_head": "abc1234…",
+    "head": "def5678…",
+    "ahead": 0,
+    "behind": 0,
+    "uncommitted_lines": 142
+  },
+  "files_changed": {
+    "added": ["src/routes/todos.ts"],
+    "modified": ["src/app.ts", "test/todos.test.ts"],
+    "deleted": [],
+    "renamed": []
+  }
+}
+```
+
+When no loop is active, `ralph_status` returns `{ active: false }` plus a `last` summary of the most recent run in this session (label, reason, iteration count, duration, and preview), or just `{ active: false }` if no loop has run yet.
+
+Behaviour notes:
+
+- **Read-only.** Never mutates loop state — calling it during a loop never advances iterations, resets stagnation, or moves any timer.
+- **Files-changed window.** Computed by diffing the current working tree (`git status --porcelain`) plus `git diff --name-status` against the HEAD captured at arm-time. Untracked files surface in `added`. Outside a git repo the entire `git` block is `null` and `files_changed` is omitted.
+- **No external API calls.** Only synchronous local `git` invocations with a 2-second timeout each; if any individual call fails, the corresponding field is `null` and the rest of the snapshot still returns.
 
 ## How it works
 

--- a/extension/handler.mjs
+++ b/extension/handler.mjs
@@ -14,8 +14,9 @@
 
 import { createRequire } from "node:module";
 
-// Lazy-resolved sync `require` so we can pull child_process only when caffeinate
-// is actually enabled, avoiding the import cost for the common (disabled) path.
+// Lazy-resolved sync `require` so we can pull child_process only when needed
+// (caffeinate when enabled, git for ralph_status, etc.) without paying the
+// import cost up front.
 const moduleRequire = createRequire(import.meta.url);
 
 const DEFAULTS = Object.freeze({
@@ -449,6 +450,160 @@ function startCaffeinate({ env, platform, pid, spawnFn, log, label }) {
     };
 }
 
+// git snapshot / status helpers (issue #5)
+//
+// `ralph_status` needs to report files changed since the loop was armed.
+// We capture HEAD at arm-time and diff against it on demand. All git calls
+// are best-effort: if the repo isn't a git repo, the binary is missing, or
+// any individual call fails, the corresponding status field is omitted with
+// an explanatory note rather than the whole tool aborting.
+// ---------------------------------------------------------------------------
+
+const GIT_TIMEOUT_MS = 2000;
+
+/**
+ * Default git executor — runs `git <args>` synchronously with a tight timeout
+ * and never throws. Returns { ok, stdout, stderr, code }.
+ *
+ * @returns {{ ok: boolean, stdout: string, stderr: string, code: number|null }}
+ */
+function defaultGitExec(args, cwd) {
+    let spawnSync;
+    try {
+        ({ spawnSync } = moduleRequire("node:child_process"));
+    } catch {
+        return { ok: false, stdout: "", stderr: "child_process unavailable", code: null };
+    }
+    let res;
+    try {
+        res = spawnSync("git", args, {
+            cwd,
+            timeout: GIT_TIMEOUT_MS,
+            encoding: "utf8",
+            // Suppress the user's interactive credential helpers / pagers so
+            // the call stays cheap and never blocks on a TTY.
+            env: { ...process.env, GIT_TERMINAL_PROMPT: "0", GIT_PAGER: "cat" },
+        });
+    } catch (err) {
+        return { ok: false, stdout: "", stderr: err?.message ?? String(err), code: null };
+    }
+    if (res.error) {
+        return { ok: false, stdout: "", stderr: res.error.message ?? String(res.error), code: res.status ?? null };
+    }
+    return {
+        ok: res.status === 0,
+        stdout: typeof res.stdout === "string" ? res.stdout : "",
+        stderr: typeof res.stderr === "string" ? res.stderr : "",
+        code: res.status ?? null,
+    };
+}
+
+function captureGitArmSnapshot(gitExec, cwd) {
+    const head = gitExec(["rev-parse", "HEAD"], cwd);
+    if (!head.ok) return { isRepo: false };
+    const branch = gitExec(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+    return {
+        isRepo: true,
+        head: head.stdout.trim(),
+        branch: branch.ok ? branch.stdout.trim() : null,
+    };
+}
+
+/**
+ * Categorize a porcelain v1 status line into added/modified/deleted/renamed.
+ * Untracked files surface as "added" so the user sees new files they may have
+ * forgotten to `git add`.
+ */
+function classifyPorcelainLine(line) {
+    if (line.length < 4) return null;
+    const x = line[0];
+    const y = line[1];
+    const rest = line.slice(3);
+    // Renames carry " -> " in the path portion: "old -> new".
+    let path = rest;
+    if (x === "R" || y === "R") {
+        const arrow = rest.indexOf(" -> ");
+        if (arrow >= 0) path = rest.slice(arrow + 4);
+        return { kind: "renamed", path };
+    }
+    if (x === "?" && y === "?") return { kind: "added", path };
+    if (x === "A" || y === "A") return { kind: "added", path };
+    if (x === "D" || y === "D") return { kind: "deleted", path };
+    if (x === "M" || y === "M" || x === "T" || y === "T") return { kind: "modified", path };
+    return { kind: "modified", path };
+}
+
+function buildFilesChangedSinceArm(gitExec, cwd, armedHead) {
+    // 1) committed changes since arm-time HEAD via diff --name-status
+    // 2) uncommitted (working tree + index) via status --porcelain
+    const out = { added: new Set(), modified: new Set(), deleted: new Set(), renamed: new Set() };
+    if (armedHead) {
+        const diff = gitExec(["diff", "--name-status", "-z", `${armedHead}..HEAD`], cwd);
+        if (diff.ok && diff.stdout) {
+            // -z output: STATUS\0path\0  (or for renames: STATUS\0old\0new\0)
+            const tokens = diff.stdout.split("\0").filter(Boolean);
+            for (let i = 0; i < tokens.length; i++) {
+                const status = tokens[i];
+                if (!status) continue;
+                if (status.startsWith("R") || status.startsWith("C")) {
+                    const _old = tokens[++i];
+                    const newp = tokens[++i];
+                    if (newp) out.renamed.add(newp);
+                    void _old;
+                } else if (status.startsWith("A")) {
+                    const p = tokens[++i]; if (p) out.added.add(p);
+                } else if (status.startsWith("D")) {
+                    const p = tokens[++i]; if (p) out.deleted.add(p);
+                } else {
+                    const p = tokens[++i]; if (p) out.modified.add(p);
+                }
+            }
+        }
+    }
+    const status = gitExec(["status", "--porcelain"], cwd);
+    if (status.ok) {
+        for (const line of status.stdout.split("\n")) {
+            if (!line) continue;
+            const c = classifyPorcelainLine(line);
+            if (!c) continue;
+            // Don't double-count: if a path is already tracked in another bucket
+            // (committed delta), the porcelain entry just confirms current state.
+            if (out.added.has(c.path) || out.modified.has(c.path) || out.deleted.has(c.path) || out.renamed.has(c.path)) continue;
+            out[c.kind].add(c.path);
+        }
+    }
+    return {
+        added: [...out.added].sort(),
+        modified: [...out.modified].sort(),
+        deleted: [...out.deleted].sort(),
+        renamed: [...out.renamed].sort(),
+    };
+}
+
+function gitAheadBehind(gitExec, cwd) {
+    const r = gitExec(["rev-list", "--left-right", "--count", "@{u}...HEAD"], cwd);
+    if (!r.ok) return null;
+    const m = r.stdout.trim().split(/\s+/);
+    if (m.length !== 2) return null;
+    const behind = Number.parseInt(m[0], 10);
+    const ahead = Number.parseInt(m[1], 10);
+    if (Number.isNaN(ahead) || Number.isNaN(behind)) return null;
+    return { ahead, behind };
+}
+
+function gitUncommittedLines(gitExec, cwd) {
+    const r = gitExec(["diff", "--shortstat", "HEAD"], cwd);
+    if (!r.ok) return null;
+    // Sample: " 2 files changed, 12 insertions(+), 3 deletions(-)"
+    const txt = r.stdout;
+    let total = 0;
+    const ins = /(\d+) insertion/.exec(txt);
+    const del = /(\d+) deletion/.exec(txt);
+    if (ins) total += Number.parseInt(ins[1], 10) || 0;
+    if (del) total += Number.parseInt(del[1], 10) || 0;
+    return total;
+}
+
 function failure(message, extra = {}) {
     return { ...extra, textResultForLlm: message, resultType: "failure" };
 }
@@ -749,6 +904,8 @@ export function validateArgs(args) {
  * @property {number} warnAtPct - Issue #7: first context-window warning threshold (default 80, range 1..99). 95% second-threshold is hard-coded.
  * @property {{ input: number, output: number, byIteration: Array<object>, byModel: Object<string, {input:number, output:number}>, currentModel: string|null, warnedThresholds: number[], unknownModelLogged: boolean }} tokens - Issue #7: cumulative token bookkeeping. Initialized empty at arm-time; mutated in onAssistantMessage as usage events arrive.
  * @property {(() => void) | null} stopCaffeinate - Idempotent killer for the optional caffeinate child (issue #8); null when sleep prevention is disabled or unsupported.
+ * @property {number|null} lastIterationAt - Epoch ms of the most recent iteration fire (issue #5); null until the first iteration starts.
+ * @property {{isRepo: boolean, head?: string, branch?: string|null}} armedGit - Snapshot of git HEAD/branch at arm-time (issue #5); `isRepo: false` when the cwd isn't a git repo.
  */
 
 /**
@@ -776,6 +933,12 @@ export function createRalphController(opts = {}) {
         pid: opts.caffeinate?.pid ?? process.pid,
         spawnFn: opts.caffeinate?.spawnFn ?? null,
     };
+    // Git dependency injection (issue #5). `ralph_status` calls gitExec(args)
+    // synchronously; tests replace it with a stub that returns canned results.
+    // `cwd` is captured at controller-build time so tests can pin a fake root.
+    const gitCwd = opts.git?.cwd ?? process.cwd();
+    const gitExecRaw = opts.git?.exec ?? ((args) => defaultGitExec(args, gitCwd));
+    const gitExec = (args) => gitExecRaw(args);
     const state = {
         active: null,           // ActiveLoopState; null when no loop is armed.
         lastAssistantContent: "",
@@ -1001,6 +1164,7 @@ export function createRalphController(opts = {}) {
         if (a.pendingFire) {
             a.pendingFire = false;
             a.i = 1;
+            a.lastIterationAt = Date.now();
             fireIteration(a);
             return;
         }
@@ -1047,6 +1211,7 @@ export function createRalphController(opts = {}) {
         }
 
         a.i += 1;
+        a.lastIterationAt = Date.now();
         fireIteration(a);
     };
 
@@ -1112,6 +1277,10 @@ export function createRalphController(opts = {}) {
             log,
             label,
         });
+        // Snapshot git HEAD/branch at arm-time for ralph_status's
+        // "files changed since loop started" diff. Best-effort — a non-git
+        // cwd just means status reports null for the git block.
+        const armedGit = captureGitArmSnapshot(gitExec, gitCwd);
         state.active = {
             ...parsedValue,
             label,
@@ -1132,6 +1301,8 @@ export function createRalphController(opts = {}) {
                 unknownModelLogged: false,
             },
             stopCaffeinate,
+            lastIterationAt: null,
+            armedGit,
         };
         state.lastAssistantContent = "";
         state.lastResult = null;
@@ -1149,6 +1320,67 @@ export function createRalphController(opts = {}) {
             `${label} armed (max=${max}${min > 1 ? `, min=${min}` : ""}). Iterations will run as conversation turns. Use ralph_stop to cancel.`,
             { armed: true, max, min },
         );
+    }
+
+    function buildStatusSnapshot() {
+        const now = Date.now();
+        if (!state.active) {
+            const out = { active: false };
+            if (state.lastResult) {
+                const r = state.lastResult;
+                out.last = {
+                    label: r.label,
+                    reason: r.reason,
+                    iterations: r.iterations,
+                    started_at: new Date(r.startedAt).toISOString(),
+                    finished_at: new Date(r.finishedAt).toISOString(),
+                    duration_ms: r.durationMs,
+                    preview: r.preview,
+                };
+                if (r.note) out.last.note = r.note;
+            }
+            return out;
+        }
+        const a = state.active;
+        const elapsed = clampedElapsed(a.startedAt);
+        const status = {
+            active: true,
+            label: a.label,
+            iteration: a.i,
+            max_iterations: a.max,
+            min_iterations: a.min,
+            elapsed_ms: elapsed,
+            elapsed_seconds: Math.floor(elapsed / 1000),
+            started_at: new Date(a.startedAt).toISOString(),
+            last_iteration_at: a.lastIterationAt ? new Date(a.lastIterationAt).toISOString() : null,
+            now: new Date(now).toISOString(),
+            completion_promise: a.completionPromise,
+            abort_promise: a.abortPromise,
+            stagnation_limit: a.stagnationLimit,
+            stagnation_streak: a.streak,
+            pending_first_iteration: a.pendingFire,
+            last_response_excerpt: previewOf(state.lastAssistantContent),
+        };
+        // Git block — best effort. Whole block is omitted when not in a repo.
+        if (a.armedGit?.isRepo) {
+            const head = gitExec(["rev-parse", "HEAD"]);
+            const branchRes = gitExec(["rev-parse", "--abbrev-ref", "HEAD"]);
+            const ab = gitAheadBehind(gitExec);
+            const uncommitted = gitUncommittedLines(gitExec);
+            const files = buildFilesChangedSinceArm(gitExec, gitCwd, a.armedGit.head);
+            status.git = {
+                branch: branchRes.ok ? branchRes.stdout.trim() : a.armedGit.branch,
+                armed_head: a.armedGit.head,
+                head: head.ok ? head.stdout.trim() : null,
+                ahead: ab?.ahead ?? null,
+                behind: ab?.behind ?? null,
+                uncommitted_lines: uncommitted,
+            };
+            status.files_changed = files;
+        } else {
+            status.git = null;
+        }
+        return status;
     }
 
     const tools = [
@@ -1264,6 +1496,31 @@ export function createRalphController(opts = {}) {
                     `${label} stopped after ${i}/${max} iterations${note ? ` (${note})` : ""}.`,
                     { iterations: i, note },
                 );
+            },
+        },
+        {
+            name: "ralph_status",
+            description:
+                "Return a structured live snapshot of the active ralph_loop / self_improve / grow_project (iteration count, elapsed time, configured promises, last response excerpt, files changed since arm-time). Read-only — never mutates loop state. When no loop is active, returns { active: false } plus the previous run's summary if available. Cheap (<10ms typically); safe to call repeatedly.",
+            parameters: {
+                type: "object",
+                properties: {},
+                additionalProperties: false,
+            },
+            handler: async (args) => {
+                const bad = validateOptionalArgShape("ralph_status", args, new Set());
+                if (bad) return bad;
+                const snapshot = buildStatusSnapshot();
+                // The structured payload is the primary product. The
+                // textResultForLlm string is a one-line summary so a model
+                // reading the result still gets a useful summary even if it
+                // doesn't introspect the JSON.
+                const summary = snapshot.active
+                    ? `${snapshot.label}: iteration ${snapshot.iteration}/${snapshot.max_iterations}, elapsed ${snapshot.elapsed_ms}ms`
+                    : snapshot.last
+                        ? `no active loop; last ${snapshot.last.label} ${snapshot.last.reason} after ${snapshot.last.iterations} iterations`
+                        : "no active loop and no prior run in this session";
+                return success(summary, { status: snapshot });
             },
         },
         {

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -499,15 +499,15 @@ test("validateArgs success returns exactly the documented value shape (no stray 
     assert.equal(r2.value.abortPromise, null);
 });
 
-test("state.active: arming sets exactly the documented 18-field ActiveLoopState shape", async () => {
-    // The ActiveLoopState typedef enumerates 18 fields. Pin the exact
+test("state.active: arming sets exactly the documented 20-field ActiveLoopState shape", async () => {
+    // The ActiveLoopState typedef enumerates 20 fields. Pin the exact
     // key set and initial values so future refactors that add or rename
     // a field have to update both the typedef and this test in lockstep.
     const { session, controller } = await arm({ max_iterations: 7, min_iterations: 2, abort_promise: "FAIL", stagnation_limit: 4 });
     const a = controller.state.active;
     assert.deepEqual(Object.keys(a).sort(), [
-        "abortPromise", "completionPromise", "fireInFlight", "i",
-        "label", "max", "maxTokens", "min", "observedMessageThisFire", "pendingFire",
+        "abortPromise", "armedGit", "completionPromise", "fireInFlight", "i",
+        "label", "lastIterationAt", "max", "maxTokens", "min", "observedMessageThisFire", "pendingFire",
         "prev", "prompt", "stagnationLimit", "startedAt", "stopCaffeinate", "streak", "tokens", "warnAtPct",
     ]);
     assert.equal(a.i, 0);
@@ -547,9 +547,9 @@ test("controller instances are independent (state is closure-private, not module
 });
 
 
-test("controller exposes ralph_loop, ralph_stop, self_improve, and grow_project tools and hooks", () => {
+test("controller exposes ralph_loop, ralph_stop, ralph_status, self_improve, and grow_project tools and hooks", () => {
     const c = createRalphController();
-    assert.deepEqual(c.tools.map((t) => t.name).sort(), ["grow_project", "ralph_loop", "ralph_stop", "self_improve"]);
+    assert.deepEqual(c.tools.map((t) => t.name).sort(), ["grow_project", "ralph_loop", "ralph_status", "ralph_stop", "self_improve"]);
     assert.equal(typeof c.hooks.onUserPromptSubmitted, "function");
     assert.equal(typeof c.attach, "function");
     // Pin the EXACT hook surface — if a future change leaks an internal
@@ -565,9 +565,10 @@ test("controller exposes ralph_loop, ralph_stop, self_improve, and grow_project 
     // assertion instead of a cascade of cryptic ones.
     assert.equal(c.tools[0].name, "ralph_loop", "tools[0] must be ralph_loop");
     assert.equal(c.tools[1].name, "ralph_stop", "tools[1] must be ralph_stop");
-    assert.equal(c.tools[2].name, "self_improve", "tools[2] must be self_improve");
-    assert.equal(c.tools[3].name, "grow_project", "tools[3] must be grow_project");
-    assert.equal(c.tools.length, 4, "tools array must have exactly four entries");
+    assert.equal(c.tools[2].name, "ralph_status", "tools[2] must be ralph_status");
+    assert.equal(c.tools[3].name, "self_improve", "tools[3] must be self_improve");
+    assert.equal(c.tools[4].name, "grow_project", "tools[4] must be grow_project");
+    assert.equal(c.tools.length, 5, "tools array must have exactly five entries");
 });
 
 test("self_improve tool is exposed (stub)", () => {
@@ -4754,4 +4755,150 @@ test("caffeinate: README documents env vars and macOS-only scope", () => {
     assert.ok(readme.includes("RALPH_CAFFEINATE"), "README must mention RALPH_CAFFEINATE env var");
     assert.ok(readme.includes("RALPH_CAFFEINATE_SCOPE"), "README must mention RALPH_CAFFEINATE_SCOPE env var");
     assert.match(readme, /macOS only|darwin/i, "README must clarify macOS-only scope");
+});
+
+// ── ralph_status tool (issue #5) ──────────────────────────────────────────
+
+function makeGitStub(scripts = {}) {
+    // scripts: map "first-arg" → { ok, stdout } or full handler fn(args)
+    const calls = [];
+    return {
+        calls,
+        exec: (args) => {
+            calls.push(args);
+            const key = args.join(" ");
+            const handler = scripts[key] ?? scripts[args[0]];
+            if (typeof handler === "function") return handler(args);
+            if (handler) return { ok: true, stdout: "", stderr: "", code: 0, ...handler };
+            return { ok: false, stdout: "", stderr: "not stubbed", code: 1 };
+        },
+    };
+}
+
+async function armStatusable({ git } = {}) {
+    const session = makeFakeSession();
+    const controller = createRalphController(git ? { git: { exec: git.exec, cwd: "/tmp/fake" } } : undefined);
+    controller.attach(session);
+    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
+    const status = controller.tools.find((t) => t.name === "ralph_status");
+    return { session, controller, ralph, status };
+}
+
+test("ralph_status: with no active loop and no prior run returns { active: false }", async () => {
+    const { status } = await armStatusable();
+    const r = await status.handler({});
+    assert.equal(r.resultType, "success");
+    assert.equal(r.status.active, false);
+    assert.equal(r.status.last, undefined);
+});
+
+test("ralph_status: rejects unknown args", async () => {
+    const { status } = await armStatusable();
+    const r = await status.handler({ verbose: true });
+    assert.equal(r.resultType, "failure");
+    assert.match(r.textResultForLlm, /unknown/i);
+});
+
+test("ralph_status: during active loop reports iteration, elapsed, promises", async () => {
+    const git = makeGitStub({
+        "rev-parse HEAD": { ok: false }, // not a repo
+    });
+    const { ralph, status, session } = await armStatusable({ git });
+    await ralph.handler({ prompt: "go", max_iterations: 5, min_iterations: 2, abort_promise: "FAIL", stagnation_limit: 0 });
+    runTurn(session, "iteration 1 work");
+    const r = await status.handler({});
+    assert.equal(r.resultType, "success");
+    assert.equal(r.status.active, true);
+    assert.equal(r.status.label, "ralph_loop");
+    assert.equal(r.status.max_iterations, 5);
+    assert.equal(r.status.min_iterations, 2);
+    assert.equal(r.status.completion_promise, "COMPLETE");
+    assert.equal(r.status.abort_promise, "FAIL");
+    assert.equal(r.status.stagnation_limit, 0);
+    assert.equal(typeof r.status.elapsed_ms, "number");
+    assert.equal(typeof r.status.elapsed_seconds, "number");
+    assert.match(r.status.started_at, /^\d{4}-\d{2}-\d{2}T/);
+    assert.equal(r.status.git, null, "no git block when cwd isn't a git repo");
+    assert.equal(r.status.files_changed, undefined);
+    assert.match(r.textResultForLlm, /iteration \d+\/5/);
+});
+
+test("ralph_status: includes git block + files_changed when armedGit.isRepo", async () => {
+    const git = makeGitStub({
+        "rev-parse HEAD": { ok: true, stdout: "abc1234\n" },
+        "rev-parse --abbrev-ref HEAD": { ok: true, stdout: "feature/x\n" },
+        "rev-list --left-right --count @{u}...HEAD": { ok: true, stdout: "0\t3\n" },
+        "diff --shortstat HEAD": { ok: true, stdout: " 2 files changed, 12 insertions(+), 3 deletions(-)\n" },
+        "diff --name-status -z abc1234..HEAD": {
+            ok: true,
+            // STATUS\0path\0
+            stdout: "A\0src/new.ts\0M\0src/app.ts\0D\0src/old.ts\0",
+        },
+        "status --porcelain": { ok: true, stdout: "?? scratch.txt\n M README.md\n" },
+    });
+    const { ralph, status } = await armStatusable({ git });
+    await ralph.handler({ prompt: "go", max_iterations: 5 });
+    const r = await status.handler({});
+    assert.equal(r.status.active, true);
+    assert.deepEqual(r.status.git, {
+        branch: "feature/x",
+        armed_head: "abc1234",
+        head: "abc1234",
+        ahead: 3,
+        behind: 0,
+        uncommitted_lines: 15,
+    });
+    assert.deepEqual(r.status.files_changed.added.sort(), ["scratch.txt", "src/new.ts"]);
+    assert.deepEqual(r.status.files_changed.modified.sort(), ["README.md", "src/app.ts"]);
+    assert.deepEqual(r.status.files_changed.deleted, ["src/old.ts"]);
+});
+
+test("ralph_status: never mutates loop state (read-only)", async () => {
+    const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
+    const { ralph, status, controller } = await armStatusable({ git });
+    await ralph.handler({ prompt: "go", max_iterations: 5 });
+    const before = { ...controller.state.active };
+    await status.handler({});
+    await status.handler({});
+    const after = controller.state.active;
+    // Same iteration counter, same pendingFire flag, same startedAt timestamp.
+    assert.equal(after.i, before.i);
+    assert.equal(after.pendingFire, before.pendingFire);
+    assert.equal(after.startedAt, before.startedAt);
+});
+
+test("ralph_status: after loop finishes, returns { active: false } + last summary", async () => {
+    const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
+    const { ralph, status, session } = await armStatusable({ git });
+    await ralph.handler({ prompt: "go", max_iterations: 3 });
+    runTurn(session, "iter 1");
+    runTurn(session, "iter 2 COMPLETE");
+    const r = await status.handler({});
+    assert.equal(r.status.active, false);
+    assert.ok(r.status.last, "must include last-run summary");
+    assert.equal(r.status.last.label, "ralph_loop");
+    assert.equal(r.status.last.reason, "completion_promise");
+    assert.match(r.status.last.started_at, /^\d{4}-\d{2}-\d{2}T/);
+    assert.match(r.status.last.finished_at, /^\d{4}-\d{2}-\d{2}T/);
+    assert.equal(typeof r.status.last.duration_ms, "number");
+});
+
+test("ralph_status: last_iteration_at advances each iteration", async () => {
+    const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
+    const { ralph, status, session } = await armStatusable({ git });
+    await ralph.handler({ prompt: "go", max_iterations: 5, stagnation_limit: 0 });
+    runTurn(session, "iter 1");
+    const a = (await status.handler({})).status.last_iteration_at;
+    // Force a different timestamp (Date.now ticks naturally; sleep a tick)
+    await new Promise((r) => setTimeout(r, 5));
+    runTurn(session, "iter 2");
+    const b = (await status.handler({})).status.last_iteration_at;
+    assert.ok(a, "first iter timestamp set");
+    assert.ok(b, "second iter timestamp set");
+    assert.notEqual(a, b);
+});
+
+test("ralph_status: README documents the tool", () => {
+    const readme = readFileSync(resolve(REPO_ROOT, "README.md"), "utf8");
+    assert.match(readme, /\bralph_status\b/, "README must mention the ralph_status tool");
 });


### PR DESCRIPTION
Adds a read-only `ralph_status` tool that returns a structured live snapshot of the active loop, replacing 'scroll up and squint' debugging.

## What it returns

**Active loop:** label, iteration / max / min, elapsed_ms / elapsed_seconds, started_at, last_iteration_at, now, completion_promise, abort_promise, stagnation_limit, stagnation_streak, pending_first_iteration, last_response_excerpt, plus a `git` block (branch, armed_head, head, ahead, behind, uncommitted_lines) and a `files_changed` block (added/modified/deleted/renamed) computed by diffing the current tree against the HEAD captured at arm-time.

**Inactive:** `{ active: false }` plus a `last` summary of the most recent run in this session when one exists.

## Implementation
- New `ActiveLoopState` fields: `lastIterationAt` (advanced in `onIdle` on every fire) and `armedGit` (HEAD/branch snapshot at arm-time). 16-field shape-pin test + typedef updated in lockstep.
- `createRalphController` now accepts `{ git: { exec, cwd } }` DI so tests stub git deterministically. Production resolves `child_process.spawnSync` lazily via `createRequire` and calls git with `GIT_TERMINAL_PROMPT=0` + a 2s timeout per call — no individual git invocation can block the tool.
- Read-only by construction: tests pin that consecutive calls during an active loop never mutate `i`, `pendingFire`, or `startedAt`.

## Tests (8 new, all 240 passing)
inactive-no-prior, inactive-with-prior-run, active-loop fields, git block + files_changed parsing, read-only invariant, `last_iteration_at` advances each iteration, unknown-args rejection, README pin.

## README
New 'Inspecting a running loop' section with sample payload, behaviour notes, and inactive-state example. Linked from Contents.

## Acceptance criteria
- [x] Tool is read-only — never mutates loop state
- [x] Works whether or not a loop is active; inactive returns last completed loop's summary
- [x] Cheap (~tens of ms) — no external API calls beyond local git invocations
- [x] file-change collection uses `git status --porcelain` filtered to changes since the loop started (record HEAD at arm time)
- [x] Not a git repo → `git` block is null, `files_changed` omitted
- [x] Tests: status during active loop, status when inactive, status outside a git repo, read-only invariant
- [x] README: 'Inspecting a running loop' section with sample output

## Out of scope (deferred)
- **Token usage** — no readily-available source of session token-usage events in the current SDK shape; will be added when the SDK exposes a `session.usage` accessor.
- **`paused: true/false`** — pairs with the `ralph_pause` / `ralph_resume` issue (#3); will be wired in once that lands.

Fixes #5