### PR TITLE
Add docs/{CONTRIBUTING,ARCHITECTURE,RELEASING}.md and SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Inspired by](https://img.shields.io/badge/inspired_by-Anthropic_Ralph_Wiggum-blue)](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum)
 
-**Contents:** [What is Ralph?](#what-is-ralph-wiggum) · [What's different](#whats-different-here) · [Install](#install) · [Usage](#usage) · [Self-improve](#self-improve-self_improve-tool) · [Grow-project](#grow-project-grow_project-tool) · [How it works](#how-it-works) · [Commit attribution](#commit-attribution) · [Troubleshooting](#troubleshooting) · [Limitations](#limitations) · [Requirements](#requirements) · [Changelog](#changelog)
+**Contents:** [What is Ralph?](#what-is-ralph-wiggum) · [What's different](#whats-different-here) · [Install](#install) · [Usage](#usage) · [Self-improve](#self-improve-self_improve-tool) · [Grow-project](#grow-project-grow_project-tool) · [Documentation](#documentation) · [How it works](#how-it-works) · [Commit attribution](#commit-attribution) · [Troubleshooting](#troubleshooting) · [Limitations](#limitations) · [Requirements](#requirements) · [Changelog](#changelog)
 
 ## What is Ralph Wiggum?
 
@@ -205,6 +205,15 @@ npm test    # runs the node:test suite under test/ (no deps, no install needed)
 ```
 
 The handler logic lives in [`extension/handler.mjs`](extension/handler.mjs) and is decoupled from the SDK so it can be unit-tested with a fake session that drives events deterministically.
+
+## Documentation
+
+Contributor and design docs live under [`docs/`](docs/) so this README can stay focused on end-users:
+
+- [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) — local dev setup, style conventions, commit-trailer rules, PR expectations.
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — design notes on the `session.idle` event-driven loop, the `extension.mjs`/`handler.mjs` split, the baked-prompt pattern, and the tool surface.
+- [`docs/RELEASING.md`](docs/RELEASING.md) — manual release checklist for tagged GitHub Releases.
+- [`SECURITY.md`](SECURITY.md) — how to report a vulnerability and the supported-versions policy.
 
 ## How it works
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you've found a security issue in `copilot-ralph-extension` — such as a prompt-injection vector, a path-traversal in `install.sh`, an unsafe shell construction in a baked prompt, or any other credential / data-exposure risk — please report it **privately** rather than opening a public issue.
+
+Use GitHub's [private vulnerability reporting](https://github.com/kloba/copilot-ralph-extension/security/advisories/new) form to file a confidential security advisory. We'll triage and respond as soon as we can. Public-issue reports for credible vulnerabilities will be redacted on request.
+
+When reporting, please include:
+
+- A clear description of the vulnerability and its impact (what an attacker can do, what privileges/access they need to start with).
+- Reproduction steps or a proof-of-concept that demonstrates the issue.
+- The version / commit SHA you observed it on.
+- Any suggested mitigations or patches you've prototyped.
+
+## Supported Versions
+
+This is a small, single-maintainer extension with a low release cadence. Only the **latest tagged release** receives security updates. If a fix is applied, it ships in the next patch release on top of `main`; older tags are not back-patched.
+
+| Version | Supported |
+| ------- | --------- |
+| latest tagged release | ✅ |
+| older tags / pre-release commits | ❌ |
+
+If you need to keep using an older version, please cherry-pick the fix yourself or pin to the next tagged release that includes it.
+
+## Scope
+
+In-scope:
+
+- `extension/extension.mjs`, `extension/handler.mjs`
+- `install.sh`
+- Anything baked into prompt templates that could be exploited by a malicious external input (e.g. a poisoned issue body fed into `grow_project`).
+
+Out-of-scope:
+
+- Vulnerabilities in upstream `@github/copilot-sdk`, the Copilot CLI itself, Node.js, or `gh`. Please report those to the respective projects.
+- Issues that require an attacker to already have local code-execution on the user's machine (we assume the local environment is trusted).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,90 @@
+# Architecture
+
+This document is for contributors and future-self maintenance. End-user docs live in the [README](../README.md). For local-dev setup see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Why `session.idle` instead of a subprocess wrapper?
+
+Existing Ralph implementations for Copilot CLI (e.g. `copilot-ralph-mode`) are **shell wrappers**: they `spawn copilot -p "<prompt>"` once per iteration. Each iteration starts with a fresh session and loses the conversation context built up by previous iterations.
+
+This extension instead runs **inside the active session**, driven by the Copilot CLI extension SDK's `session.idle` event — the same architectural pattern as Anthropic's Claude Code [`ralph-wiggum`](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum) plugin (their `Stop` hook). When the root agent finishes its turn:
+
+1. The SDK emits `session.idle` to all attached extensions.
+2. The Ralph controller's `onIdle` handler runs the completion / abort / stagnation / max-iterations checks.
+3. If the loop should continue, the controller calls `session.send({ prompt })` to inject the prompt as a new user turn.
+4. Copilot CLI processes that turn exactly as if the human had typed it — including all UI rendering, model calls, tool execution, and ancillary handlers.
+
+The trade-off is documented in the README's comparison table; see [What's different here?](../README.md#whats-different-here).
+
+## Source layout
+
+```
+extension/
+├── extension.mjs   # SDK glue — joinSession + createRalphController() + register tools/hooks
+└── handler.mjs     # The entire controller: state machine, validation, tool defs, baked prompts
+test/
+└── extension.test.mjs   # node:test suite, exercises handler against a fake session
+install.sh          # User- or project-scoped install into ~/.copilot/extensions or .github/extensions
+```
+
+### `extension.mjs` vs `handler.mjs` split
+
+- **`extension.mjs`** is the only file that talks to the SDK. It's intentionally tiny (~30 LOC). Anything beyond `joinSession`, `controller.attach(session)`, and `for (const t of controller.tools) session.registerTool(t)` does not belong here.
+- **`handler.mjs`** is everything else: state machine, prompt validation, tool definitions, completion / abort / stagnation logic, baked-prompt templates, adaptive-budget signal evaluation, caffeinate spawning, etc. Because it's pure JS over a tiny event-bus interface (`on`/`emit`/`send`/`log`), it can be unit-tested with `makeFakeSession()` from `test/extension.test.mjs` — no SDK mock required.
+
+The `createRalphController(opts?)` factory returns `{ tools, hooks, attach, state }`. Each call returns an **independent** controller with closure-private state — important because tests routinely create two controllers and assert non-leakage.
+
+## State machine: `state.active` (the `ActiveLoopState`)
+
+While a loop is running, `state.active` holds the canonical loop state. Field-by-field documentation lives in the JSDoc above `createRalphController` in `handler.mjs`. Notable fields:
+
+- `i` / `max` / `min` — current iteration index, effective max, lower bound for honoring the completion / abort promises.
+- `prompt` / `completionPromise` / `abortPromise` — the strings re-fed each iter and the substrings that terminate the loop.
+- `prev` / `streak` / `stagnationLimit` — byte-identical-response detector that aborts a stuck loop.
+- `pendingFire` / `fireInFlight` / `observedMessageThisFire` — per-iteration dispatch guards. The first idle (the one that *armed* the loop) consumes `pendingFire` to fire iter 1; the in-flight markers prevent stale-idle bloat from cancelled tool calls or sub-agents.
+- Adaptive-budget fields (issue [#4](https://github.com/kloba/copilot-ralph-extension/issues/4)): `adaptiveBudget`, `adaptiveExtension`, `adaptiveMaxTotal`, `originalMax`, `adaptiveContentHashes`, `adaptiveExtensionHistory`.
+
+When the loop finishes, `state.active` becomes `null` and the immutable `state.lastResult` (a deep-frozen `RalphResult`) holds the post-mortem.
+
+## Sub-agent event filtering
+
+Copilot CLI's `task` / `explore` / `code-review` / `rubber-duck` agents share the same event bus as the root agent. Without filtering, a sub-agent's `session.idle` would queue an extra prompt fire, and a sub-agent's abort would tear down the root loop. `isSubAgentEvent(ev)` (in `handler.mjs`) returns `true` whenever `ev.agentId` is a non-empty string — root events have no `agentId`. **All loop-driving handlers must early-return on `isSubAgentEvent(ev)`.**
+
+## The "baked prompt" pattern
+
+`self_improve` and `grow_project` are convenience tools that wrap `armLoop()` with a **prompt baked in**: the user only supplies optional `focus` / `max_iterations` / `min_iterations`, and the tool builds a multi-paragraph SDLC or backlog-grooming prompt from a template constant (`PROMPT_SELF_IMPROVE`, `PROMPT_GROW_PROJECT`). The bake is opaque to `validateArgs` — we validate only what the user supplied, then construct the prompt and call `armLoop({ prompt: baked, ... })`.
+
+The baked prompts include hard-coded `COMPLETE` / `ABORT_…` tokens and `min_iterations` defaults that defer honoring those tokens (otherwise the agent would emit `COMPLETE` on iter 1 by virtue of merely *describing* the protocol). When changing a baked prompt, run the existing prompt-shape tests (`PROMPT_SELF_IMPROVE: contains the protocol literal`, etc.) — they pin the user-visible contract.
+
+## Tool surface
+
+| Tool | Purpose | Key contract |
+|---|---|---|
+| `ralph_loop` | Generic re-fed-prompt loop | One loop at a time. Returns immediately after arming. Driven by `session.idle`. |
+| `ralph_stop` | Cancel the active loop | Returns failure if no loop is active. Optional `reason` string is recorded as `note` on the result. |
+| `ralph_status` | Live structured snapshot of the active loop | Issue [#5](https://github.com/kloba/copilot-ralph-extension/issues/5) — read-only; safe to call mid-loop. |
+| `self_improve` | Baked SDLC self-improvement prompt | Wraps `armLoop` with `PROMPT_SELF_IMPROVE`. Honors `focus` for narrowing scope. |
+| `grow_project` | Baked backlog-grooming + execution loop | Wraps `armLoop` with `PROMPT_GROW_PROJECT`. Drives `gh` CLI calls. |
+
+All tools share the `success(message, extra)` / `failure(message, extra)` envelope: `{ ...extra, textResultForLlm, resultType }` (extras cannot override `textResultForLlm` or `resultType`). The shape is pinned by tests so refactors can't accidentally leak internal scratch into the LLM-facing return.
+
+## Completion-promise & abort-promise contracts
+
+- **`completion_promise`** (default `"COMPLETE"`) — substring match against the latest assistant content. When seen on iter ≥ `min_iterations`, finishes the loop with `reason: "completion_promise"`.
+- **`abort_promise`** (optional, no default) — same mechanism, but finishes with `reason: "abort_promise"`. Used by `grow_project` (`ABORT_NO_BACKLOG`) to bail when there's nothing to do.
+- Both promises are **only honored once `i >= min_iterations`** to avoid premature termination from the agent merely describing the protocol on iter 1. Stagnation, max-iterations, and adaptive-budget terminators have their own thresholds and do not respect `min_iterations`.
+
+## Adaptive iteration budget (issue [#4](https://github.com/kloba/copilot-ralph-extension/issues/4))
+
+Opt-in. When the loop reaches `max_iterations`, `evaluateAdaptiveSignals(a, gitExec)` returns a non-null reason iff *either* `git diff --shortstat HEAD` or `git status --porcelain` reports working-tree changes, *or* the rolling 3-iteration content-hash window contains ≥ 2 distinct hashes. A positive signal grants `adaptive_extension` more iterations, capped at `adaptive_max_total`. Stagnation / completion / abort still win unconditionally because they're checked earlier in `onIdle`.
+
+## Caffeinate integration (issue [#8](https://github.com/kloba/copilot-ralph-extension/issues/8))
+
+Opt-in via `RALPH_CAFFEINATE=1`. On macOS, `armLoop` spawns `caffeinate -i [-d] -w <pid>` to inhibit display/system sleep for the duration of the loop. `finish()` (and every error path) kills the caffeinate process. Tests inject a `spawnFn` stub via `createRalphController({ caffeinate: { spawnFn } })`.
+
+## Test architecture
+
+- `node:test` runner; no third-party test deps.
+- `makeFakeSession()` returns a `{ on, emit, send, log }` object that mimics the SDK's event bus.
+- `runTurn(session, content)` drives one iteration: emits `assistant.message` then `session.idle`.
+- DI on the controller (`createRalphController({ caffeinate, git, adaptive })`) lets tests stub external effects (process spawn, git exec) without monkey-patching.
+- Several **shape-pin tests** lock down field counts and key sets on `state.active`, the success-envelope, the parsed-args object, and the tool-array order. These exist specifically to catch refactors that silently leak internal scratch into the LLM-facing surface.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+Thanks for your interest in `copilot-ralph-extension`! This page is the entry point for contributors. End-user docs live in the [README](../README.md).
+
+## Local development setup
+
+```bash
+git clone https://github.com/kloba/copilot-ralph-extension.git
+cd copilot-ralph-extension
+npm test    # runs the node:test suite under test/ (no install needed — zero runtime deps)
+```
+
+The repository has **zero npm runtime dependencies** and only Node ≥ 20's built-ins (`node:test`, `node:assert`, `node:child_process`). `npm install` is not required to run the test suite.
+
+## Running the extension locally against Copilot CLI
+
+For day-to-day iteration, prefer a **project-scoped** install so your `git checkout` is the live source the CLI loads:
+
+```bash
+./install.sh --project   # installs into .github/extensions/ralph in this repo
+```
+
+After editing `extension/handler.mjs`, run `extensions_reload` from inside Copilot CLI (or restart the CLI) — new tool definitions are picked up immediately.
+
+For a user-scoped install (loads the same extension across all your repos):
+
+```bash
+./install.sh             # default: ~/.copilot/extensions/ralph
+./install.sh --dry-run   # show what would be copied without writing
+```
+
+## Style conventions
+
+- **Source files**: `extension/extension.mjs` (SDK glue, ~30 lines) and `extension/handler.mjs` (controller, ~1.3kLOC). Keep the SDK layer thin — all logic that needs unit-testing belongs in `handler.mjs` so it can be exercised against a fake session.
+- **No third-party deps.** New runtime dependencies require a strong justification (security review, zero-fork ecosystem cost, etc.). Prefer Node built-ins.
+- **Comments**: only where context is non-obvious. The codebase already uses comments to explain *why* (rationale, edge cases, prompt-injection guards) rather than *what*.
+- **Formatting**: 4-space indentation, trailing commas in multi-line literals, double-quoted strings.
+- **Tests**: every behavior change adds or updates a test in `test/extension.test.mjs`. Use the existing `makeFakeSession` / `runTurn` / `arm` helpers — they exercise the controller through the same event surface the SDK uses.
+
+## Commit trailer rules
+
+Every commit MUST include both `Co-authored-by` trailers in this order:
+
+```
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+Co-authored-by: copilot-ralph <noreply+copilot-ralph@github.com>
+```
+
+The first attributes the underlying Copilot model; the second attributes the loop that executed the iteration. Order matters — GitHub surfaces the first co-author more prominently. See the [README "Commit attribution" section](../README.md#commit-attribution) and [CHANGELOG](../CHANGELOG.md) for full rationale and opt-out (`RALPH_NO_ATTRIBUTION=1`).
+
+## Pull request expectations
+
+- `npm test` is green locally and in CI.
+- The PR description references the issue (`Fixes #N`) so it auto-closes on merge.
+- For user-visible changes, append a one-line entry to the **Unreleased** section of [`CHANGELOG.md`](../CHANGELOG.md).
+- README and `docs/ARCHITECTURE.md` are updated when the change affects user-facing behavior or the architectural shape.
+- Surgical commits are preferred over rebases-of-rebases; do not force-push `main`.
+
+## Releasing
+
+See [`docs/RELEASING.md`](RELEASING.md) for the tag-driven release checklist.
+
+## Reporting security issues
+
+See [`SECURITY.md`](../SECURITY.md) for the private disclosure process.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,55 @@
+# Releasing
+
+`copilot-ralph-extension` ships as a small set of `.mjs` files copied into `~/.copilot/extensions/ralph` (or `.github/extensions/ralph` for project-scoped installs). There is **no npm publish**; releases are tagged commits on `main` plus an annotated GitHub Release page.
+
+A formal tag-driven release-automation workflow is tracked in issue [#10](https://github.com/kloba/copilot-ralph-extension/issues/10). Until that ships, the steps below are the manual checklist.
+
+## Manual release checklist
+
+1. **Verify `main` is green**: `npm test` and the GitHub Actions CI workflow on the latest commit.
+2. **Update `CHANGELOG.md`**:
+   - Move entries from `## Unreleased` to a new `## [vX.Y.Z] - YYYY-MM-DD` heading.
+   - Re-create an empty `## Unreleased` heading immediately above it for the next cycle.
+   - Commit with message `Release vX.Y.Z` and the standard `Co-authored-by` trailer.
+3. **Tag the release**: `git tag -a vX.Y.Z -m "vX.Y.Z"` and `git push --tags`.
+4. **Create a GitHub Release**:
+   - Title: `vX.Y.Z`.
+   - Body: paste the new `## [vX.Y.Z]` section from `CHANGELOG.md` verbatim.
+   - Attach `extension/extension.mjs` and `extension/handler.mjs` as release assets so users can pin a specific revision without cloning the repo:
+     ```bash
+     gh release create vX.Y.Z extension/extension.mjs extension/handler.mjs \
+       --title "vX.Y.Z" --notes-file <(awk '/^## \[vX.Y.Z\]/,/^## \[/' CHANGELOG.md | sed '$d')
+     ```
+
+## Versioning
+
+We follow **Semantic Versioning**:
+
+- **MAJOR** — breaking change to the tool surface (renamed/removed tool, removed parameter, changed default that flips loop behavior).
+- **MINOR** — new tool, new optional parameter, new opt-in feature flag.
+- **PATCH** — bug fix, doc-only change, internal refactor with no user-visible behavior change.
+
+The package has zero runtime dependencies, so dependency-driven version bumps don't apply.
+
+## Pinning a specific version (for end users)
+
+Once a release exists with assets attached, end users can pin a specific revision:
+
+```bash
+# Project-scoped pin
+mkdir -p .github/extensions/ralph
+curl -L -o .github/extensions/ralph/extension.mjs \
+  https://github.com/kloba/copilot-ralph-extension/releases/download/vX.Y.Z/extension.mjs
+curl -L -o .github/extensions/ralph/handler.mjs \
+  https://github.com/kloba/copilot-ralph-extension/releases/download/vX.Y.Z/handler.mjs
+```
+
+For the user-scoped equivalent, swap `.github/extensions/ralph` for `~/.copilot/extensions/ralph`.
+
+## Hotfix branches
+
+For an out-of-band patch when `main` has unshippable in-progress work:
+
+1. `git checkout -b hotfix/vX.Y.Z+1 vX.Y.Z`
+2. Cherry-pick the fix commit, update CHANGELOG, tag `vX.Y.Z+1`, release.
+3. Merge `hotfix/vX.Y.Z+1` into `main` so the fix isn't lost.


### PR DESCRIPTION
Splits contributor and design docs out of README into a dedicated docs/
folder and adds a GitHub-recognized SECURITY.md at the repo root for
private vulnerability reporting. README gains a 'Documentation' section
linking to all four files.

- docs/CONTRIBUTING.md — local dev setup, style, commit-trailer rules, PR expectations
- docs/ARCHITECTURE.md — session.idle pattern, source split, state machine, baked prompts, tool surface, adaptive budget, caffeinate
- docs/RELEASING.md — manual tag-driven release checklist (full automation tracked in #10)
- SECURITY.md — private disclosure via GitHub security advisories, latest-tag-only support policy

No content duplicated verbatim between README and docs/ — README links instead.

Fixes #11

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
