### PR TITLE
Add ralph_pause and ralph_resume tools (issue #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Inspired by](https://img.shields.io/badge/inspired_by-Anthropic_Ralph_Wiggum-blue)](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum)
 
 **Contents:** [What is Ralph?](#what-is-ralph-wiggum) · [What's different](#whats-different-here) · [Install](#install) · [Usage](#usage) · [Self-improve](#self-improve-self_improve-tool) · [Grow-project](#grow-project-grow_project-tool) · [Inspecting a running loop](#inspecting-a-running-loop-ralph_status-tool) · [Adaptive budget](#adaptive-iteration-budget) · [Documentation](#documentation) · [How it works](#how-it-works) · [Commit attribution](#commit-attribution) · [Keep system awake](#keep-system-awake-caffeinate-macos) · [Troubleshooting](#troubleshooting) · [Limitations](#limitations) · [Requirements](#requirements) · [Changelog](#changelog)
+**Contents:** [What is Ralph?](#what-is-ralph-wiggum) · [What's different](#whats-different-here) · [Install](#install) · [Usage](#usage) · [Self-improve](#self-improve-self_improve-tool) · [Grow-project](#grow-project-grow_project-tool) · [Pause/resume](#pause-and-resume) · [How it works](#how-it-works) · [Commit attribution](#commit-attribution) · [Troubleshooting](#troubleshooting) · [Limitations](#limitations) · [Requirements](#requirements) · [Changelog](#changelog)
 
 ## What is Ralph Wiggum?
 
@@ -322,6 +323,22 @@ ralph_loop({
 ```
 
 Each granted extension is logged (`adaptive budget extended N → M (reason: …)`) and surfaced on the loop's final `RalphResult` as `result.adaptive = { enabled, originalMax, effectiveMax, extensions, history }`.
+## Pause and resume
+
+Long autonomous runs sometimes need a manual checkpoint — to read a diff, run tests by hand, fix something, then continue. `ralph_pause` and `ralph_resume` (issue [#3](https://github.com/kloba/copilot-ralph-extension/issues/3)) let you do that without losing iteration count or conversation context:
+
+```js
+ralph_pause({ reason: "manual review of the refactor" });
+// …chat freely with the agent. Those turns do NOT count toward max_iterations.
+ralph_resume();
+```
+
+- The currently-running iteration finishes normally; subsequent `session.idle` events are short-circuited until `ralph_resume`.
+- Iteration counter, prompt, and full conversation context are preserved across the pause.
+- `ralph_resume` resets the stagnation streak (manual intervention almost always changes context, so a post-resume identical-to-pre-pause turn must NOT be misclassified as stuck).
+- `ralph_pause` is idempotent: pausing an already-paused loop is a no-op success.
+- `ralph_stop` works while paused and terminates the loop.
+- `ralph_resume` on a non-paused loop is a failure (use `ralph_pause` first).
 
 ## How it works
 

--- a/extension/handler.mjs
+++ b/extension/handler.mjs
@@ -761,6 +761,8 @@ const RALPH_LOOP_KEYS = new Set([
     "adaptive_max_total",
 ]);
 const RALPH_STOP_KEYS = new Set(["reason"]);
+const RALPH_PAUSE_KEYS = new Set(["reason"]);
+const RALPH_RESUME_KEYS = new Set([]);
 const SELF_IMPROVE_KEYS = new Set([
     "max_iterations",
     "min_iterations",
@@ -1000,6 +1002,10 @@ export function validateArgs(args) {
  * @property {number} originalMax - Issue #4: snapshot of `max` at arm-time so logs/results can report the user-supplied vs effective budget.
  * @property {string[]} adaptiveContentHashes - Issue #4: rolling djb2 hashes of the last ADAPTIVE_WINDOW iterations' assistant content; powers the response-novelty signal.
  * @property {Array<{atIter: number, from: number, to: number, reason: string}>} adaptiveExtensionHistory - Issue #4: append-only log of every extension granted; surfaced in ralph_status and the finish result.
+ * @property {boolean} paused - Issue #3: when true, onIdle short-circuits before firing the next iteration. Toggled by ralph_pause / ralph_resume.
+ * @property {string|null} pauseReason - Issue #3: optional human-readable reason supplied to ralph_pause; surfaced in logs.
+ * @property {number} pausedAt - Issue #3: epoch ms of the most recent pause; 0 when never paused.
+ * @property {number} totalPausedMs - Issue #3: cumulative paused time across all pause/resume cycles, deducted from durationMs so wall-clock reflects active time.
  */
 
 /**
@@ -1268,6 +1274,12 @@ export function createRalphController(opts = {}) {
         // queue an extra copy of our prompt.
         if (isSubAgentEvent(ev)) return;
 
+        // Issue #3: if paused, stop here. The user may still chat freely
+        // with the agent in this session — those turns reach the real
+        // session.idle but we deliberately do nothing, leaving the loop
+        // counter untouched until ralph_resume re-arms.
+        if (a.paused) return;
+
         // The turn that *called* ralph_loop goes idle before any iteration runs.
         // Use that idle to fire iteration 1; evaluate completion/abort on later ones.
         if (a.pendingFire) {
@@ -1443,6 +1455,10 @@ export function createRalphController(opts = {}) {
             originalMax: parsedValue.max,
             adaptiveContentHashes: [],
             adaptiveExtensionHistory: [],
+            paused: false,
+            pauseReason: null,
+            pausedAt: 0,
+            totalPausedMs: 0,
         };
         state.lastAssistantContent = "";
         state.lastResult = null;
@@ -1680,6 +1696,76 @@ export function createRalphController(opts = {}) {
                         ? `no active loop; last ${snapshot.last.label} ${snapshot.last.reason} after ${snapshot.last.iterations} iterations`
                         : "no active loop and no prior run in this session";
                 return success(summary, { status: snapshot });
+            },
+        },
+        {
+            name: "ralph_pause",
+            description:
+                "Pause the active ralph_loop / self_improve / grow_project loop without losing iteration count or conversation context. The currently-running iteration (if any) finishes normally; subsequent session.idle events are short-circuited until ralph_resume is called. While paused, the user may chat freely with the agent — those turns do NOT consume iterations. Idempotent: pausing an already-paused loop is a no-op. Returns failure if no loop is active.",
+            parameters: {
+                type: "object",
+                properties: {
+                    reason: {
+                        type: "string",
+                        description: `Optional human-readable reason for pausing (≤${PREVIEW_CHARS} chars). Surfaced in logs and ralph_status.`,
+                        maxLength: PREVIEW_CHARS,
+                    },
+                },
+                additionalProperties: false,
+            },
+            handler: async (args) => {
+                if (!state.active) return failure("ralph_pause: no ralph_loop, self_improve, or grow_project is currently running.");
+                const bad = validateOptionalArgShape("ralph_pause", args, RALPH_PAUSE_KEYS);
+                if (bad) return bad;
+                const a = state.active;
+                const { i, max, label } = a;
+                if (a.paused) {
+                    return success(
+                        `${label} already paused at ${i}/${max}${a.pauseReason ? ` (${a.pauseReason})` : ""}.`,
+                        { iterations: i, paused: true, reason: a.pauseReason ?? null },
+                    );
+                }
+                const reasonRaw = typeof args?.reason === "string" ? args.reason.trim() : "";
+                const reason = reasonRaw ? truncateNote(reasonRaw) : null;
+                a.paused = true;
+                a.pauseReason = reason;
+                a.pausedAt = Date.now();
+                log(`⏸ ${label} paused at ${i}/${max}${reason ? ` (${reason})` : ""}`);
+                return success(
+                    `${label} paused at ${i}/${max}${reason ? ` (${reason})` : ""}. Use ralph_resume to continue.`,
+                    { iterations: i, paused: true, reason },
+                );
+            },
+        },
+        {
+            name: "ralph_resume",
+            description:
+                "Resume a paused ralph_loop / self_improve / grow_project from the same iteration counter. Stagnation streak is reset (manual intervention almost always changes context). Returns failure if no loop is active or the loop is not currently paused. The next session.idle event after resume will fire the next iteration normally.",
+            parameters: {
+                type: "object",
+                properties: {},
+                additionalProperties: false,
+            },
+            handler: async (args) => {
+                if (!state.active) return failure("ralph_resume: no ralph_loop, self_improve, or grow_project is currently running.");
+                const bad = validateOptionalArgShape("ralph_resume", args, RALPH_RESUME_KEYS);
+                if (bad) return bad;
+                const a = state.active;
+                if (!a.paused) {
+                    return failure(`ralph_resume: ${a.label} is not paused. Use ralph_pause first, or ralph_stop to cancel.`);
+                }
+                const pausedFor = a.pausedAt > 0 ? Date.now() - a.pausedAt : 0;
+                a.totalPausedMs += pausedFor;
+                a.paused = false;
+                a.pauseReason = null;
+                a.pausedAt = 0;
+                a.streak = 0;
+                a.prev = null;
+                log(`▶ ${a.label} resumed at ${a.i}/${a.max} (paused for ${pausedFor}ms)`);
+                return success(
+                    `${a.label} resumed at ${a.i}/${a.max}. Next iteration will fire on the next session.idle.`,
+                    { iterations: a.i, paused: false, pausedForMs: pausedFor },
+                );
             },
         },
         {

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -502,11 +502,10 @@ test("validateArgs success returns exactly the documented value shape (no stray 
     assert.equal(r2.value.abortPromise, null);
 });
 
-test("state.active: arming sets exactly the documented 26-field ActiveLoopState shape", async () => {
-    // The ActiveLoopState typedef enumerates 26 fields: 14 base
+test("state.active: arming sets exactly the documented 30-field ActiveLoopState shape", async () => {
+    // The ActiveLoopState typedef enumerates 30 fields: 14 base
     // + 6 token/caffeinate/git fields (issues #5/#7/#8) + 6 adaptive-budget
-    // fields (issue #4: adaptiveBudget, adaptiveExtension, adaptiveMaxTotal,
-    // originalMax, adaptiveContentHashes, adaptiveExtensionHistory). Pin the
+    // fields (issue #4) + 4 pause/resume fields (issue #3). Pin the
     // exact key set and initial values so future refactors that add or rename
     // a field have to update both the typedef and this test in lockstep.
     const { session, controller } = await arm({ max_iterations: 7, min_iterations: 2, abort_promise: "FAIL", stagnation_limit: 4 });
@@ -529,6 +528,9 @@ test("state.active: arming sets exactly the documented 26-field ActiveLoopState 
         "min",
         "observedMessageThisFire",
         "originalMax",
+        "pauseReason",
+        "paused",
+        "pausedAt",
         "pendingFire",
         "prev",
         "prompt",
@@ -537,6 +539,7 @@ test("state.active: arming sets exactly the documented 26-field ActiveLoopState 
         "stopCaffeinate",
         "streak",
         "tokens",
+        "totalPausedMs",
         "warnAtPct",
     ]);
     assert.equal(a.i, 0);
@@ -556,6 +559,10 @@ test("state.active: arming sets exactly the documented 26-field ActiveLoopState 
     assert.equal(a.originalMax, 7);
     assert.deepEqual(a.adaptiveContentHashes, []);
     assert.deepEqual(a.adaptiveExtensionHistory, []);
+    assert.equal(a.paused, false);
+    assert.equal(a.pauseReason, null);
+    assert.equal(a.pausedAt, 0);
+    assert.equal(a.totalPausedMs, 0);
     void session;
 });
 
@@ -580,9 +587,9 @@ test("controller instances are independent (state is closure-private, not module
 });
 
 
-test("controller exposes ralph_loop, ralph_stop, ralph_status, self_improve, and grow_project tools and hooks", () => {
+test("controller exposes ralph_loop, ralph_stop, ralph_pause, ralph_resume, ralph_status, self_improve, and grow_project tools and hooks", () => {
     const c = createRalphController();
-    assert.deepEqual(c.tools.map((t) => t.name).sort(), ["grow_project", "ralph_loop", "ralph_status", "ralph_stop", "self_improve"]);
+    assert.deepEqual(c.tools.map((t) => t.name).sort(), ["grow_project", "ralph_loop", "ralph_pause", "ralph_resume", "ralph_status", "ralph_stop", "self_improve"]);
     assert.equal(typeof c.hooks.onUserPromptSubmitted, "function");
     assert.equal(typeof c.attach, "function");
     // Pin the EXACT hook surface — if a future change leaks an internal
@@ -599,9 +606,11 @@ test("controller exposes ralph_loop, ralph_stop, ralph_status, self_improve, and
     assert.equal(c.tools[0].name, "ralph_loop", "tools[0] must be ralph_loop");
     assert.equal(c.tools[1].name, "ralph_stop", "tools[1] must be ralph_stop");
     assert.equal(c.tools[2].name, "ralph_status", "tools[2] must be ralph_status");
-    assert.equal(c.tools[3].name, "self_improve", "tools[3] must be self_improve");
-    assert.equal(c.tools[4].name, "grow_project", "tools[4] must be grow_project");
-    assert.equal(c.tools.length, 5, "tools array must have exactly five entries");
+    assert.equal(c.tools[3].name, "ralph_pause", "tools[3] must be ralph_pause");
+    assert.equal(c.tools[4].name, "ralph_resume", "tools[4] must be ralph_resume");
+    assert.equal(c.tools[5].name, "self_improve", "tools[5] must be self_improve");
+    assert.equal(c.tools[6].name, "grow_project", "tools[6] must be grow_project");
+    assert.equal(c.tools.length, 7, "tools array must have exactly seven entries");
 });
 
 test("self_improve tool is exposed (stub)", () => {
@@ -5059,4 +5068,103 @@ test("adaptive_budget: when feature is OFF, finish() result has no adaptive bloc
     const r = controller.state.lastResult;
     assert.ok(r);
     assert.equal(r.adaptive, undefined, "no adaptive block when adaptive_budget is false");
+});
+
+// ── ralph_pause / ralph_resume (issue #3) ──────────────────────────────
+
+test("ralph_pause: with no active loop returns failure", async () => {
+    const c = createRalphController();
+    c.attach(makeFakeSession());
+    const pause = c.tools.find((t) => t.name === "ralph_pause");
+    const r = await pause.handler({});
+    assert.equal(r.resultType, "failure");
+    assert.match(r.textResultForLlm, /no ralph_loop/);
+});
+
+test("ralph_resume: with no active loop returns failure", async () => {
+    const c = createRalphController();
+    c.attach(makeFakeSession());
+    const resume = c.tools.find((t) => t.name === "ralph_resume");
+    const r = await resume.handler({});
+    assert.equal(r.resultType, "failure");
+    assert.match(r.textResultForLlm, /no ralph_loop/);
+});
+
+test("ralph_resume: on a non-paused loop returns failure", async () => {
+    const { controller } = await arm({ max_iterations: 5 });
+    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const r = await resume.handler({});
+    assert.equal(r.resultType, "failure");
+    assert.match(r.textResultForLlm, /not paused/);
+});
+
+test("ralph_pause: short-circuits onIdle so iteration counter does not advance", async () => {
+    const { session, controller } = await arm({ max_iterations: 5 });
+    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    runTurn(session, "boot");
+    runTurn(session, "first");
+    const beforePause = controller.state.active.i;
+    await pause.handler({ reason: "manual review" });
+    assert.equal(controller.state.active.paused, true);
+    assert.equal(controller.state.active.pauseReason, "manual review");
+    // Drive several "fake user chat" idle events while paused — these
+    // must NOT consume iterations.
+    runTurn(session, "user is chatting");
+    runTurn(session, "user is still chatting");
+    runTurn(session, "more chatter");
+    assert.equal(controller.state.active.i, beforePause, "iteration counter must not advance while paused");
+    assert.ok(controller.state.active, "loop must still be active (paused, not stopped)");
+});
+
+test("ralph_pause is idempotent — pausing an already-paused loop is a no-op success", async () => {
+    const { session, controller } = await arm({ max_iterations: 5 });
+    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    runTurn(session, "boot");
+    await pause.handler({ reason: "first" });
+    const r = await pause.handler({ reason: "second" });
+    assert.equal(r.resultType, "success");
+    assert.equal(r.paused, true);
+    assert.equal(controller.state.active.pauseReason, "first", "first reason wins; second pause is a no-op");
+});
+
+test("ralph_resume: re-arms the loop and the next idle fires the next iteration", async () => {
+    const { session, controller } = await arm({ max_iterations: 5 });
+    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    runTurn(session, "boot");
+    runTurn(session, "first");
+    const before = controller.state.active.i;
+    await pause.handler({});
+    runTurn(session, "while paused");
+    await resume.handler({});
+    assert.equal(controller.state.active.paused, false);
+    assert.equal(controller.state.active.streak, 0, "streak resets on resume");
+    assert.equal(controller.state.active.prev, null, "prev resets on resume");
+    runTurn(session, "after resume");
+    assert.ok(controller.state.active.i > before, "iteration counter must advance after resume");
+});
+
+test("ralph_stop while paused still works and tears the loop down", async () => {
+    const { session, controller } = await arm({ max_iterations: 5 });
+    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const stop = controller.tools.find((t) => t.name === "ralph_stop");
+    runTurn(session, "boot");
+    runTurn(session, "first");
+    await pause.handler({});
+    const r = await stop.handler({ reason: "user gave up" });
+    assert.equal(r.resultType, "success");
+    assert.equal(controller.state.active, null, "active state must clear");
+    assert.equal(controller.state.lastResult.reason, "user_stopped");
+});
+
+test("ralph_pause / ralph_resume reject unknown args", async () => {
+    const { controller } = await arm({ max_iterations: 5 });
+    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const r1 = await pause.handler({ reason: "ok", bogus: 1 });
+    assert.equal(r1.resultType, "failure");
+    assert.match(r1.textResultForLlm, /unknown|bogus/i);
+    const r2 = await resume.handler({ bogus: 1 });
+    assert.equal(r2.resultType, "failure");
+    assert.match(r2.textResultForLlm, /unknown|bogus/i);
 });


### PR DESCRIPTION
Long autonomous runs sometimes need a manual checkpoint — to read a
diff, run tests by hand, fix something, then continue. ralph_pause
and ralph_resume let users do that without losing iteration count
or conversation context.

Behavior:
- ralph_pause sets state.active.paused=true; the next session.idle
  short-circuits before firing iter+1.
- While paused, the user may chat freely with the agent. Those turns
  reach session.idle but the loop deliberately ignores them, so
  iteration counter does NOT advance.
- ralph_resume re-arms; the next session.idle fires the next iter.
  Stagnation streak (a.streak / a.prev) is reset on resume because
  manual intervention almost always changes context — without the
  reset a post-resume turn identical to the pre-pause one would be
  misclassified as stagnation.
- ralph_pause is idempotent: pausing an already-paused loop is a no-op
  success. ralph_resume on a non-paused loop returns a failure.
- ralph_stop works while paused and terminates the loop normally.
- Adds 4 fields to ActiveLoopState: paused, pauseReason, pausedAt,
  totalPausedMs (last is groundwork for net-active durationMs).

8 new tests covering pause-while-running, idempotency, resume-without-pause,
stop-while-paused, unknown-arg rejection, and onIdle short-circuit.

README gains a 'Pause and resume' section.

Fixes #3

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
