### PR TITLE
Add MkDocs Material site scaffold (issue #2)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+name: Deploy docs site
+
+# Tracked in issue #2: https://github.com/kloba/copilot-ralph-extension/issues/2
+# Deploys the MkDocs Material site under /docs/ to the gh-pages branch
+# whenever the docs/, mkdocs.yml, or this workflow itself change on main.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.x"
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material==9.5.* mkdocs==1.6.*
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Deploy to gh-pages
+        run: mkdocs gh-deploy --force --clean --message "docs: deploy ${{ github.sha }}"

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,13 @@
+# Concepts
+
+!!! note "Stub page (issue #2)"
+    Scaffold only — to be expanded in follow-ups. See the [README](https://github.com/kloba/copilot-ralph-extension#readme) until this page is filled in.
+
+Topics planned:
+
+- The arming → idle-driven iteration model
+- Completion / abort / stagnation finish reasons
+- Sub-agent isolation
+- Token tracking and context-window warnings
+- Pause / resume semantics
+- Adaptive iteration budget

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,4 @@
+# FAQ
+
+!!! note "Stub page (issue #2)"
+    Scaffold only — to be expanded in follow-ups. See the [README](https://github.com/kloba/copilot-ralph-extension#readme) Troubleshooting + Limitations sections until this page is filled in.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+# Ralph
+
+A Ralph Wiggum-style autonomous loop for the GitHub Copilot CLI.
+
+!!! warning "Stub documentation site"
+    This site is the v0 scaffold for [issue #2](https://github.com/kloba/copilot-ralph-extension/issues/2). The pages below mirror the planned navigation but are intentionally short — they will be filled in by follow-up PRs.
+
+## What is this?
+
+Ralph turns the Copilot CLI into a self-driving iteration engine. You arm it with a prompt, and it re-fires that prompt every time the agent goes idle until either the agent emits a "done" phrase, you call `ralph_stop`, or a hard cap is reached.
+
+See the [Quickstart](quickstart.md) to get going in under a minute.
+
+## Why "Ralph"?
+
+The loop is the simplest possible form of agentic autonomy: one prompt, repeated, until done. Like Ralph Wiggum eating glue — single-minded, persistent, surprisingly effective.
+
+## Repository
+
+- [Source on GitHub](https://github.com/kloba/copilot-ralph-extension)
+- [Issue tracker](https://github.com/kloba/copilot-ralph-extension/issues)
+- [Releases](https://github.com/kloba/copilot-ralph-extension/releases)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,26 @@
+# Quickstart
+
+!!! note "Stub page (issue #2)"
+    Scaffold only — to be expanded in follow-ups.
+
+## Install
+
+```bash
+git clone https://github.com/kloba/copilot-ralph-extension
+cd copilot-ralph-extension
+./install.sh
+```
+
+## Arm a loop
+
+```js
+ralph_loop({ prompt: "Refactor src/auth.js. Emit COMPLETE when done." })
+```
+
+Stop early:
+
+```js
+ralph_stop({ reason: "changed plan" })
+```
+
+See the project [README](https://github.com/kloba/copilot-ralph-extension#readme) for the full reference until these pages are filled in.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,11 @@
+# Recipes
+
+!!! note "Stub page (issue #2)"
+    Scaffold only — to be expanded in follow-ups. See the [README](https://github.com/kloba/copilot-ralph-extension#readme) until this page is filled in.
+
+Planned recipes:
+
+- "Refactor a module until tests pass"
+- "Walk a backlog issue-by-issue"
+- "Self-improve a project across SDLC categories"
+- "Long-running grow-project run with adaptive budget"

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,0 +1,10 @@
+# Showcase
+
+!!! note "Stub page (issue #2)"
+    Scaffold only — to be expanded in follow-ups.
+
+This page will eventually feature:
+
+- Recorded demos of long Ralph runs
+- Live dashboard screenshots (see [issue #6](https://github.com/kloba/copilot-ralph-extension/issues/6))
+- Real-world projects built or maintained by Ralph

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,60 @@
+# MkDocs Material configuration for the Ralph documentation site.
+# Tracked in issue #2: https://github.com/kloba/copilot-ralph-extension/issues/2
+#
+# Build locally:
+#   pip install mkdocs-material
+#   mkdocs serve   # http://127.0.0.1:8000
+#
+# Deploys via .github/workflows/docs.yml on pushes to main.
+
+site_name: Ralph
+site_description: A Ralph Wiggum-style autonomous loop for the GitHub Copilot CLI.
+site_url: https://kloba.github.io/copilot-ralph-extension/
+repo_url: https://github.com/kloba/copilot-ralph-extension
+repo_name: kloba/copilot-ralph-extension
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - content.code.copy
+    - navigation.instant
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - search.suggest
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - Concepts: concepts.md
+  - Recipes: recipes.md
+  - Showcase: showcase.md
+  - FAQ: faq.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - toc:
+      permalink: true


### PR DESCRIPTION
Partial implementation of #2.

Scaffolds the documentation site:
- `mkdocs.yml` with Material theme, navigation, and markdown extensions
- `docs/{index,quickstart,concepts,recipes,showcase,faq}.md` stub pages
- `.github/workflows/docs.yml` deploys to `gh-pages` on push to main

Site URL once enabled: https://kloba.github.io/copilot-ralph-extension/

Future PRs will:
- Fill in each stub page with full content
- Add asciinema / video embeds on the showcase page
- Add a custom domain CNAME if/when desired
- Wire in the dashboard demo (#6)

Marked draft to make the partial scope explicit. Fixes #2 once the page content lands in follow-ups.