### PR TITLE
feat(branding)!: stage 1 rename (refs #49)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Copilot Instructions for copilot-ralph-extension
+# Copilot Instructions for autopilot
 
 This is the canonical filename GitHub Copilot (and other AI coding
 assistants that load `.github/copilot-instructions.md` automatically)
@@ -25,10 +25,11 @@ the single source of truth:
   `.github/workflows/release.yml` enforces the match.
 - **AI-authored commits** must include both
   `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`
-  and (unless `RALPH_NO_ATTRIBUTION=1` is set in the environment)
+  and (unless `AUTOPILOT_NO_ATTRIBUTION=1` is set in the environment)
   `Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>`
   trailers so loop-driven commits are passively searchable across
-  public GitHub.
+  public GitHub. Legacy `RALPH_*` env vars (e.g. `RALPH_NO_ATTRIBUTION`)
+  still work via fallback for one release.
 - **Tests**: the project is pure-stdlib Node; run them with `npm test`.
   No build, no lint, no transpiler — `node --test test/*.test.mjs
   packages/*/test/*.test.mjs` covers everything.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,6 @@
 name: Deploy docs site
 
-# Tracked in issue #2: https://github.com/kloba/copilot-ralph-extension/issues/2
+# Tracked in issue #2: https://github.com/kloba/autopilot/issues/2
 # Deploys the MkDocs Material site under /docs/ to the gh-pages branch
 # whenever the docs/, mkdocs.yml, or this workflow itself change on main.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — Development Guide for Humans and AI Agents
 
 This file is the authoritative process guide for anyone (human or AI) making
-changes to **copilot-ralph-extension**. It pins the three conventions that
+changes to **autopilot**. It pins the three conventions that
 keep the project releasable without drama: **Semantic Versioning** for the
 public surface, **Keep a Changelog** for `CHANGELOG.md`, and **Conventional
 Commits** for git history. Together they let us cut a release by tagging
@@ -68,7 +68,7 @@ what makes automated changelog generation possible.
 
 Use the package or directory name when it narrows the change:
 `extension`, `tui`, `install`, `release`, `docs`, `prompt`, or a tool name
-(`grow_project`, `ralph_loop`, `ralph_status`, …). Scope is optional but
+(`grow_project`, `ap_loop`, `ap_status`, …). Scope is optional but
 encouraged — it lands in changelog grouping.
 
 ### Breaking changes
@@ -96,11 +96,11 @@ bump with a `### Breaking` changelog section).
 ### Examples (good)
 
 ```
-feat(ralph_status): include adaptive extension history in snapshot
+feat(ap_status): include adaptive extension history in snapshot
 fix(install): atomic per-file copy via temp + rename to avoid torn reads
 docs(agents): add Conventional Commits guide
 chore(deps): bump node engine floor to 20
-refactor(handler): extract gitExec helper for ralph_status reuse
+refactor(handler): extract gitExec helper for ap_status reuse
 feat(grow_project)!: drop pre-flight ideation when backlog non-empty
 ```
 
@@ -199,9 +199,13 @@ The placement reasoning:
 
 - Reference the issue or PR (`(issue #25)` or `(#42)`).
 - Write what the user observes, not the diff. ("Adds opt-out env var
-  `RALPH_NO_ATTRIBUTION` to suppress the second `copilot-ralph`
+  `AUTOPILOT_NO_ATTRIBUTION` to suppress the second `copilot-ralph`
   trailer" — not "added new branch in handler.mjs").
 - Wrap prose at ~72 chars for readable git diffs.
+
+Legacy `RALPH_*` env-var names are still read for one release with a one-line stderr deprecation notice.
+
+Legacy `~/.copilot/ralph[ -tui]/runs` paths are still read on first run with a one-line stderr migration notice; new runs write to the autopilot* paths.
 
 ### Release flow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 ## Unreleased
 
 ### Features
+- Issue #54 — `ralph-tui run` UX hardening across the
+  three-level layout. The four top panes
+  (`<Header>` / `<StagesRow>` / `<TasksPane>` /
+  `<SubstagesPane>`) now render a bold-underline heading
+  (`Run` / `Stages` / `Tasks` / `Activity`) inside their
+  bordered Box matching the existing inside-border heading
+  convention used by `<Timeline>` / `<DetailPane>` /
+  `<LastCommit>`, so each pane is identifiable without
+  hovering for context. `<SubstagesPane>` decouples the
+  pane heading from the active-stage marker — `Activity` is
+  the heading and the `▸ STAGE_NAME` body row remains in the
+  first content position so the substage stream still scopes
+  visually to its parent stage. The `<Timeline>` pane now
+  shows `(working…)` (dim) for in-flight iters that haven't
+  yet streamed an excerpt, instead of the misleading
+  `(no excerpt)` which made finished and in-flight iters
+  indistinguishable; finished iters with no captured
+  excerpt still get the historical `(no excerpt)` placeholder
+  so replay fidelity for old runs is intact. `<Timeline>`
+  also picks up live excerpt streaming: the runner streams
+  root-agent `assistant.message.data.content` into existing
+  `usage_update` events whenever 80+ new chars accumulate,
+  capped at 500 chars surrogate-safely. `foldEvents` extends
+  the `usage_update` case to update `iterations[last].excerpt`
+  when the live event matches the in-flight iter (guarded by
+  `endedAt == null` so a late event can't clobber a closed
+  iter's excerpt) and `snap.lastExcerpt` for run-scope
+  display, so the user sees mid-iter narration update within
+  seconds of the agent emitting it rather than waiting for
+  `iteration_end` at iter close. The `<LastCommit>` pane is
+  no longer empty on mount when the run hasn't yet made a
+  commit: the runner shells `git rev-parse --short HEAD` +
+  `git log -1 --pretty=format:%s%(trailers:only)` once at
+  arm time (right after the canonical `armed` event,
+  carrying `iteration: 0`) so HEAD surfaces immediately;
+  `defaultGitExec` gained a 200 ms `spawnSync` timeout to
+  protect the start path against a wedged repo (lock file,
+  hung credential helper). When `gitExec` is null (test
+  injection without a stub) or the cwd isn't a git repo,
+  arm-time replay is silently skipped — no crash, no spurious
+  event, the pane just stays empty exactly like before the
+  fix when there's nothing to surface.
+
 - TUI 3-level renderer (issue #48 slice 9): the `<App>` layout
   now composes the new `<TasksPane>` + `<LastCommit>` panes
   alongside the existing `<Header>` / `<StagesRow>` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,22 @@
   `feat/rename-autopilot` branch and ship together as a single
   `feat!:` squash-merge.
 
+- Refs #49: sync `docs/quickstart.md`, `docs/index.md`, and
+  `docs/faq.md` user-facing tool-name references to the renamed
+  surface shipped by `ca5ca91` — `ralph_loop` → `ap_loop`,
+  `ralph_stop` → `ap_stop`, `ralph_pause` → `ap_pause`,
+  `ralph_resume` → `ap_resume`, `ralph_status.paused_for_ms` →
+  `ap_status.paused_for_ms`. Also fix a now-broken FAQ anchor:
+  `#inspecting-a-running-loop-ralph_status-tool` →
+  `#inspecting-a-running-loop-ap_status-tool` (the README's
+  matching heading was already renamed). Untouched on this slice
+  pending the open #49 decisions A (filesystem paths under
+  `~/.copilot/ralph/`), B (`RALPH_*` environment variables and
+  `RALPH_DONE_42` example completion phrase), and the locked
+  `copilot-ralph` co-author trailer literal. The `ralph-tui`
+  binary references in `docs/faq.md` also stay until the binary
+  rename slice lands.
+
 ### Features
 - `events.mjs` gains the `stage_plan` / `stage_plan_amend` /
   `task_list` / `task_start` / `task_end` / `commit_observed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Breaking
+
+- **Project renamed `copilot-ralph-extension` → `autopilot`.** Top-level npm package, sub-package `@copilot-ralph-extension/tui` → `@autopilot/tui`, binary `ralph-tui` → `autopilot`, GitHub repo URL `kloba/copilot-ralph-extension` → `kloba/autopilot`. (refs #49)
+- **Tools renamed `ralph_{loop,status,pause,resume,stop}` → `ap_*`.** `self_improve` and `grow_project` keep their names. Existing scripts using the old tool names will fail with `unknown tool` errors. (refs #49)
+- **Runtime paths flipped.** Default events root `~/.copilot/ralph/runs` → `~/.copilot/autopilot/runs`; default TUI runner state root `~/.copilot/ralph-tui/runs` → `~/.copilot/autopilot-tui/runs`; install root `~/.copilot/extensions/ralph` → `~/.copilot/extensions/autopilot`; `.github/extensions/ralph` → `.github/extensions/autopilot`. On first run, if the new path doesn't yet exist and the legacy `~/.copilot/ralph[-tui]/runs` does, the new code reads from the legacy path and prints a one-line stderr migration notice (sentinel-gated so it doesn't reprint). Subsequent writes land in the new path. (refs #49)
+- **Env vars renamed `RALPH_*` → `AUTOPILOT_*`** (`RALPH_EVENTS_DIR` → `AUTOPILOT_EVENTS_DIR`; `RALPH_TUI_RUNS_DIR` → `AUTOPILOT_RUNS_DIR`; `RALPH_TUI_COPILOT_BIN` → `AUTOPILOT_COPILOT_BIN`; `RALPH_NO_ATTRIBUTION` → `AUTOPILOT_NO_ATTRIBUTION`; `RALPH_CAFFEINATE` → `AUTOPILOT_CAFFEINATE`; `RALPH_CAFFEINATE_SCOPE` → `AUTOPILOT_CAFFEINATE_SCOPE`). Old names are still read for one release with a one-line stderr deprecation notice on first read. (refs #49)
+- **`events.jsonl` vocabulary breaking.** Event `label` values flip `ralph_loop` → `ap_loop`, `ralph_pause` → `ap_pause`, etc. The `runId` mode prefixes `ralph-tui-self-improve` / `ralph-tui-grow-project` / `ralph-tui-prompt` flip to `autopilot-self-improve` / `autopilot-grow-project` / `autopilot-prompt`. No compatibility shim — external scripts filtering on the old labels must update their patterns. (refs #49)
+- **`scripts/ralph-tui-fresh.sh` is now a deprecating wrapper around `scripts/autopilot-fresh.sh`.** Existing aliases keep working (with a one-line stderr notice on each invocation). The wrapper will be removed in a future release. (refs #49)
+
+### Preserved
+
+- The `Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>` trailer literal continues to ship on every loop-driven commit. Cross-GitHub searchability of past + future loop commits is preserved verbatim. The `AUTOPILOT_NO_ATTRIBUTION=1` env var (legacy `RALPH_NO_ATTRIBUTION=1` still works) suppresses ONLY the second trailer; the first `Copilot` trailer always ships. (refs #49)
+
 ### Features
 - Issue #54 — `ralph-tui run` UX hardening across the
   three-level layout. The four top panes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,24 @@
   into a `{sha, subject, trailers[]}` triple, capping
   trailers at 8 to match the events.mjs serializer.
 
+### Documentation
+- Refs #49: drop "Ralph Wiggum"-style project-branding prose
+  from package metadata, file headers, mkdocs site description,
+  the `ralph_loop` tool description, README subtitle, and the
+  docs landing page. Also drop `ralph-wiggum` from the root
+  `package.json` and `packages/tui/package.json` `keywords`
+  arrays. Factual external attribution to Anthropic's original
+  Ralph Wiggum Claude Code plugin (README "Inspired by" badge,
+  README "What is Ralph Wiggum?" explainer, `docs/index.md`
+  technique footnote, `docs/ARCHITECTURE.md` factual link)
+  stays — those sentences cite the originator of the technique
+  rather than brand this project as Ralph-style. First slice
+  of the multi-stage rename tracked by issue #49; subsequent
+  slices land the binary, tool-name, env-var, path, and
+  package-name renames as separate commits on the same
+  `feat/rename-autopilot` branch and ship together as a single
+  `feat!:` squash-merge.
+
 ### Features
 - `events.mjs` gains the `stage_plan` / `stage_plan_amend` /
   `task_list` / `task_start` / `task_end` / `commit_observed`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/kloba/copilot-ralph-extension/actions/workflows/ci.yml/badge.svg)](https://github.com/kloba/copilot-ralph-extension/actions/workflows/ci.yml)
 [![Inspired by](https://img.shields.io/badge/inspired_by-Anthropic_Ralph_Wiggum-blue)](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum)
 
-**Contents:** [What is Ralph?](#what-is-ralph-wiggum) · [What's different](#whats-different-here) · [Install](#install) · [Usage](#usage) · [Development](#development) · [Documentation](#documentation) · [Self-improve](#self-improve-self_improve-tool) · [Grow-project](#grow-project-grow_project-tool) · [Inspecting a running loop](#inspecting-a-running-loop-ralph_status-tool) · [Adaptive budget](#adaptive-iteration-budget) · [Pause/resume](#pause-and-resume) · [How it works](#how-it-works) · [Commit attribution](#commit-attribution) · [Keep system awake](#keep-system-awake-caffeinate-macos) · [Troubleshooting](#troubleshooting) · [Limitations](#limitations) · [Requirements](#requirements) · [Changelog](#changelog) · [License](#license)
+**Contents:** [What is Ralph?](#what-is-ralph-wiggum) · [What's different](#whats-different-here) · [Install](#install) · [Usage](#usage) · [Development](#development) · [Documentation](#documentation) · [Self-improve](#self-improve-self_improve-tool) · [Grow-project](#grow-project-grow_project-tool) · [Inspecting a running loop](#inspecting-a-running-loop-ap_status-tool) · [Adaptive budget](#adaptive-iteration-budget) · [Pause/resume](#pause-and-resume) · [How it works](#how-it-works) · [Commit attribution](#commit-attribution) · [Keep system awake](#keep-system-awake-caffeinate-macos) · [Troubleshooting](#troubleshooting) · [Limitations](#limitations) · [Requirements](#requirements) · [Changelog](#changelog) · [License](#license)
 
 ## What is Ralph Wiggum?
 
@@ -94,9 +94,9 @@ For a project-scoped pin, swap `~/.copilot/extensions/ralph` for `.github/extens
 
 ## Usage
 
-In a Copilot CLI session, ask the agent to invoke `ralph_loop`:
+In a Copilot CLI session, ask the agent to invoke `ap_loop`:
 
-> *"Use ralph_loop to: create a REST API for todos with CRUD operations and tests. Run tests after each change. Output COMPLETE when all tests pass. max_iterations 20."*
+> *"Use ap_loop to: create a REST API for todos with CRUD operations and tests. Run tests after each change. Output COMPLETE when all tests pass. max_iterations 20."*
 
 The tool **arms** the loop and returns immediately. Iterations then play out as normal assistant turns, each kicked off by a `session.idle` event re-injecting the prompt via `session.send`.
 
@@ -118,32 +118,32 @@ The tool **arms** the loop and returns immediately. Iterations then play out as 
 
 ### Companion tool
 
-`ralph_stop` cancels an active loop and returns the iteration count. Optionally takes a `reason` string (≤500 chars) which is recorded on the result as `note` and surfaced in the log line and `additionalContext` injection — handy when the agent (or user) wants to record *why* the loop was stopped manually.
+`ap_stop` cancels an active loop and returns the iteration count. Optionally takes a `reason` string (≤500 chars) which is recorded on the result as `note` and surfaced in the log line and `additionalContext` injection — handy when the agent (or user) wants to record *why* the loop was stopped manually.
 
 ```js
-ralph_stop({ reason: "user changed plan" })
+ap_stop({ reason: "user changed plan" })
 ```
 
-`ralph_stop` returns:
+`ap_stop` returns:
 
 ```js
 {
-  textResultForLlm: "ralph_loop stopped after 4/20 iterations (user changed plan).",   // leading "ralph_loop" reflects the calling tool's label — a self_improve-armed loop reads "self_improve stopped after …", and a grow_project-armed loop reads "grow_project stopped after …"
+  textResultForLlm: "ap_loop stopped after 4/20 iterations (user changed plan).",   // leading "ap_loop" reflects the calling tool's label — a self_improve-armed loop reads "self_improve stopped after …", and a grow_project-armed loop reads "grow_project stopped after …"
   resultType: "success",
   iterations: 4,
   note: "user changed plan"   // omitted when no reason was supplied
 }
 ```
 
-If no loop is active it returns `resultType: "failure"` with the message `ralph_stop: no ralph_loop, self_improve, or grow_project is currently running.` and does nothing else — there's no new outcome to surface. (When `ralph_stop` *does* succeed, the resulting `user_stopped` outcome flows through the `additionalContext` injection on the next `onUserPromptSubmitted` hook, exactly as for any other finish reason.)
+If no loop is active it returns `resultType: "failure"` with the message `ap_stop: no ap_loop, self_improve, or grow_project is currently running.` and does nothing else — there's no new outcome to surface. (When `ap_stop` *does* succeed, the resulting `user_stopped` outcome flows through the `additionalContext` injection on the next `onUserPromptSubmitted` hook, exactly as for any other finish reason.)
 
 ### Result shape
 
-`ralph_loop` (the arming call) returns:
+`ap_loop` (the arming call) returns:
 
 ```js
 {
-  textResultForLlm: "ralph_loop armed (max=20). Iterations will run as conversation turns. Use ralph_stop to cancel.",
+  textResultForLlm: "ap_loop armed (max=20). Iterations will run as conversation turns. Use ap_stop to cancel.",
   resultType: "success",
   armed: true,
   max: 20,
@@ -152,8 +152,8 @@ If no loop is active it returns `resultType: "failure"` with the message `ralph_
 ```
 
 The actual loop **outcome** (iteration count, reason, timing) is surfaced in two ways:
-- `session.log` markers visible in the timeline (`🔁 ralph_loop iter 4/20 (elapsed 12345ms)`, `✅ completed ralph_loop after 4 iterations (reason: completion_promise, 12345ms)`). The leading label (`ralph_loop`, `self_improve`, or `grow_project`) reflects which tool armed the loop, so a `self_improve`-armed run shows `🔁 self_improve iter 4/20` and a `grow_project`-armed run shows `🔁 grow_project iter 4/200`. The closing-line verb depends on the finish reason: ✅ *completed* (`completion_promise`), ⚠️ *ended* (`send_error`, `aborted`, `abort_promise`, `stagnation` — the four reasons that map to `type=abort` in the terminal event, so the marker matches the red badge in the TUI), and ⏹ *stopped* for the neutral exits (`max_iterations`, `max_tokens`, `user_stopped`, `detached`).
-- An `additionalContext` injection on the *next* `onUserPromptSubmitted` hook so the agent silently learns the loop finished and why (`[ralph_loop just finished — iterations=4, reason=completion_promise, durationMs=12345]`, or `[self_improve just finished — …]` / `[grow_project just finished — …]` when armed via the corresponding tool).
+- `session.log` markers visible in the timeline (`🔁 ap_loop iter 4/20 (elapsed 12345ms)`, `✅ completed ap_loop after 4 iterations (reason: completion_promise, 12345ms)`). The leading label (`ap_loop`, `self_improve`, or `grow_project`) reflects which tool armed the loop, so a `self_improve`-armed run shows `🔁 self_improve iter 4/20` and a `grow_project`-armed run shows `🔁 grow_project iter 4/200`. The closing-line verb depends on the finish reason: ✅ *completed* (`completion_promise`), ⚠️ *ended* (`send_error`, `aborted`, `abort_promise`, `stagnation` — the four reasons that map to `type=abort` in the terminal event, so the marker matches the red badge in the TUI), and ⏹ *stopped* for the neutral exits (`max_iterations`, `max_tokens`, `user_stopped`, `detached`).
+- An `additionalContext` injection on the *next* `onUserPromptSubmitted` hook so the agent silently learns the loop finished and why (`[ap_loop just finished — iterations=4, reason=completion_promise, durationMs=12345]`, or `[self_improve just finished — …]` / `[grow_project just finished — …]` when armed via the corresponding tool).
 
 The full structured result (available via `controller.state.lastResult` for embedders):
 
@@ -161,12 +161,12 @@ The full structured result (available via `controller.state.lastResult` for embe
 {
   reason: "completion_promise",
   iterations: 4,
-  label: "ralph_loop",                 // "ralph_loop", "self_improve", or "grow_project" — which tool armed the loop
+  label: "ap_loop",                 // "ap_loop", "self_improve", or "grow_project" — which tool armed the loop
   preview: "first 500 chars of last assistant content…",
   startedAt: 1719000000000,
   finishedAt: 1719000012345,
   durationMs: 12345,                  // active runtime — wall-clock from arming MINUS total paused time (issue #3)
-  note: "user changed plan",          // present when set via ralph_stop or on send_error / abort with reason
+  note: "user changed plan",          // present when set via ap_stop or on send_error / abort with reason
   tokens: {                            // present only when usage events were observed (issue #7)
     input: 12500,
     output: 1800,
@@ -198,7 +198,7 @@ The loop tracks per-iteration token usage from the SDK's `assistant.message` eve
 
 ### Self-improve (`self_improve` tool)
 
-`self_improve` is a thin wrapper that arms `ralph_loop` with a baked-in, **project-agnostic SDLC** prompt. Use it on **any repo** to drive an autonomous improvement loop without writing the prompt yourself:
+`self_improve` is a thin wrapper that arms `ap_loop` with a baked-in, **project-agnostic SDLC** prompt. Use it on **any repo** to drive an autonomous improvement loop without writing the prompt yourself:
 
 > *"Use self_improve to keep improving this project for 100 iterations."*
 
@@ -210,12 +210,12 @@ Each iteration walks the agent through nine stages: **ORIENT** (read recent comm
 | `min_iterations` | `5` | Honors completion / abort phrases only after N iterations. The default is automatically clamped down to `max_iterations` when `max_iterations < 5` (so `self_improve({max_iterations: 3})` runs 3 iters, not a confusing rejection); an explicitly-supplied `min_iterations > max_iterations` is still rejected loudly. |
 | `focus` | _(none)_ | Optional ≤2000-char string. Appended verbatim as `Focus this run on: <focus>` after the SDLC scaffolding — narrows the run to one area without altering the SDLC stages. |
 | `completion_promise` | `"COMPLETE"` | Substring → stop. Trimmed; max 200 chars. |
-| `abort_promise` | _(none)_ | Substring → early abort. Same disjoint-substring rule as `ralph_loop`. |
-| `stagnation_limit` | `3` | Same rules as `ralph_loop` (≥ 2 or `0` to disable; `1` is rejected). |
+| `abort_promise` | _(none)_ | Substring → early abort. Same disjoint-substring rule as `ap_loop`. |
+| `stagnation_limit` | `3` | Same rules as `ap_loop` (≥ 2 or `0` to disable; `1` is rejected). |
 
-`self_improve` reuses the same internal state machine as `ralph_loop` — the same `controller.state.active` shape, the same `finish()` pipeline, the same timeline log line (just with `self_improve` as the label), and the same `additionalContext` post-loop hook. Only one loop runs per session at a time, so a `self_improve` while a `ralph_loop` (or `grow_project`) is active fails fast (and vice versa). Cancel with `ralph_stop` exactly as you would for any `ralph_loop`.
+`self_improve` reuses the same internal state machine as `ap_loop` — the same `controller.state.active` shape, the same `finish()` pipeline, the same timeline log line (just with `self_improve` as the label), and the same `additionalContext` post-loop hook. Only one loop runs per session at a time, so a `self_improve` while a `ap_loop` (or `grow_project`) is active fails fast (and vice versa). Cancel with `ap_stop` exactly as you would for any `ap_loop`.
 
-> ⚠️ **The baked SDLC prompt instructs the agent to emit `COMPLETE` at the end of every iteration.** That means `completion_promise` would fire on iter 1 if `min_iterations` allowed it. The default `min_iterations: 5` defers honoring `COMPLETE` until iter 5 (so a 100-iter call usually stops there). To run the full budget, set `min_iterations` equal to `max_iterations` — e.g. `self_improve({ max_iterations: 100, min_iterations: 100 })`. Use `ralph_stop` to tear down a long-running session early.
+> ⚠️ **The baked SDLC prompt instructs the agent to emit `COMPLETE` at the end of every iteration.** That means `completion_promise` would fire on iter 1 if `min_iterations` allowed it. The default `min_iterations: 5` defers honoring `COMPLETE` until iter 5 (so a 100-iter call usually stops there). To run the full budget, set `min_iterations` equal to `max_iterations` — e.g. `self_improve({ max_iterations: 100, min_iterations: 100 })`. Use `ap_stop` to tear down a long-running session early.
 
 ### Grow-project (`grow_project` tool)
 
@@ -231,18 +231,18 @@ Each iteration walks the agent through thirteen stages: **ORIENT** (`gh issue li
 | `min_iterations` | `10` | Honors completion / abort phrases only after N iterations. Drains a baseline portion of the backlog before honoring early `ABORT_NO_BACKLOG`. The default is automatically clamped down to `max_iterations` when `max_iterations < 10`; an explicitly-supplied `min_iterations > max_iterations` is still rejected loudly. |
 | `focus` | _(none)_ | Optional ≤2000-char string. Appended verbatim as `Focus this run on: <focus>` after the SDLC scaffolding — narrows the backlog ideation/selection to one area without altering the SDLC stages. |
 | `completion_promise` | `"COMPLETE"` | Substring → stop. Trimmed; max 200 chars. |
-| `abort_promise` | `"ABORT_NO_BACKLOG"` | Substring → early abort (signaled by the agent when no proposed issue is ready). Same disjoint-substring rule as `ralph_loop`. |
-| `stagnation_limit` | `3` | Same rules as `ralph_loop` (≥ 2 or `0` to disable; `1` is rejected). |
+| `abort_promise` | `"ABORT_NO_BACKLOG"` | Substring → early abort (signaled by the agent when no proposed issue is ready). Same disjoint-substring rule as `ap_loop`. |
+| `stagnation_limit` | `3` | Same rules as `ap_loop` (≥ 2 or `0` to disable; `1` is rejected). |
 
-`grow_project` reuses the same internal state machine as `ralph_loop` and `self_improve` — the same `controller.state.active` shape, the same `finish()` pipeline, the same timeline log line (just with `grow_project` as the label), and the same `additionalContext` post-loop hook. **Only one loop runs per session at a time**, so calling `grow_project` while a `ralph_loop` or `self_improve` is active fails fast (and vice versa). Cancel with `ralph_stop` exactly as you would for any `ralph_loop`.
+`grow_project` reuses the same internal state machine as `ap_loop` and `self_improve` — the same `controller.state.active` shape, the same `finish()` pipeline, the same timeline log line (just with `grow_project` as the label), and the same `additionalContext` post-loop hook. **Only one loop runs per session at a time**, so calling `grow_project` while a `ap_loop` or `self_improve` is active fails fast (and vice versa). Cancel with `ap_stop` exactly as you would for any `ap_loop`.
 
 > ⚠️ **The baked prompt drives `gh` CLI calls.** Make sure the agent has a working `gh auth status` before arming `grow_project` — without auth, the very first `gh issue list` call fails and the agent will burn iterations trying to recover. Run `gh auth login` once per repo / once per machine. The `grow-project` and `proposed` labels do not need to exist beforehand; `gh issue create --label X` will refuse on first use, but the agent is instructed to create them with `gh label create grow-project` / `gh label create proposed` on the first iter.
 
-> ⚠️ **The baked prompt instructs the agent to emit `COMPLETE` at the end of every iteration and `ABORT_NO_BACKLOG` when the backlog is exhausted.** As with `self_improve`, `completion_promise` would fire on iter 1 if `min_iterations` allowed it; the default `min_iterations: 10` defers honoring `COMPLETE` until iter 10. Set `min_iterations` equal to `max_iterations` to drain the full budget. Use `ralph_stop` to tear down a long-running session early.
+> ⚠️ **The baked prompt instructs the agent to emit `COMPLETE` at the end of every iteration and `ABORT_NO_BACKLOG` when the backlog is exhausted.** As with `self_improve`, `completion_promise` would fire on iter 1 if `min_iterations` allowed it; the default `min_iterations: 10` defers honoring `COMPLETE` until iter 10. Set `min_iterations` equal to `max_iterations` to drain the full budget. Use `ap_stop` to tear down a long-running session early.
 
 ### Out-of-session driver (`ralph-tui run`)
 
-The in-session loop tools (`ralph_loop` / `self_improve` / `grow_project`) reuse the same Copilot CLI session across every iteration, so context grows monotonically — useful when each iter builds on the last, but it caps the practical iteration count and the Copilot SDK exposes no session-history reset to extension code, so a "clean context per iter" mode is not possible from inside the tool surface.
+The in-session loop tools (`ap_loop` / `self_improve` / `grow_project`) reuse the same Copilot CLI session across every iteration, so context grows monotonically — useful when each iter builds on the last, but it caps the practical iteration count and the Copilot SDK exposes no session-history reset to extension code, so a "clean context per iter" mode is not possible from inside the tool surface.
 
 The `ralph-tui run` subcommand is the **out-of-session** alternative: it spawns each iteration as a fresh `copilot -p "<prompt>" --allow-all-tools --output-format json` subprocess and gives you both shapes:
 
@@ -251,7 +251,7 @@ The `ralph-tui run` subcommand is the **out-of-session** alternative: it spawns 
 ralph-tui run --self-improve --fresh --max 50
 
 # Drain the backlog while the conversation history grows across iters
-# (closer to the in-session ralph_loop shape, but with a TTY-free driver).
+# (closer to the in-session ap_loop shape, but with a TTY-free driver).
 ralph-tui run --self-improve --continue --max 50
 
 # Grow the project backlog with a focus area, fresh context per iter.
@@ -291,12 +291,12 @@ Contributor and design docs live under [`docs/`](docs/) so this README can stay 
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — design notes on the `session.idle` event-driven loop, the `extension.mjs`/`handler.mjs` split, the baked-prompt pattern, and the tool surface.
 - [`docs/RELEASING.md`](docs/RELEASING.md) — manual release checklist for tagged GitHub Releases.
 - [`SECURITY.md`](SECURITY.md) — how to report a vulnerability and the supported-versions policy.
-## Inspecting a running loop (`ralph_status` tool)
+## Inspecting a running loop (`ap_status` tool)
 
-`ralph_status` returns a structured live snapshot of the active loop — iteration count, elapsed time, configured promises, pause state, live token usage, last response excerpt, and (when running inside a git repo) the files touched since the loop was armed. It's read-only and cheap (typically <10ms), so call it as often as you like.
+`ap_status` returns a structured live snapshot of the active loop — iteration count, elapsed time, configured promises, pause state, live token usage, last response excerpt, and (when running inside a git repo) the files touched since the loop was armed. It's read-only and cheap (typically <10ms), so call it as often as you like.
 
 ```bash
-> ralph_status
+> ap_status
 ```
 
 Sample structured payload (`status` key on the tool result):
@@ -347,20 +347,20 @@ Sample structured payload (`status` key on the tool result):
 }
 ```
 
-When no loop is active, `ralph_status` returns `{ active: false }` plus a `last` summary of the most recent run in this session (label, reason, iteration count, duration, and preview), or just `{ active: false }` if no loop has run yet.
+When no loop is active, `ap_status` returns `{ active: false }` plus a `last` summary of the most recent run in this session (label, reason, iteration count, duration, and preview), or just `{ active: false }` if no loop has run yet.
 
 Behaviour notes:
 
 - **Read-only.** Never mutates loop state — calling it during a loop never advances iterations, resets stagnation, or moves any timer.
-- **`elapsed_ms` is wall-clock.** Counted from arm-time to "now" and includes pause time — so a loop paused for 60 seconds reports `elapsed_ms` 60_000 ms higher than its active-time peer would. Subtract `total_paused_ms` (and `paused_for_ms` if currently paused) from the structured snapshot if you need active-only time. The one-line `textResultForLlm` summary uses the same wall-clock value, mirroring the [`ralph_status` summary contract documented in concepts.md](./docs/concepts.md#ralph_status-one-line-summary).
-- **Pause visibility.** When `ralph_pause` has parked the loop, `paused` is `true`, `pause_reason` echoes whatever was passed (truncated to a preview length), `paused_at` is the ISO timestamp the pause took effect, `paused_for_ms` is the *current* pause duration (always 0 when not paused), and `total_paused_ms` is the cumulative time spent paused across prior pause/resume cycles in this run. The one-line `textResultForLlm` summary appends `(PAUSED — <reason>, for <ms>ms)` when a reason was supplied, or the bare `(PAUSED, for <ms>ms)` (no em-dash, no reason slot) when `ralph_pause` was called without one — see the [summary contract in concepts.md](./docs/concepts.md#ralph_status-one-line-summary) for the canonical grammar — so a model reading the result without introspecting the JSON still sees the pause.
+- **`elapsed_ms` is wall-clock.** Counted from arm-time to "now" and includes pause time — so a loop paused for 60 seconds reports `elapsed_ms` 60_000 ms higher than its active-time peer would. Subtract `total_paused_ms` (and `paused_for_ms` if currently paused) from the structured snapshot if you need active-only time. The one-line `textResultForLlm` summary uses the same wall-clock value, mirroring the [`ap_status` summary contract documented in concepts.md](./docs/concepts.md#ap_status-one-line-summary).
+- **Pause visibility.** When `ap_pause` has parked the loop, `paused` is `true`, `pause_reason` echoes whatever was passed (truncated to a preview length), `paused_at` is the ISO timestamp the pause took effect, `paused_for_ms` is the *current* pause duration (always 0 when not paused), and `total_paused_ms` is the cumulative time spent paused across prior pause/resume cycles in this run. The one-line `textResultForLlm` summary appends `(PAUSED — <reason>, for <ms>ms)` when a reason was supplied, or the bare `(PAUSED, for <ms>ms)` (no em-dash, no reason slot) when `ap_pause` was called without one — see the [summary contract in concepts.md](./docs/concepts.md#ap_status-one-line-summary) for the canonical grammar — so a model reading the result without introspecting the JSON still sees the pause.
 - **Live token usage.** The `tokens` block surfaces cumulative `input`, `output`, and `total` token counts credited so far, plus the configured `max_tokens` cap (or `null` when no cap was armed). Counts start at 0 and accumulate from every `assistant.message` event observed during the loop; while the loop is paused, no tokens are credited (matching the pause/resume isolation contract). Use this to monitor budget consumption mid-run without waiting for the terminal result. The one-line `textResultForLlm` summary appends `, tokens X/Y` when `max_tokens` is armed (omitted otherwise) so a model reading the result without introspecting the JSON still sees budget pressure.
 - **Files-changed window.** Computed by diffing the current working tree (`git status --porcelain`) plus `git diff --name-status` against the HEAD captured at arm-time. Untracked files surface in `added`. Outside a git repo the entire `git` block is `null` and `files_changed` is omitted.
 - **No external API calls.** Only synchronous local `git` invocations with a 2-second timeout each; if any individual call fails, the corresponding field is `null` and the rest of the snapshot still returns.
 
 ## Adaptive iteration budget
 
-By default, `ralph_loop` (and `self_improve`, `grow_project`) hard-stops at `max_iterations`. Sometimes the loop is genuinely making progress at the terminator and a flat cap aborts useful work. Issue [#4](https://github.com/kloba/copilot-ralph-extension/issues/4) adds an opt-in **adaptive budget**: when the loop hits `max_iterations`, the controller checks two cheap signals — and if either is positive, grants `adaptive_extension` more iterations (capped by `adaptive_max_total`).
+By default, `ap_loop` (and `self_improve`, `grow_project`) hard-stops at `max_iterations`. Sometimes the loop is genuinely making progress at the terminator and a flat cap aborts useful work. Issue [#4](https://github.com/kloba/copilot-ralph-extension/issues/4) adds an opt-in **adaptive budget**: when the loop hits `max_iterations`, the controller checks two cheap signals — and if either is positive, grants `adaptive_extension` more iterations (capped by `adaptive_max_total`).
 
 Signals (positive ⇒ extend):
 
@@ -370,7 +370,7 @@ Signals (positive ⇒ extend):
 Stagnation, `completion_promise`, and `abort_promise` always win over the adaptive extension. The hard ceiling `adaptive_max_total` is never crossed.
 
 ```js
-ralph_loop({
+ap_loop({
   prompt: "Fix the failing build, run tests, commit. Emit COMPLETE when green.",
   max_iterations: 20,
   adaptive_budget: true,
@@ -382,21 +382,21 @@ ralph_loop({
 Each granted extension is logged (`adaptive budget extended N → M (reason: …)`) and surfaced on the loop's final `RalphResult` as `result.adaptive = { enabled, originalMax, effectiveMax, extensions, history }`.
 ## Pause and resume
 
-Long autonomous runs sometimes need a manual checkpoint — to read a diff, run tests by hand, fix something, then continue. `ralph_pause` and `ralph_resume` (issue [#3](https://github.com/kloba/copilot-ralph-extension/issues/3)) let you do that without losing iteration count or conversation context:
+Long autonomous runs sometimes need a manual checkpoint — to read a diff, run tests by hand, fix something, then continue. `ap_pause` and `ap_resume` (issue [#3](https://github.com/kloba/copilot-ralph-extension/issues/3)) let you do that without losing iteration count or conversation context:
 
 ```js
-ralph_pause({ reason: "manual review of the refactor" });
+ap_pause({ reason: "manual review of the refactor" });
 // …chat freely with the agent. Those turns do NOT count toward max_iterations.
-ralph_resume();
+ap_resume();
 ```
 
-- The currently-running iteration finishes normally; subsequent `session.idle` events are short-circuited until `ralph_resume`.
+- The currently-running iteration finishes normally; subsequent `session.idle` events are short-circuited until `ap_resume`.
 - Iteration counter, prompt, and full conversation context are preserved across the pause.
-- **Pause-time chat is isolated from loop bookkeeping.** Tokens consumed during your pause-time conversation are not credited to the loop's budget (so a long chat cannot spuriously trip a configured `max_tokens` cap on resume), and your pause-time messages are not inspected for the configured `completion_promise` / `abort_promise` triggers (so a casual mention of the phrase will not terminate the loop). See [Concepts → Pause / resume semantics](./docs/concepts.md#pause--resume-semantics) for the full contract and the trade-off (an in-flight iter completion signal that landed right before pause is forfeited; you can still inspect it via `ralph_status.last_response_excerpt`).
-- `ralph_resume` resets the stagnation streak (manual intervention almost always changes context, so a post-resume identical-to-pre-pause turn must NOT be misclassified as stuck).
-- `ralph_pause` is idempotent: pausing an already-paused loop is a no-op success. **First reason wins** — a second `ralph_pause({reason: "newer"})` against an already-paused loop returns the FIRST reason in both the success payload (`reason` field) and the rendered `textResultForLlm` (`<label> already paused at i/max (firstReason).`). Automation polling pause state will not see its own input echoed back.
-- `ralph_stop` works while paused and terminates the loop.
-- `ralph_resume` on a non-paused loop is a failure (use `ralph_pause` first).
+- **Pause-time chat is isolated from loop bookkeeping.** Tokens consumed during your pause-time conversation are not credited to the loop's budget (so a long chat cannot spuriously trip a configured `max_tokens` cap on resume), and your pause-time messages are not inspected for the configured `completion_promise` / `abort_promise` triggers (so a casual mention of the phrase will not terminate the loop). See [Concepts → Pause / resume semantics](./docs/concepts.md#pause--resume-semantics) for the full contract and the trade-off (an in-flight iter completion signal that landed right before pause is forfeited; you can still inspect it via `ap_status.last_response_excerpt`).
+- `ap_resume` resets the stagnation streak (manual intervention almost always changes context, so a post-resume identical-to-pre-pause turn must NOT be misclassified as stuck).
+- `ap_pause` is idempotent: pausing an already-paused loop is a no-op success. **First reason wins** — a second `ap_pause({reason: "newer"})` against an already-paused loop returns the FIRST reason in both the success payload (`reason` field) and the rendered `textResultForLlm` (`<label> already paused at i/max (firstReason).`). Automation polling pause state will not see its own input echoed back.
+- `ap_stop` works while paused and terminates the loop.
+- `ap_resume` on a non-paused loop is a failure (use `ap_pause` first).
 
 ## How it works
 
@@ -406,7 +406,7 @@ import { createRalphController } from "./handler.mjs";
 
 const controller = createRalphController();
 const session = await joinSession({
-    tools: controller.tools,   // ralph_loop + ralph_stop + ralph_status + ralph_pause + ralph_resume + self_improve + grow_project
+    tools: controller.tools,   // ap_loop + ap_stop + ap_status + ap_pause + ap_resume + self_improve + grow_project
     hooks: controller.hooks,   // onUserPromptSubmitted carries the result forward
 });
 const detach = controller.attach(session);    // wires session.idle / assistant.message / abort listeners
@@ -415,7 +415,7 @@ const detach = controller.attach(session);    // wires session.idle / assistant.
 
 ### Arming
 
-`ralph_loop(...)` returns immediately with `{ armed: true }`. It does **not** loop synchronously. The validated arguments (`prompt`, `max`, `min`, `completionPromise`, `abortPromise`, `stagnationLimit`) are stored on `controller.state.active`; the loop is now driven entirely by SDK events.
+`ap_loop(...)` returns immediately with `{ armed: true }`. It does **not** loop synchronously. The validated arguments (`prompt`, `max`, `min`, `completionPromise`, `abortPromise`, `stagnationLimit`) are stored on `controller.state.active`; the loop is now driven entirely by SDK events.
 
 ### Iterations are driven by events, not by a hook
 
@@ -424,7 +424,7 @@ const detach = controller.attach(session);    // wires session.idle / assistant.
 | Event | Role |
 |---|---|
 | `assistant.message` | Accumulates the current turn's content into `state.lastAssistantContent` (capped at 1 MiB; tail preserved so completion phrases near the end aren't lost). |
-| `session.idle` | The heartbeat. The first idle after arming is the turn that *called* `ralph_loop` — that fires iteration 1's prompt. Each subsequent idle runs the decision ladder: completion → abort → stagnation → max → otherwise re-fire. |
+| `session.idle` | The heartbeat. The first idle after arming is the turn that *called* `ap_loop` — that fires iteration 1's prompt. Each subsequent idle runs the decision ladder: completion → abort → stagnation → max → otherwise re-fire. |
 | `abort` | Finalizes the loop with `reason: "aborted"` (and `note` if the SDK supplies a reason). |
 
 Re-firing means calling `session.send({ prompt })` and not awaiting the response synchronously — the next iteration is driven by the next `session.idle`. The returned promise *is* still observed for rejection: an async send-failure finishes the loop with `reason: "send_error"` rather than silently dropping the iteration. Each call **enqueues a new user-turn** in the live conversation, which is why every iteration shows up in the timeline as a real user prompt followed by a real assistant turn (not some hidden background invocation).
@@ -458,16 +458,16 @@ The SDK emits one `session.idle` per *root-level* agentic loop completion — no
 `onUserPromptSubmitted` is the only hook the extension registers. It does **not** drive iterations. It runs on the *next* user prompt after the loop has finished and injects a single `additionalContext` line so the agent silently learns the outcome:
 
 ```text
-[ralph_loop just finished — iterations=4, reason=completion_promise, durationMs=12345]
+[ap_loop just finished — iterations=4, reason=completion_promise, durationMs=12345]
 ```
 
 This mirrors how Anthropic's Claude Code `ralph-wiggum` plugin uses the `Stop` hook to re-prompt — same architectural shape, just expressed via the Copilot CLI extension SDK.
 
-If you arm a new `ralph_loop` *before* the next user prompt fires, the prior run's result is wiped during arming — the post-loop context from the previous run will **not** leak into the new loop's first prompt.
+If you arm a new `ap_loop` *before* the next user prompt fires, the prior run's result is wiped during arming — the post-loop context from the previous run will **not** leak into the new loop's first prompt.
 
 ## Commit attribution
 
-The baked `self_improve` and `grow_project` SDLC prompts instruct the agent to add `Co-authored-by:` trailers to every commit so loop-driven changes are attributable. `ralph_loop` reaches parity by appending a small commit-attribution rider to the user-supplied prompt at arm time — so any commit produced during a `ralph_loop` iteration carries the same dual trailer. By default, every loop-driven commit ships **two** trailers (per [issue #1](https://github.com/kloba/copilot-ralph-extension/issues/1)):
+The baked `self_improve` and `grow_project` SDLC prompts instruct the agent to add `Co-authored-by:` trailers to every commit so loop-driven changes are attributable. `ap_loop` reaches parity by appending a small commit-attribution rider to the user-supplied prompt at arm time — so any commit produced during a `ap_loop` iteration carries the same dual trailer. By default, every loop-driven commit ships **two** trailers (per [issue #1](https://github.com/kloba/copilot-ralph-extension/issues/1)):
 
 ```
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
@@ -478,10 +478,10 @@ The first identifies the agent. The second attributes the commit to a dedicated 
 
 ### Opt-out
 
-Set `RALPH_NO_ATTRIBUTION=1` in the environment before arming the loop to suppress the second `copilot-ralph` trailer. The first `Copilot` trailer still ships, since it identifies the agent that made the change. The opt-out is **honored by the prompt** (baked SDLC prompt for `self_improve` / `grow_project`; appended rider for `ralph_loop`), not by the extension code path — the agent reads the env var during the COMMIT stage and omits the trailer accordingly.
+Set `RALPH_NO_ATTRIBUTION=1` in the environment before arming the loop to suppress the second `copilot-ralph` trailer. The first `Copilot` trailer still ships, since it identifies the agent that made the change. The opt-out is **honored by the prompt** (baked SDLC prompt for `self_improve` / `grow_project`; appended rider for `ap_loop`), not by the extension code path — the agent reads the env var during the COMMIT stage and omits the trailer accordingly.
 
 ```bash
-RALPH_NO_ATTRIBUTION=1 copilot   # subsequent ralph_loop / self_improve / grow_project loops omit the copilot-ralph trailer
+RALPH_NO_ATTRIBUTION=1 copilot   # subsequent ap_loop / self_improve / grow_project loops omit the copilot-ralph trailer
 ```
 
 ### Caveats
@@ -492,7 +492,7 @@ RALPH_NO_ATTRIBUTION=1 copilot   # subsequent ralph_loop / self_improve / grow_p
 
 ## Keep system awake (`caffeinate`, macOS)
 
-Long `ralph_loop` / `self_improve` / `grow_project` runs can outlast macOS's idle-sleep timeout, which interrupts in-flight tool calls and timers. Opt in to a `caffeinate`-backed sleep block for the duration of the loop:
+Long `ap_loop` / `self_improve` / `grow_project` runs can outlast macOS's idle-sleep timeout, which interrupts in-flight tool calls and timers. Opt in to a `caffeinate`-backed sleep block for the duration of the loop:
 
 ```bash
 RALPH_CAFFEINATE=1 copilot                                # block idle sleep only (default)
@@ -507,7 +507,7 @@ RALPH_CAFFEINATE=1 RALPH_CAFFEINATE_SCOPE=idle+display copilot   # also keep the
 Behaviour:
 
 - Spawns `caffeinate -i [-d] -w <pid>` on arm, where `<pid>` is the host CLI process. Logs a single line: `keeping system awake via caffeinate (pid=…, scope=…)`.
-- Killed automatically on loop completion, `ralph_stop`, abort, or detach. The `-w` flag is a belt-and-braces fallback so a hard crash of the CLI still releases the wake-lock.
+- Killed automatically on loop completion, `ap_stop`, abort, or detach. The `-w` flag is a belt-and-braces fallback so a hard crash of the CLI still releases the wake-lock.
 - **macOS only.** On Linux/Windows the helper is a silent no-op (a single log line records the skip). Future PRs may add `systemd-inhibit` / `SetThreadExecutionState` equivalents.
 - **Graceful when the binary is missing.** If `caffeinate` isn't on `PATH` or `spawn` fails, the loop runs without sleep prevention and logs the failure — it never aborts the loop over a power-management nicety.
 - **Disabled by default.** The extension does not modify system power state unless you set `RALPH_CAFFEINATE`.
@@ -515,7 +515,7 @@ Behaviour:
 ## Troubleshooting
 
 - **`/extensions` doesn't list `ralph`.** Confirm every `.mjs` from `extension/` (currently `extension.mjs`, `handler.mjs`, and `events-emit.mjs`) is present in `~/.copilot/extensions/ralph/` (user-scoped) or `.github/extensions/ralph/` (project-scoped, only visible from inside that repo) and restart Copilot CLI. `./install.sh` from source double-checks every file with `node --check` before writing, and a partial copy (e.g. only the first two modules) crashes at module-load with `Cannot find module './events-emit.mjs'`.
-- **`<owner> is already armed/running` failure.** Only one loop runs per session at a time — call `ralph_stop` before re-arming. The leading word (`ralph_loop`, `self_improve`, or `grow_project`) reflects whichever tool armed the active loop, so the guard fires on any of the three when one of the others is active.
+- **`<owner> is already armed/running` failure.** Only one loop runs per session at a time — call `ap_stop` before re-arming. The leading word (`ap_loop`, `self_improve`, or `grow_project`) reflects whichever tool armed the active loop, so the guard fires on any of the three when one of the others is active.
 - **`abort_promise … overlap as substrings`.** `completion_promise` and `abort_promise` must be disjoint phrases (e.g. `"DONE"` and `"DONE_FAIL"` is rejected because one contains the other). Pick non-overlapping tokens.
 - **Loop ends immediately with `reason: send_error`.** The first `session.send` call rejected — usually because `controller.attach(session)` was not called or the session is no longer live. Check `result.note` for the underlying error.
 - **Loop runs N+ times instead of stopping.** Check that the prompt actually instructs the agent to emit the `completion_promise` literally; with a quoted/paraphrased completion phrase the loop only stops at `max_iterations`.
@@ -525,12 +525,12 @@ Behaviour:
 
 - **Substring-match completion can self-trigger.** Both `completion_promise` and `abort_promise` use plain substring matching against the assistant's accumulated turn output. If the agent quotes the trigger phrase mid-thought (e.g. *"I'll mark this COMPLETE when done"*), the loop will finish on that turn. Pick a phrase the agent is unlikely to mention casually; emoji or unusual tokens (e.g. `RALPH_DONE_42`) work well.
 - **Multi-message turns join with newlines.** When the SDK emits multiple `assistant.message` events within a single turn, Ralph concatenates them with `\n`. A trigger phrase that lands *split* exactly across the boundary (e.g. one message ends with `"DO"` and the next starts with `"NE"` while looking for `"DONE"`) becomes `"DO\nNE"` and won't match. In practice the SDK emits whole responses or large multi-paragraph chunks, so this rarely bites — but choose phrases that won't realistically straddle a chunk boundary.
-- **Prompt is re-injected verbatim every iteration.** The loop has no concept of progress — the agent must derive what's already done from its own conversation history. This is intentional (it matches the Anthropic plugin) but means a vague prompt yields vague iteration. Note: `ralph_loop` augments the user-supplied prompt once at arm time with a small commit-attribution rider (see [Commit attribution](#commit-attribution)); after that augmentation, the same composed prompt is what gets re-injected verbatim each iteration.
+- **Prompt is re-injected verbatim every iteration.** The loop has no concept of progress — the agent must derive what's already done from its own conversation history. This is intentional (it matches the Anthropic plugin) but means a vague prompt yields vague iteration. Note: `ap_loop` augments the user-supplied prompt once at arm time with a small commit-attribution rider (see [Commit attribution](#commit-attribution)); after that augmentation, the same composed prompt is what gets re-injected verbatim each iteration.
 - **Stagnation always overrides `min_iterations`.** Identical responses fire stagnation regardless of `min_iterations` — this is a safety floor, not a configurable behavior.
-- **Iteration timing is loop-arm-relative and pause-deducted.** The `(elapsed Xms)` value in iter logs is wall-clock from arming. The final `durationMs` on the result is **active time** — wall-clock from arming minus `total_paused_ms` (cumulative time the loop spent paused via `ralph_pause`), so a loop paused for an hour and then run for five minutes reports `durationMs ≈ 5 min`, not `≈ 65 min`. Per-turn timing isn't tracked. See [Pause and resume](#pause-and-resume) for the pause semantics.
-- **One loop per session.** Arming a second `ralph_loop` (or a `self_improve`, or a `grow_project`) while one is active fails fast — you must `ralph_stop` the active loop first. The guard applies symmetrically across all three tools: a `ralph_loop` while `self_improve` or `grow_project` is active is also rejected, and vice versa.
-- **`self_improve` keeps re-iterating with no commits.** The baked SDLC prompt instructs the agent to emit `COMPLETE` when the staircase is done. Until that token appears in an iteration, the loop runs to `max_iterations`. To stop early, either `ralph_stop` it manually or prepend a tighter `focus` so each iteration converges faster.
-- **Attribution opt-out is honored by the prompt, not enforced by the runtime.** [`RALPH_NO_ATTRIBUTION=1`](#opt-out) suppresses the second `copilot-ralph` `Co-authored-by:` trailer only because the prompt instructs the agent to read the env var during the COMMIT stage and omit the trailer (baked into `self_improve` / `grow_project` SDLC prompts; appended as a rider to user prompts on `ralph_loop`). The extension does not rewrite commits — if a sub-agent ignores the env var (or runs in a context where `process.env` isn't visible), the trailer can still ship. Audit a commit afterwards with `git log -1 --pretty=%B` if attribution must be guaranteed off.
+- **Iteration timing is loop-arm-relative and pause-deducted.** The `(elapsed Xms)` value in iter logs is wall-clock from arming. The final `durationMs` on the result is **active time** — wall-clock from arming minus `total_paused_ms` (cumulative time the loop spent paused via `ap_pause`), so a loop paused for an hour and then run for five minutes reports `durationMs ≈ 5 min`, not `≈ 65 min`. Per-turn timing isn't tracked. See [Pause and resume](#pause-and-resume) for the pause semantics.
+- **One loop per session.** Arming a second `ap_loop` (or a `self_improve`, or a `grow_project`) while one is active fails fast — you must `ap_stop` the active loop first. The guard applies symmetrically across all three tools: a `ap_loop` while `self_improve` or `grow_project` is active is also rejected, and vice versa.
+- **`self_improve` keeps re-iterating with no commits.** The baked SDLC prompt instructs the agent to emit `COMPLETE` when the staircase is done. Until that token appears in an iteration, the loop runs to `max_iterations`. To stop early, either `ap_stop` it manually or prepend a tighter `focus` so each iteration converges faster.
+- **Attribution opt-out is honored by the prompt, not enforced by the runtime.** [`RALPH_NO_ATTRIBUTION=1`](#opt-out) suppresses the second `copilot-ralph` `Co-authored-by:` trailer only because the prompt instructs the agent to read the env var during the COMMIT stage and omit the trailer (baked into `self_improve` / `grow_project` SDLC prompts; appended as a rider to user prompts on `ap_loop`). The extension does not rewrite commits — if a sub-agent ignores the env var (or runs in a context where `process.env` isn't visible), the trailer can still ship. Audit a commit afterwards with `git log -1 --pretty=%B` if attribution must be guaranteed off.
 
 ## Requirements
 
@@ -538,7 +538,7 @@ Behaviour:
 - Copilot CLI Extension SDK (`@github/copilot-sdk/extension`) — bundled with Copilot CLI
 - Node.js ≥ 20 (only required for running the test suite; the installed extension uses the Node runtime bundled with Copilot CLI)
 - No runtime npm dependencies. Tests use `node:test` (built-in); run them with `npm test`.
-- **`gh` CLI** (≥ 2.0) authenticated via `gh auth login` — *only* required when arming `grow_project`. The baked SDLC prompt drives `gh issue list/create/edit/close` calls every iteration; without auth, the very first call fails and the agent burns iterations trying to recover. `ralph_loop` and `self_improve` do not invoke `gh` and have no such requirement.
+- **`gh` CLI** (≥ 2.0) authenticated via `gh auth login` — *only* required when arming `grow_project`. The baked SDLC prompt drives `gh issue list/create/edit/close` calls every iteration; without auth, the very first call fails and the agent burns iterations trying to recover. `ap_loop` and `self_improve` do not invoke `gh` and have no such requirement.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# copilot-ralph-extension
+# autopilot
 
 > Autonomous iterative loop for **GitHub Copilot CLI**, implemented as an in-session extension.
 
-[![CI](https://github.com/kloba/copilot-ralph-extension/actions/workflows/ci.yml/badge.svg)](https://github.com/kloba/copilot-ralph-extension/actions/workflows/ci.yml)
+[![CI](https://github.com/kloba/autopilot/actions/workflows/ci.yml/badge.svg)](https://github.com/kloba/autopilot/actions/workflows/ci.yml)
 [![Inspired by](https://img.shields.io/badge/inspired_by-Anthropic_Ralph_Wiggum-blue)](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum)
 
 **Contents:** [What is Ralph?](#what-is-ralph-wiggum) · [What's different](#whats-different-here) · [Install](#install) · [Usage](#usage) · [Development](#development) · [Documentation](#documentation) · [Self-improve](#self-improve-self_improve-tool) · [Grow-project](#grow-project-grow_project-tool) · [Inspecting a running loop](#inspecting-a-running-loop-ap_status-tool) · [Adaptive budget](#adaptive-iteration-budget) · [Pause/resume](#pause-and-resume) · [How it works](#how-it-works) · [Commit attribution](#commit-attribution) · [Keep system awake](#keep-system-awake-caffeinate-macos) · [Troubleshooting](#troubleshooting) · [Limitations](#limitations) · [Requirements](#requirements) · [Changelog](#changelog) · [License](#license)
@@ -31,13 +31,13 @@ If you want fresh-context iterations, use a shell-wrapper implementation. If you
 ### Option A — User-scoped (persists across all repos)
 
 ```bash
-mkdir -p ~/.copilot/extensions/ralph
+mkdir -p ~/.copilot/extensions/autopilot
 # Order matters: leaf modules first, entry point (extension.mjs) LAST.
 # If `/extensions reload` fires mid-download, this guarantees the SDK
 # never sees a new entry point importing missing/old siblings.
 for f in events-emit.mjs prompts.mjs handler.mjs extension.mjs; do
-  curl -fsSL "https://raw.githubusercontent.com/kloba/copilot-ralph-extension/main/extension/$f" \
-    -o ~/.copilot/extensions/ralph/$f
+  curl -fsSL "https://raw.githubusercontent.com/kloba/autopilot/main/extension/$f" \
+    -o ~/.copilot/extensions/autopilot/$f
 done
 ```
 
@@ -47,50 +47,52 @@ Then in any Copilot CLI session, run:
 /extensions
 ```
 
-…and confirm `ralph` is loaded. Or simply restart Copilot CLI.
+…and confirm `autopilot` is loaded. Or simply restart Copilot CLI.
 
 ### Option B — Project-scoped (only in one repo)
 
 ```bash
-mkdir -p .github/extensions/ralph
+mkdir -p .github/extensions/autopilot
 # Same leaf-first ordering as Option A — see comment there.
 for f in events-emit.mjs prompts.mjs handler.mjs extension.mjs; do
-  curl -fsSL "https://raw.githubusercontent.com/kloba/copilot-ralph-extension/main/extension/$f" \
-    -o .github/extensions/ralph/$f
+  curl -fsSL "https://raw.githubusercontent.com/kloba/autopilot/main/extension/$f" \
+    -o .github/extensions/autopilot/$f
 done
 ```
 
 ### Option C — From source
 
 ```bash
-git clone https://github.com/kloba/copilot-ralph-extension
-cd copilot-ralph-extension
-./install.sh                # user-scoped → ~/.copilot/extensions/ralph
-./install.sh --project      # project-scoped → .github/extensions/ralph (cwd must be inside a git repo)
+git clone https://github.com/kloba/autopilot
+cd autopilot
+./install.sh                # user-scoped → ~/.copilot/extensions/autopilot
+./install.sh --project      # project-scoped → .github/extensions/autopilot (cwd must be inside a git repo)
 ./install.sh --dry-run      # show what would be installed without writing anything
-./install.sh --version      # print the extension version (e.g. "copilot-ralph-extension v0.6.0") and exit
+./install.sh --version      # print the extension version (e.g. "autopilot v0.6.0") and exit
 ./install.sh --help         # print usage and exit
 ```
 
 `install.sh` syntax-checks each source file with `node --check` and writes via temp-file + atomic `mv`, so a concurrent Copilot CLI reload can never see a half-written `handler.mjs`.
 
-> **Windows note:** the runtime extension (`extension.mjs`, `handler.mjs`, and `events-emit.mjs`) is plain ESM and works wherever Copilot CLI runs. The `install.sh` script requires a Bash shell — on Windows use **WSL**, **Git Bash**, or **MSYS2**. As a fallback, follow Option A or B above (the `mkdir -p` + `curl` snippets) inside any POSIX-ish shell, or copy every `.mjs` file from `extension/` manually into `%USERPROFILE%\.copilot\extensions\ralph\`.
+> **Windows note:** the runtime extension (`extension.mjs`, `handler.mjs`, and `events-emit.mjs`) is plain ESM and works wherever Copilot CLI runs. The `install.sh` script requires a Bash shell — on Windows use **WSL**, **Git Bash**, or **MSYS2**. As a fallback, follow Option A or B above (the `mkdir -p` + `curl` snippets) inside any POSIX-ish shell, or copy every `.mjs` file from `extension/` manually into `%USERPROFILE%\.copilot\extensions\autopilot\`.
 
 ### Option D — Pin a specific tagged release
 
-The default install snippets curl from `main`, which is rolling-latest. To pin a specific revision (recommended for shared/CI environments), download the assets attached to a [GitHub Release](https://github.com/kloba/copilot-ralph-extension/releases):
+The default install snippets curl from `main`, which is rolling-latest. To pin a specific revision (recommended for shared/CI environments), download the assets attached to a [GitHub Release](https://github.com/kloba/autopilot/releases):
 
 ```bash
 VERSION=v0.7.0
-mkdir -p ~/.copilot/extensions/ralph
+mkdir -p ~/.copilot/extensions/autopilot
 # Same leaf-first ordering as Option A — see comment there.
 for f in events-emit.mjs prompts.mjs handler.mjs extension.mjs; do
-  curl -fsSL "https://github.com/kloba/copilot-ralph-extension/releases/download/$VERSION/$f" \
-    -o ~/.copilot/extensions/ralph/$f
+  curl -fsSL "https://github.com/kloba/autopilot/releases/download/$VERSION/$f" \
+    -o ~/.copilot/extensions/autopilot/$f
 done
 ```
 
-For a project-scoped pin, swap `~/.copilot/extensions/ralph` for `.github/extensions/ralph` inside your repo. See [`docs/RELEASING.md`](docs/RELEASING.md) for the release workflow that produces these assets.
+For a project-scoped pin, swap `~/.copilot/extensions/autopilot` for `.github/extensions/autopilot` inside your repo. See [`docs/RELEASING.md`](docs/RELEASING.md) for the release workflow that produces these assets.
+
+> Legacy `~/.copilot/ralph[ -tui]/runs` paths are still read on first run with a one-line stderr migration notice; new runs write to the autopilot* paths.
 
 ## Usage
 
@@ -112,7 +114,7 @@ The tool **arms** the loop and returns immediately. Iterations then play out as 
 | `stagnation_limit` | `3` | Abort after N consecutive byte-identical responses (0 disables, must be ≥ 2 if set — `1` is rejected since no comparison is possible after a single response) |
 | `max_tokens` | _(none)_ | Optional cumulative token cap (input + output combined). Loop stops with reason `max_tokens` when crossed at end of an iteration. Useful to bound spend on long-running self-improve / grow-project runs. |
 | `warn_at_pct` | `80` | First context-window warning threshold (percent of model's total window). A second hard-coded warning fires at 95%. Each fires at most once per loop run. |
-| `adaptive_budget` | `false` | Opt-in adaptive iteration budget (issue [#4](https://github.com/kloba/copilot-ralph-extension/issues/4)). When the loop reaches `max_iterations` and progress signals are positive (see [Adaptive iteration budget](#adaptive-iteration-budget) below), grants `adaptive_extension` more iterations, capped at `adaptive_max_total`. |
+| `adaptive_budget` | `false` | Opt-in adaptive iteration budget (issue [#4](https://github.com/kloba/autopilot/issues/4)). When the loop reaches `max_iterations` and progress signals are positive (see [Adaptive iteration budget](#adaptive-iteration-budget) below), grants `adaptive_extension` more iterations, capped at `adaptive_max_total`. |
 | `adaptive_extension` | `10` | Iterations granted per adaptive extension. Ignored when `adaptive_budget` is `false`. Integer, 1–1000. |
 | `adaptive_max_total` | `min(max_iterations*5, 1000)` | Hard ceiling for the effective max even after adaptive extensions. Must be ≥ `max_iterations` and ≤ 1000. |
 
@@ -240,36 +242,36 @@ Each iteration walks the agent through thirteen stages: **ORIENT** (`gh issue li
 
 > ⚠️ **The baked prompt instructs the agent to emit `COMPLETE` at the end of every iteration and `ABORT_NO_BACKLOG` when the backlog is exhausted.** As with `self_improve`, `completion_promise` would fire on iter 1 if `min_iterations` allowed it; the default `min_iterations: 10` defers honoring `COMPLETE` until iter 10. Set `min_iterations` equal to `max_iterations` to drain the full budget. Use `ap_stop` to tear down a long-running session early.
 
-### Out-of-session driver (`ralph-tui run`)
+### Out-of-session driver (`autopilot run`)
 
 The in-session loop tools (`ap_loop` / `self_improve` / `grow_project`) reuse the same Copilot CLI session across every iteration, so context grows monotonically — useful when each iter builds on the last, but it caps the practical iteration count and the Copilot SDK exposes no session-history reset to extension code, so a "clean context per iter" mode is not possible from inside the tool surface.
 
-The `ralph-tui run` subcommand is the **out-of-session** alternative: it spawns each iteration as a fresh `copilot -p "<prompt>" --allow-all-tools --output-format json` subprocess and gives you both shapes:
+The `autopilot run` subcommand is the **out-of-session** alternative: it spawns each iteration as a fresh `copilot -p "<prompt>" --allow-all-tools --output-format json` subprocess and gives you both shapes:
 
 ```bash
 # Drain the backlog with a fresh context every iter (no growing history).
-ralph-tui run --self-improve --fresh --max 50
+autopilot run --self-improve --fresh --max 50
 
 # Drain the backlog while the conversation history grows across iters
 # (closer to the in-session ap_loop shape, but with a TTY-free driver).
-ralph-tui run --self-improve --continue --max 50
+autopilot run --self-improve --continue --max 50
 
 # Grow the project backlog with a focus area, fresh context per iter.
-ralph-tui run --grow-project --fresh --focus "ralph-tui replay UX" --max 30
+autopilot run --grow-project --fresh --focus "autopilot replay UX" --max 30
 
 # Custom prompt mode.
-ralph-tui run --prompt "Refactor extension/handler.mjs..." --fresh
+autopilot run --prompt "Refactor extension/handler.mjs..." --fresh
 ```
 
-Pick exactly one prompt mode (`--self-improve` / `--grow-project` / `--prompt "..."`) AND exactly one context mode (`--continue` / `--fresh`). `--continue` captures the terminal `result.sessionId` from the JSONL stream on iter 1 and resumes via `--resume=<sessionId>` on iter 2+; `--fresh` re-spawns with no session reuse so every iteration starts from a clean slate. Events flow into the same `~/.copilot/ralph-tui/runs/<runId>/events.jsonl` stream the in-session runner uses, so `ralph-tui watch / replay / list / stats` all work unchanged.
+Pick exactly one prompt mode (`--self-improve` / `--grow-project` / `--prompt "..."`) AND exactly one context mode (`--continue` / `--fresh`). `--continue` captures the terminal `result.sessionId` from the JSONL stream on iter 1 and resumes via `--resume=<sessionId>` on iter 2+; `--fresh` re-spawns with no session reuse so every iteration starts from a clean slate. Events flow into the same `~/.copilot/autopilot-tui/runs/<runId>/events.jsonl` stream the in-session runner uses, so `autopilot watch / replay / list / stats` all work unchanged.
 
 Sibling commands operate on a live run's state file:
 
 ```bash
-ralph-tui run --pause   <runId>     # pause at next iter boundary
-ralph-tui run --resume  <runId>     # resume a paused run
-ralph-tui run --stop    <runId>     # request graceful stop
-ralph-tui run --status  <runId>     # snapshot of run state
+autopilot run --pause   <runId>     # pause at next iter boundary
+autopilot run --resume  <runId>     # resume a paused run
+autopilot run --stop    <runId>     # request graceful stop
+autopilot run --status  <runId>     # snapshot of run state
 ```
 
 `SIGINT` / `SIGTERM` at the driver process flips `stopRequested=true` via the same lock-protected CAS path; the in-flight child is allowed to exit naturally before the driver emits the terminal `abort` event with `reason: "user_stopped"`.
@@ -360,7 +362,7 @@ Behaviour notes:
 
 ## Adaptive iteration budget
 
-By default, `ap_loop` (and `self_improve`, `grow_project`) hard-stops at `max_iterations`. Sometimes the loop is genuinely making progress at the terminator and a flat cap aborts useful work. Issue [#4](https://github.com/kloba/copilot-ralph-extension/issues/4) adds an opt-in **adaptive budget**: when the loop hits `max_iterations`, the controller checks two cheap signals — and if either is positive, grants `adaptive_extension` more iterations (capped by `adaptive_max_total`).
+By default, `ap_loop` (and `self_improve`, `grow_project`) hard-stops at `max_iterations`. Sometimes the loop is genuinely making progress at the terminator and a flat cap aborts useful work. Issue [#4](https://github.com/kloba/autopilot/issues/4) adds an opt-in **adaptive budget**: when the loop hits `max_iterations`, the controller checks two cheap signals — and if either is positive, grants `adaptive_extension` more iterations (capped by `adaptive_max_total`).
 
 Signals (positive ⇒ extend):
 
@@ -382,7 +384,7 @@ ap_loop({
 Each granted extension is logged (`adaptive budget extended N → M (reason: …)`) and surfaced on the loop's final `RalphResult` as `result.adaptive = { enabled, originalMax, effectiveMax, extensions, history }`.
 ## Pause and resume
 
-Long autonomous runs sometimes need a manual checkpoint — to read a diff, run tests by hand, fix something, then continue. `ap_pause` and `ap_resume` (issue [#3](https://github.com/kloba/copilot-ralph-extension/issues/3)) let you do that without losing iteration count or conversation context:
+Long autonomous runs sometimes need a manual checkpoint — to read a diff, run tests by hand, fix something, then continue. `ap_pause` and `ap_resume` (issue [#3](https://github.com/kloba/autopilot/issues/3)) let you do that without losing iteration count or conversation context:
 
 ```js
 ap_pause({ reason: "manual review of the refactor" });
@@ -467,7 +469,7 @@ If you arm a new `ap_loop` *before* the next user prompt fires, the prior run's 
 
 ## Commit attribution
 
-The baked `self_improve` and `grow_project` SDLC prompts instruct the agent to add `Co-authored-by:` trailers to every commit so loop-driven changes are attributable. `ap_loop` reaches parity by appending a small commit-attribution rider to the user-supplied prompt at arm time — so any commit produced during a `ap_loop` iteration carries the same dual trailer. By default, every loop-driven commit ships **two** trailers (per [issue #1](https://github.com/kloba/copilot-ralph-extension/issues/1)):
+The baked `self_improve` and `grow_project` SDLC prompts instruct the agent to add `Co-authored-by:` trailers to every commit so loop-driven changes are attributable. `ap_loop` reaches parity by appending a small commit-attribution rider to the user-supplied prompt at arm time — so any commit produced during a `ap_loop` iteration carries the same dual trailer. By default, every loop-driven commit ships **two** trailers (per [issue #1](https://github.com/kloba/autopilot/issues/1)):
 
 ```
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
@@ -478,11 +480,13 @@ The first identifies the agent. The second attributes the commit to a dedicated 
 
 ### Opt-out
 
-Set `RALPH_NO_ATTRIBUTION=1` in the environment before arming the loop to suppress the second `copilot-ralph` trailer. The first `Copilot` trailer still ships, since it identifies the agent that made the change. The opt-out is **honored by the prompt** (baked SDLC prompt for `self_improve` / `grow_project`; appended rider for `ap_loop`), not by the extension code path — the agent reads the env var during the COMMIT stage and omits the trailer accordingly.
+Set `AUTOPILOT_NO_ATTRIBUTION=1` in the environment before arming the loop to suppress the second `copilot-ralph` trailer. The first `Copilot` trailer still ships, since it identifies the agent that made the change. The opt-out is **honored by the prompt** (baked SDLC prompt for `self_improve` / `grow_project`; appended rider for `ap_loop`), not by the extension code path — the agent reads the env var during the COMMIT stage and omits the trailer accordingly.
 
 ```bash
-RALPH_NO_ATTRIBUTION=1 copilot   # subsequent ap_loop / self_improve / grow_project loops omit the copilot-ralph trailer
+AUTOPILOT_NO_ATTRIBUTION=1 copilot   # subsequent ap_loop / self_improve / grow_project loops omit the copilot-ralph trailer
 ```
+
+> Legacy `RALPH_*` env-var names (e.g. `RALPH_NO_ATTRIBUTION=1`) are still read for one release with a one-line stderr deprecation notice.
 
 ### Caveats
 
@@ -495,14 +499,14 @@ RALPH_NO_ATTRIBUTION=1 copilot   # subsequent ap_loop / self_improve / grow_proj
 Long `ap_loop` / `self_improve` / `grow_project` runs can outlast macOS's idle-sleep timeout, which interrupts in-flight tool calls and timers. Opt in to a `caffeinate`-backed sleep block for the duration of the loop:
 
 ```bash
-RALPH_CAFFEINATE=1 copilot                                # block idle sleep only (default)
-RALPH_CAFFEINATE=1 RALPH_CAFFEINATE_SCOPE=idle+display copilot   # also keep the display awake
+AUTOPILOT_CAFFEINATE=1 copilot                                # block idle sleep only (default)
+AUTOPILOT_CAFFEINATE=1 AUTOPILOT_CAFFEINATE_SCOPE=idle+display copilot   # also keep the display awake
 ```
 
 | Variable | Values | Default | Effect |
 |---|---|---|---|
-| `RALPH_CAFFEINATE` | `1` / `true` / `yes` / `on` (case-insensitive) — anything else disables | unset (disabled) | Master switch. When unset, the extension **never** spawns `caffeinate`. |
-| `RALPH_CAFFEINATE_SCOPE` | `idle` or `idle+display` | `idle` | `idle` blocks idle/system sleep but lets the display lock for security. `idle+display` also prevents display sleep. |
+| `AUTOPILOT_CAFFEINATE` | `1` / `true` / `yes` / `on` (case-insensitive) — anything else disables | unset (disabled) | Master switch. When unset, the extension **never** spawns `caffeinate`. |
+| `AUTOPILOT_CAFFEINATE_SCOPE` | `idle` or `idle+display` | `idle` | `idle` blocks idle/system sleep but lets the display lock for security. `idle+display` also prevents display sleep. |
 
 Behaviour:
 
@@ -510,16 +514,17 @@ Behaviour:
 - Killed automatically on loop completion, `ap_stop`, abort, or detach. The `-w` flag is a belt-and-braces fallback so a hard crash of the CLI still releases the wake-lock.
 - **macOS only.** On Linux/Windows the helper is a silent no-op (a single log line records the skip). Future PRs may add `systemd-inhibit` / `SetThreadExecutionState` equivalents.
 - **Graceful when the binary is missing.** If `caffeinate` isn't on `PATH` or `spawn` fails, the loop runs without sleep prevention and logs the failure — it never aborts the loop over a power-management nicety.
-- **Disabled by default.** The extension does not modify system power state unless you set `RALPH_CAFFEINATE`.
+- **Disabled by default.** The extension does not modify system power state unless you set `AUTOPILOT_CAFFEINATE`.
+- **Legacy names.** `RALPH_CAFFEINATE` / `RALPH_CAFFEINATE_SCOPE` are still read for one release with a one-line stderr deprecation notice.
 
 ## Troubleshooting
 
-- **`/extensions` doesn't list `ralph`.** Confirm every `.mjs` from `extension/` (currently `extension.mjs`, `handler.mjs`, and `events-emit.mjs`) is present in `~/.copilot/extensions/ralph/` (user-scoped) or `.github/extensions/ralph/` (project-scoped, only visible from inside that repo) and restart Copilot CLI. `./install.sh` from source double-checks every file with `node --check` before writing, and a partial copy (e.g. only the first two modules) crashes at module-load with `Cannot find module './events-emit.mjs'`.
+- **`/extensions` doesn't list `autopilot`.** Confirm every `.mjs` from `extension/` (currently `extension.mjs`, `handler.mjs`, and `events-emit.mjs`) is present in `~/.copilot/extensions/autopilot/` (user-scoped) or `.github/extensions/autopilot/` (project-scoped, only visible from inside that repo) and restart Copilot CLI. `./install.sh` from source double-checks every file with `node --check` before writing, and a partial copy (e.g. only the first two modules) crashes at module-load with `Cannot find module './events-emit.mjs'`.
 - **`<owner> is already armed/running` failure.** Only one loop runs per session at a time — call `ap_stop` before re-arming. The leading word (`ap_loop`, `self_improve`, or `grow_project`) reflects whichever tool armed the active loop, so the guard fires on any of the three when one of the others is active.
 - **`abort_promise … overlap as substrings`.** `completion_promise` and `abort_promise` must be disjoint phrases (e.g. `"DONE"` and `"DONE_FAIL"` is rejected because one contains the other). Pick non-overlapping tokens.
 - **Loop ends immediately with `reason: send_error`.** The first `session.send` call rejected — usually because `controller.attach(session)` was not called or the session is no longer live. Check `result.note` for the underlying error.
 - **Loop runs N+ times instead of stopping.** Check that the prompt actually instructs the agent to emit the `completion_promise` literally; with a quoted/paraphrased completion phrase the loop only stops at `max_iterations`.
-- **Commit is missing the `copilot-ralph` `Co-authored-by:` trailer (or shipping it despite `RALPH_NO_ATTRIBUTION=1`).** The dual-trailer + opt-out behaviour lives in the [baked SDLC prompt](#commit-attribution), not in the extension code path — the agent reads the env var during COMMIT and decides accordingly. If the second trailer is missing on a commit you expected to attribute, re-run the iteration with the var unset (or audit `git log -1 --pretty=%B` to confirm); if it's still present despite the opt-out, the sub-agent likely couldn't see `process.env` (Limitations).
+- **Commit is missing the `copilot-ralph` `Co-authored-by:` trailer (or shipping it despite `AUTOPILOT_NO_ATTRIBUTION=1`).** The dual-trailer + opt-out behaviour lives in the [baked SDLC prompt](#commit-attribution), not in the extension code path — the agent reads the env var during COMMIT and decides accordingly. If the second trailer is missing on a commit you expected to attribute, re-run the iteration with the var unset (or audit `git log -1 --pretty=%B` to confirm); if it's still present despite the opt-out, the sub-agent likely couldn't see `process.env` (Limitations).
 
 ## Limitations
 
@@ -530,7 +535,7 @@ Behaviour:
 - **Iteration timing is loop-arm-relative and pause-deducted.** The `(elapsed Xms)` value in iter logs is wall-clock from arming. The final `durationMs` on the result is **active time** — wall-clock from arming minus `total_paused_ms` (cumulative time the loop spent paused via `ap_pause`), so a loop paused for an hour and then run for five minutes reports `durationMs ≈ 5 min`, not `≈ 65 min`. Per-turn timing isn't tracked. See [Pause and resume](#pause-and-resume) for the pause semantics.
 - **One loop per session.** Arming a second `ap_loop` (or a `self_improve`, or a `grow_project`) while one is active fails fast — you must `ap_stop` the active loop first. The guard applies symmetrically across all three tools: a `ap_loop` while `self_improve` or `grow_project` is active is also rejected, and vice versa.
 - **`self_improve` keeps re-iterating with no commits.** The baked SDLC prompt instructs the agent to emit `COMPLETE` when the staircase is done. Until that token appears in an iteration, the loop runs to `max_iterations`. To stop early, either `ap_stop` it manually or prepend a tighter `focus` so each iteration converges faster.
-- **Attribution opt-out is honored by the prompt, not enforced by the runtime.** [`RALPH_NO_ATTRIBUTION=1`](#opt-out) suppresses the second `copilot-ralph` `Co-authored-by:` trailer only because the prompt instructs the agent to read the env var during the COMMIT stage and omit the trailer (baked into `self_improve` / `grow_project` SDLC prompts; appended as a rider to user prompts on `ap_loop`). The extension does not rewrite commits — if a sub-agent ignores the env var (or runs in a context where `process.env` isn't visible), the trailer can still ship. Audit a commit afterwards with `git log -1 --pretty=%B` if attribution must be guaranteed off.
+- **Attribution opt-out is honored by the prompt, not enforced by the runtime.** [`AUTOPILOT_NO_ATTRIBUTION=1`](#opt-out) suppresses the second `copilot-ralph` `Co-authored-by:` trailer only because the prompt instructs the agent to read the env var during the COMMIT stage and omit the trailer (baked into `self_improve` / `grow_project` SDLC prompts; appended as a rider to user prompts on `ap_loop`). The extension does not rewrite commits — if a sub-agent ignores the env var (or runs in a context where `process.env` isn't visible), the trailer can still ship. Audit a commit afterwards with `git log -1 --pretty=%B` if attribution must be guaranteed off.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # copilot-ralph-extension
 
-> Ralph Wiggum-style autonomous iterative loop for **GitHub Copilot CLI**, implemented as an in-session extension.
+> Autonomous iterative loop for **GitHub Copilot CLI**, implemented as an in-session extension.
 
 [![CI](https://github.com/kloba/copilot-ralph-extension/actions/workflows/ci.yml/badge.svg)](https://github.com/kloba/copilot-ralph-extension/actions/workflows/ci.yml)
 [![Inspired by](https://img.shields.io/badge/inspired_by-Anthropic_Ralph_Wiggum-blue)](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Reporting a Vulnerability
 
-If you believe you've found a security issue in `copilot-ralph-extension` — such as a prompt-injection vector, a path-traversal in `install.sh`, an unsafe shell construction in a baked prompt, or any other credential / data-exposure risk — please report it **privately** rather than opening a public issue.
+If you believe you've found a security issue in `autopilot` — such as a prompt-injection vector, a path-traversal in `install.sh`, an unsafe shell construction in a baked prompt, or any other credential / data-exposure risk — please report it **privately** rather than opening a public issue.
 
-Use GitHub's [private vulnerability reporting](https://github.com/kloba/copilot-ralph-extension/security/advisories/new) form to file a confidential security advisory. We'll triage and respond as soon as we can. Public-issue reports for credible vulnerabilities will be redacted on request.
+Use GitHub's [private vulnerability reporting](https://github.com/kloba/autopilot/security/advisories/new) form to file a confidential security advisory. We'll triage and respond as soon as we can. Public-issue reports for credible vulnerabilities will be redacted on request.
 
 When reporting, please include:
 
@@ -36,3 +36,7 @@ Out-of-scope:
 
 - Vulnerabilities in upstream `@github/copilot-sdk`, the Copilot CLI itself, Node.js, or `gh`. Please report those to the respective projects.
 - Issues that require an attacker to already have local code-execution on the user's machine (we assume the local environment is trusted).
+
+Legacy `RALPH_*` env-var names are still read for one release with a one-line stderr deprecation notice.
+
+Legacy `~/.copilot/ralph[ -tui]/runs` paths are still read on first run with a one-line stderr migration notice; new runs write to the autopilot* paths.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,12 +21,12 @@ The trade-off is documented in the README's comparison table; see [What's differ
 extension/
 ├── extension.mjs   # SDK glue — joinSession + createRalphController() + register tools/hooks
 ├── handler.mjs     # The entire controller: state machine, validation, tool defs, baked prompts
-└── events-emit.mjs # Zero-dep JSONL event emitter (writes ~/.copilot/ralph/runs/<runId>/events.jsonl)
+└── events-emit.mjs # Zero-dep JSONL event emitter (writes ~/.copilot/autopilot/runs/<runId>/events.jsonl)
 test/
 ├── extension.test.mjs       # node:test suite — controller against a fake session
 ├── events-emit.test.mjs     # Unit tests for the JSONL emitter helpers
 └── handler-events.test.mjs  # Integration tests covering controller↔emitter wiring
-packages/tui/       # Stand-alone TUI consumer (`ralph-tui`) — see packages/tui/README.md
+packages/tui/       # Stand-alone TUI consumer (`autopilot`) — see packages/tui/README.md
 install.sh          # User- or project-scoped install into ~/.copilot/extensions or .github/extensions
 ```
 
@@ -45,8 +45,8 @@ While a loop is running, `state.active` holds the canonical loop state. Field-by
 - `prompt` / `completionPromise` / `abortPromise` — the strings re-fed each iter and the substrings that terminate the loop.
 - `prev` / `streak` / `stagnationLimit` — byte-identical-response detector that aborts a stuck loop.
 - `pendingFire` / `fireInFlight` / `observedMessageThisFire` — per-iteration dispatch guards. The first idle (the one that *armed* the loop) consumes `pendingFire` to fire iter 1; the in-flight markers prevent stale-idle bloat from cancelled tool calls or sub-agents.
-- `paused` / `pauseReason` / `pausedAt` / `totalPausedMs` — pause-state fields (issue [#3](https://github.com/kloba/copilot-ralph-extension/issues/3)). When `paused === true`, `onIdle` short-circuits before firing the next iteration so the user can chat freely without consuming iterations. `ap_resume` re-arms by zeroing the streak detector (manual intervention almost always changes context) and folding `pausedFor` into `totalPausedMs` for accurate elapsed-time reporting in `ap_status`.
-- Adaptive-budget fields (issue [#4](https://github.com/kloba/copilot-ralph-extension/issues/4)): `adaptiveBudget`, `adaptiveExtension`, `adaptiveMaxTotal`, `originalMax`, `adaptiveContentHashes`, `adaptiveExtensionHistory`.
+- `paused` / `pauseReason` / `pausedAt` / `totalPausedMs` — pause-state fields (issue [#3](https://github.com/kloba/autopilot/issues/3)). When `paused === true`, `onIdle` short-circuits before firing the next iteration so the user can chat freely without consuming iterations. `ap_resume` re-arms by zeroing the streak detector (manual intervention almost always changes context) and folding `pausedFor` into `totalPausedMs` for accurate elapsed-time reporting in `ap_status`.
+- Adaptive-budget fields (issue [#4](https://github.com/kloba/autopilot/issues/4)): `adaptiveBudget`, `adaptiveExtension`, `adaptiveMaxTotal`, `originalMax`, `adaptiveContentHashes`, `adaptiveExtensionHistory`.
 
 When the loop finishes, `state.active` becomes `null` and the immutable `state.lastResult` (a deep-frozen `RalphResult`) holds the post-mortem.
 
@@ -66,8 +66,8 @@ The baked prompts include hard-coded `COMPLETE` / `ABORT_…` tokens and `min_it
 |---|---|---|
 | `ap_loop` | Generic re-fed-prompt loop | One loop at a time. Returns immediately after arming. Driven by `session.idle`. |
 | `ap_stop` | Cancel the active loop | Returns failure if no loop is active. Optional `reason` string is recorded as `note` on the result. |
-| `ap_status` | Live structured snapshot of the active loop | Issue [#5](https://github.com/kloba/copilot-ralph-extension/issues/5) — read-only; safe to call mid-loop. |
-| `ap_pause` | Pause the active loop without losing state | Issue [#3](https://github.com/kloba/copilot-ralph-extension/issues/3). Idempotent; `onIdle` short-circuits while `paused === true`. Returns failure if no loop is active. |
+| `ap_status` | Live structured snapshot of the active loop | Issue [#5](https://github.com/kloba/autopilot/issues/5) — read-only; safe to call mid-loop. |
+| `ap_pause` | Pause the active loop without losing state | Issue [#3](https://github.com/kloba/autopilot/issues/3). Idempotent; `onIdle` short-circuits while `paused === true`. Returns failure if no loop is active. |
 | `ap_resume` | Resume a paused loop | Returns failure if no loop is active or the loop is not paused. Stagnation streak is reset on resume. |
 | `self_improve` | Baked SDLC self-improvement prompt | Wraps `armLoop` with `PROMPT_SELF_IMPROVE`. Honors `focus` for narrowing scope. |
 | `grow_project` | Baked backlog-grooming + execution loop | Wraps `armLoop` with `PROMPT_GROW_PROJECT`. Drives `gh` CLI calls. |
@@ -80,11 +80,11 @@ All tools share the `success(message, extra)` / `failure(message, extra)` envelo
 - **`abort_promise`** (optional, no default) — same mechanism, but finishes with `reason: "abort_promise"`. Used by `grow_project` (`ABORT_NO_BACKLOG`) to bail when there's nothing to do.
 - Both promises are **only honored once `i >= min_iterations`** to avoid premature termination from the agent merely describing the protocol on iter 1. Stagnation, max-iterations, and adaptive-budget terminators have their own thresholds and do not respect `min_iterations`.
 
-## Adaptive iteration budget (issue [#4](https://github.com/kloba/copilot-ralph-extension/issues/4))
+## Adaptive iteration budget (issue [#4](https://github.com/kloba/autopilot/issues/4))
 
 Opt-in. When the loop reaches `max_iterations`, `evaluateAdaptiveSignals(a, gitExec)` returns a non-null reason iff *either* `git diff --shortstat HEAD` or `git status --porcelain` reports working-tree changes, *or* the rolling 3-iteration content-hash window contains ≥ 2 distinct hashes. A positive signal grants `adaptive_extension` more iterations, capped at `adaptive_max_total`. Stagnation / completion / abort still win unconditionally because they're checked earlier in `onIdle`.
 
-## Token tracking (issue [#7](https://github.com/kloba/copilot-ralph-extension/issues/7))
+## Token tracking (issue [#7](https://github.com/kloba/autopilot/issues/7))
 
 `assistant.message` events from the root agent are routed through two helpers in `handler.mjs`: `extractUsage(ev)` reads `data.usage.{input_tokens, output_tokens, model}` (or the flat `data.usage_input_tokens`/`usage_output_tokens`/`usage_model` form used by the SDK's events table); `creditUsage(a, usage)` accumulates the result onto `a.tokens.input` / `a.tokens.output`, appends a per-iteration breakdown to `byIteration` (`{iter, input, output, model}`), and folds per-model totals into `byModel`. Sub-agent events are filtered upstream by `isSubAgentEvent`, so token credit covers root-agent usage only.
 
@@ -97,14 +97,14 @@ Two thresholds are derived from the running `tokens.input` total against `MODEL_
 
 The `max_tokens` cap (set at arm time) is checked at the end of each iteration in `onIdle`; the running total — input + output — is compared against the cap, and the loop finishes with `reason: "max_tokens"` once it crosses. Because pause-time and rejected events do not credit, this cap is never tripped by chat-time activity or malformed events.
 
-## Caffeinate integration (issue [#8](https://github.com/kloba/copilot-ralph-extension/issues/8))
+## Caffeinate integration (issue [#8](https://github.com/kloba/autopilot/issues/8))
 
-Opt-in via `RALPH_CAFFEINATE=1`. On macOS, `armLoop` spawns `caffeinate -i [-d] -w <pid>` to inhibit display/system sleep for the duration of the loop. `finish()` (and every error path) kills the caffeinate process. Tests inject a `spawnFn` stub via `createRalphController({ caffeinate: { spawnFn } })`.
+Opt-in via `AUTOPILOT_CAFFEINATE=1`. On macOS, `armLoop` spawns `caffeinate -i [-d] -w <pid>` to inhibit display/system sleep for the duration of the loop. `finish()` (and every error path) kills the caffeinate process. Tests inject a `spawnFn` stub via `createRalphController({ caffeinate: { spawnFn } })`.
 
 ## Test architecture
 
 - `node:test` runner; no third-party test deps.
 - `makeFakeSession()` returns a `{ on, emit, send, log }` object that mimics the SDK's event bus.
 - `runTurn(session, content)` drives one iteration: emits `assistant.message` then `session.idle`.
-- DI on the controller (`createRalphController({ caffeinate, git, adaptive, events })`) lets tests stub external effects (process spawn, git exec, JSONL event emit) without monkey-patching. The `events` slot is the issue [#22](https://github.com/kloba/copilot-ralph-extension/issues/22) JSONL emitter wiring — accepts `true` (default emitter), `{ env, fs }` (default emitter w/ overrides), or `{ factory }` (custom emitter built per-arm); see the inline JSDoc above `armLoop` for the full contract.
+- DI on the controller (`createRalphController({ caffeinate, git, adaptive, events })`) lets tests stub external effects (process spawn, git exec, JSONL event emit) without monkey-patching. The `events` slot is the issue [#22](https://github.com/kloba/autopilot/issues/22) JSONL emitter wiring — accepts `true` (default emitter), `{ env, fs }` (default emitter w/ overrides), or `{ factory }` (custom emitter built per-arm); see the inline JSDoc above `armLoop` for the full contract.
 - Several **shape-pin tests** lock down field counts and key sets on `state.active`, the success-envelope, the parsed-args object, and the tool-array order. These exist specifically to catch refactors that silently leak internal scratch into the LLM-facing surface.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,7 +45,7 @@ While a loop is running, `state.active` holds the canonical loop state. Field-by
 - `prompt` / `completionPromise` / `abortPromise` — the strings re-fed each iter and the substrings that terminate the loop.
 - `prev` / `streak` / `stagnationLimit` — byte-identical-response detector that aborts a stuck loop.
 - `pendingFire` / `fireInFlight` / `observedMessageThisFire` — per-iteration dispatch guards. The first idle (the one that *armed* the loop) consumes `pendingFire` to fire iter 1; the in-flight markers prevent stale-idle bloat from cancelled tool calls or sub-agents.
-- `paused` / `pauseReason` / `pausedAt` / `totalPausedMs` — pause-state fields (issue [#3](https://github.com/kloba/copilot-ralph-extension/issues/3)). When `paused === true`, `onIdle` short-circuits before firing the next iteration so the user can chat freely without consuming iterations. `ralph_resume` re-arms by zeroing the streak detector (manual intervention almost always changes context) and folding `pausedFor` into `totalPausedMs` for accurate elapsed-time reporting in `ralph_status`.
+- `paused` / `pauseReason` / `pausedAt` / `totalPausedMs` — pause-state fields (issue [#3](https://github.com/kloba/copilot-ralph-extension/issues/3)). When `paused === true`, `onIdle` short-circuits before firing the next iteration so the user can chat freely without consuming iterations. `ap_resume` re-arms by zeroing the streak detector (manual intervention almost always changes context) and folding `pausedFor` into `totalPausedMs` for accurate elapsed-time reporting in `ap_status`.
 - Adaptive-budget fields (issue [#4](https://github.com/kloba/copilot-ralph-extension/issues/4)): `adaptiveBudget`, `adaptiveExtension`, `adaptiveMaxTotal`, `originalMax`, `adaptiveContentHashes`, `adaptiveExtensionHistory`.
 
 When the loop finishes, `state.active` becomes `null` and the immutable `state.lastResult` (a deep-frozen `RalphResult`) holds the post-mortem.
@@ -64,11 +64,11 @@ The baked prompts include hard-coded `COMPLETE` / `ABORT_…` tokens and `min_it
 
 | Tool | Purpose | Key contract |
 |---|---|---|
-| `ralph_loop` | Generic re-fed-prompt loop | One loop at a time. Returns immediately after arming. Driven by `session.idle`. |
-| `ralph_stop` | Cancel the active loop | Returns failure if no loop is active. Optional `reason` string is recorded as `note` on the result. |
-| `ralph_status` | Live structured snapshot of the active loop | Issue [#5](https://github.com/kloba/copilot-ralph-extension/issues/5) — read-only; safe to call mid-loop. |
-| `ralph_pause` | Pause the active loop without losing state | Issue [#3](https://github.com/kloba/copilot-ralph-extension/issues/3). Idempotent; `onIdle` short-circuits while `paused === true`. Returns failure if no loop is active. |
-| `ralph_resume` | Resume a paused loop | Returns failure if no loop is active or the loop is not paused. Stagnation streak is reset on resume. |
+| `ap_loop` | Generic re-fed-prompt loop | One loop at a time. Returns immediately after arming. Driven by `session.idle`. |
+| `ap_stop` | Cancel the active loop | Returns failure if no loop is active. Optional `reason` string is recorded as `note` on the result. |
+| `ap_status` | Live structured snapshot of the active loop | Issue [#5](https://github.com/kloba/copilot-ralph-extension/issues/5) — read-only; safe to call mid-loop. |
+| `ap_pause` | Pause the active loop without losing state | Issue [#3](https://github.com/kloba/copilot-ralph-extension/issues/3). Idempotent; `onIdle` short-circuits while `paused === true`. Returns failure if no loop is active. |
+| `ap_resume` | Resume a paused loop | Returns failure if no loop is active or the loop is not paused. Stagnation streak is reset on resume. |
 | `self_improve` | Baked SDLC self-improvement prompt | Wraps `armLoop` with `PROMPT_SELF_IMPROVE`. Honors `focus` for narrowing scope. |
 | `grow_project` | Baked backlog-grooming + execution loop | Wraps `armLoop` with `PROMPT_GROW_PROJECT`. Drives `gh` CLI calls. |
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing
 
-Thanks for your interest in `copilot-ralph-extension`! This page is the entry point for contributors. End-user docs live in the [README](../README.md).
+Thanks for your interest in `autopilot`! This page is the entry point for contributors. End-user docs live in the [README](../README.md).
 
 ## Local development setup
 
 ```bash
-git clone https://github.com/kloba/copilot-ralph-extension.git
-cd copilot-ralph-extension
+git clone https://github.com/kloba/autopilot.git
+cd autopilot
 npm test    # runs the node:test suite under test/ (no install needed — zero runtime deps)
 ```
 
@@ -17,7 +17,7 @@ The repository has **zero npm runtime dependencies** and only Node ≥ 20's buil
 For day-to-day iteration, prefer a **project-scoped** install so your `git checkout` is the live source the CLI loads:
 
 ```bash
-./install.sh --project   # installs into .github/extensions/ralph in this repo
+./install.sh --project   # installs into .github/extensions/autopilot in this repo
 ```
 
 After editing `extension/handler.mjs`, run `extensions_reload` from inside Copilot CLI (or restart the CLI) — new tool definitions are picked up immediately.
@@ -25,7 +25,7 @@ After editing `extension/handler.mjs`, run `extensions_reload` from inside Copil
 For a user-scoped install (loads the same extension across all your repos):
 
 ```bash
-./install.sh             # default: ~/.copilot/extensions/ralph
+./install.sh             # default: ~/.copilot/extensions/autopilot
 ./install.sh --dry-run   # show what would be copied without writing
 ```
 
@@ -46,7 +46,7 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 Co-authored-by: copilot-ralph <noreply+copilot-ralph@github.com>
 ```
 
-The first attributes the underlying Copilot model; the second attributes the loop that executed the iteration. Order matters — GitHub surfaces the first co-author more prominently. See the [README "Commit attribution" section](../README.md#commit-attribution) and [CHANGELOG](../CHANGELOG.md) for full rationale and opt-out (`RALPH_NO_ATTRIBUTION=1`).
+The first attributes the underlying Copilot model; the second attributes the loop that executed the iteration. Order matters — GitHub surfaces the first co-author more prominently. See the [README "Commit attribution" section](../README.md#commit-attribution) and [CHANGELOG](../CHANGELOG.md) for full rationale and opt-out (`AUTOPILOT_NO_ATTRIBUTION=1`).
 
 ## Pull request expectations
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,8 +1,8 @@
 # Releasing
 
-`copilot-ralph-extension` ships as a small set of `.mjs` files copied into `~/.copilot/extensions/ralph` (or `.github/extensions/ralph` for project-scoped installs). There is **no npm publish**; releases are tagged commits on `main` plus an annotated GitHub Release page.
+`autopilot` ships as a small set of `.mjs` files copied into `~/.copilot/extensions/autopilot` (or `.github/extensions/autopilot` for project-scoped installs). There is **no npm publish**; releases are tagged commits on `main` plus an annotated GitHub Release page.
 
-A formal tag-driven release-automation workflow now ships at [`.github/workflows/release.yml`](../.github/workflows/release.yml) (see issue [#10](https://github.com/kloba/copilot-ralph-extension/issues/10) for the rationale). Pushing a `vX.Y.Z` tag verifies `package.json` matches the tag, asserts a matching `CHANGELOG.md` section exists, runs `npm test`, and creates the GitHub Release with every `extension/*.mjs` attached as an asset. The manual checklist below is the fallback when the workflow is unavailable or you need to cut a release out-of-band.
+A formal tag-driven release-automation workflow now ships at [`.github/workflows/release.yml`](../.github/workflows/release.yml) (see issue [#10](https://github.com/kloba/autopilot/issues/10) for the rationale). Pushing a `vX.Y.Z` tag verifies `package.json` matches the tag, asserts a matching `CHANGELOG.md` section exists, runs `npm test`, and creates the GitHub Release with every `extension/*.mjs` attached as an asset. The manual checklist below is the fallback when the workflow is unavailable or you need to cut a release out-of-band.
 
 ## Manual release checklist
 
@@ -49,18 +49,18 @@ Once a release exists with assets attached, end users can pin a specific revisio
 
 ```bash
 # Project-scoped pin
-mkdir -p .github/extensions/ralph
+mkdir -p .github/extensions/autopilot
 # Order matters: leaf modules first, entry point (extension.mjs) LAST —
 # mirrors install.sh's FILES array and README Option A/B/D. If
 # `/extensions reload` fires mid-download, this guarantees the SDK
 # never sees a new `extension.mjs` importing missing/old siblings.
 for f in events-emit.mjs prompts.mjs handler.mjs extension.mjs; do
-  curl -L -o ".github/extensions/ralph/$f" \
-    "https://github.com/kloba/copilot-ralph-extension/releases/download/vX.Y.Z/$f"
+  curl -L -o ".github/extensions/autopilot/$f" \
+    "https://github.com/kloba/autopilot/releases/download/vX.Y.Z/$f"
 done
 ```
 
-For the user-scoped equivalent, swap `.github/extensions/ralph` for `~/.copilot/extensions/ralph`.
+For the user-scoped equivalent, swap `.github/extensions/autopilot` for `~/.copilot/extensions/autopilot`.
 
 ## Hotfix branches
 

--- a/docs/cli-stack.md
+++ b/docs/cli-stack.md
@@ -2,7 +2,7 @@
 
 > Stack-verification reference for `packages/tui/` (issue #22).
 >
-> The ralph TUI is built on the same proven trio used by today's leading
+> The autopilot TUI is built on the same proven trio used by today's leading
 > agentic-CLI tools: **Ink** (React for terminal UIs), **Yoga**
 > (Facebook's Flexbox engine that Ink uses for layout), and **Commander**
 > (the de-facto Node.js CLI argument parser). This document captures
@@ -72,7 +72,7 @@ the extension's webview stays consistent with the CLI.
 
 Commander has been the dominant Node CLI parser since 2011 and is
 what tools like ESLint, Vue CLI, and `pnpm` ship with. The reasons
-for picking it for `ralph-tui`:
+for picking it for `autopilot`:
 
 * **Subcommand ergonomics.** `program.command("replay <runId>")` and
   `program.command("watch [runId]")` map 1:1 to our `cmd` switch.
@@ -120,7 +120,7 @@ at Yoga as the layout backend.
 
 The TUI's full dependency closure resolves to ~3 MB of `node_modules/`
 when installed (Ink + React + Yoga's WASM + Commander). That cost is
-paid only by users who run `ralph-tui watch` interactively. The
+paid only by users who run `autopilot watch` interactively. The
 *event emitter* in the core extension stays stdlib-only, so an
 extension install via `install.sh` adds zero new packages.
 
@@ -130,5 +130,5 @@ extension install via `install.sh` adds zero new packages.
   Live TUI walkthrough + asciinema recipe.
 * [packages/tui/package.json](../packages/tui/package.json) — current
   pinned versions.
-* [Issue #22](https://github.com/kloba/copilot-ralph-extension/issues/22) —
+* [Issue #22](https://github.com/kloba/autopilot/issues/22) —
   TUI design discussion.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -13,10 +13,10 @@ Topics planned:
 
 ## Pause / resume semantics
 
-`ralph_pause` and `ralph_resume` let you stop the next iteration from
+`ap_pause` and `ap_resume` let you stop the next iteration from
 firing without losing the iteration counter, the conversation context,
 or the arm-time git snapshot. The iteration in flight at the moment
-you call `ralph_pause` is not interrupted — it runs to completion and
+you call `ap_pause` is not interrupted — it runs to completion and
 emits its `iteration_end` event. Pause only takes effect on the
 **next** `session.idle`: the on-idle handler short-circuits when
 `active.paused` is `true`, and the iteration counter stays at the
@@ -43,12 +43,12 @@ loop also **isolates** its bookkeeping from the pause-time chat:
   terminate the loop. Trade-off: a genuine completion / abort signal
   that landed in the in-flight iteration's response right before you
   paused is forfeited; you can still read it via
-  `ralph_status.last_response_excerpt` and `ralph_stop` the loop
+  `ap_status.last_response_excerpt` and `ap_stop` the loop
   explicitly if you want to honor it.
 
-`ralph_pause` is idempotent: calling it on an already-paused loop is
+`ap_pause` is idempotent: calling it on an already-paused loop is
 a no-op and returns success. **First reason wins** — a redundant
-`ralph_pause({reason: "newer"})` against an already-paused loop
+`ap_pause({reason: "newer"})` against an already-paused loop
 returns the FIRST committed reason in both the success payload's
 `reason` field and the rendered `textResultForLlm` (`<label>
 already paused at i/max (firstReason).`). Automation polling pause
@@ -59,7 +59,7 @@ modes are:
 1. No loop is currently active (`{ active: false }`).
 2. The `reason` argument exceeds 500 chars (validation rejection).
 
-`ralph_resume` flips `paused` back to `false` and resets three
+`ap_resume` flips `paused` back to `false` and resets three
 pieces of state that would otherwise leak pause-time context into
 the next iteration's evaluation:
 
@@ -71,7 +71,7 @@ the next iteration's evaluation:
   could trip the stagnation guard even though the conversation
   context has changed substantially.
 - The **last-assistant-content buffer** (`state.lastAssistantContent
-  = ""`). Even though `ralph_pause` itself stops new pause-time
+  = ""`). Even though `ap_pause` itself stops new pause-time
   content from being appended (see "Completion / abort isolation"
   above), the in-flight iteration's response that arrived **before**
   the pause is still sitting in that buffer at resume time. Clearing
@@ -79,13 +79,13 @@ the next iteration's evaluation:
   string for completion / abort triggers — same defense-in-depth
   reasoning as the streak reset.
 
-`ralph_resume` returns failure if the loop is **not** currently
+`ap_resume` returns failure if the loop is **not** currently
 paused — the error message is
-`ralph_resume: <label> is not paused. Use ralph_pause first, or
-ralph_stop to cancel.` So unlike `ralph_pause`, `ralph_resume` is
+`ap_resume: <label> is not paused. Use ap_pause first, or
+ap_stop to cancel.` So unlike `ap_pause`, `ap_resume` is
 **not** idempotent.
 
-Pause time is tracked in two places visible via `ralph_status`:
+Pause time is tracked in two places visible via `ap_status`:
 
 - `paused_for_ms` — the duration of the **current** pause (zero when
   the loop is not paused).
@@ -101,9 +101,9 @@ In summary, the contract is:
 
 | Operation         | When it succeeds                       | What it does                                                                |
 | ----------------- | -------------------------------------- | --------------------------------------------------------------------------- |
-| `ralph_pause`     | Loop active (paused or unpaused)       | Sets `paused = true`. Currently-running iteration finishes normally. Pause-time `assistant.message` events are not credited to the loop's token budget and do not accumulate into the completion/abort buffer. |
-| `ralph_resume`    | Loop active **and** paused             | Clears `paused`, resets `streak` / `prev` / `lastAssistantContent`, adds elapsed pause to `total_paused_ms`. |
-| `ralph_stop`      | Loop active (paused or unpaused)       | Cancels the loop entirely. Pausing first is not required.                   |
+| `ap_pause`     | Loop active (paused or unpaused)       | Sets `paused = true`. Currently-running iteration finishes normally. Pause-time `assistant.message` events are not credited to the loop's token budget and do not accumulate into the completion/abort buffer. |
+| `ap_resume`    | Loop active **and** paused             | Clears `paused`, resets `streak` / `prev` / `lastAssistantContent`, adds elapsed pause to `total_paused_ms`. |
+| `ap_stop`      | Loop active (paused or unpaused)       | Cancels the loop entirely. Pausing first is not required.                   |
 
 
 ## Token tracking and context-window warnings
@@ -115,22 +115,22 @@ window pressure climb in real time.
 
 ### What you observe
 
-- **Live cumulative totals** — `ralph_status.tokens` (added in
+- **Live cumulative totals** — `ap_status.tokens` (added in
   issue [#7](https://github.com/kloba/copilot-ralph-extension/issues/7))
   exposes `{ input, output, total, max_tokens }` on the active
   snapshot. Counts start at zero and grow with every credited
   iteration. `max_tokens` echoes the configured cap, or is `null`
   when no cap was armed.
-- **Post-finish summary** — `ralph_status.last.tokens` mirrors the
+- **Post-finish summary** — `ap_status.last.tokens` mirrors the
   same `{ input, output, total }` shape on the prior-run summary so
-  a post-mortem `ralph_status` call after the loop exits still sees
+  a post-mortem `ap_status` call after the loop exits still sees
   how many tokens the run consumed. Omitted entirely when the run
   credited zero tokens.
 - **Per-iteration breakdown** — the deep-frozen
   `result.tokens.byIteration` and `result.tokens.byModel` (returned
   on the loop's terminal value, not on the live snapshot) carry
   per-iter and per-model rollups for callers that want detail. They
-  are intentionally **not** mirrored on `ralph_status` to keep that
+  are intentionally **not** mirrored on `ap_status` to keep that
   payload cheap to serialise.
 
 ### Two safety contracts
@@ -172,9 +172,9 @@ exact lines enforce the two contracts — see the
 [Token tracking section in `docs/ARCHITECTURE.md`](ARCHITECTURE.md).
 
 
-## `ralph_status` one-line summary
+## `ap_status` one-line summary
 
-Every `ralph_status` invocation returns a structured snapshot **plus**
+Every `ap_status` invocation returns a structured snapshot **plus**
 a single-line `textResultForLlm` summary so a model that reads only
 the prose result still sees the loop's pulse. The shape is fixed and
 intended to be parsed (or grepped) by tooling.
@@ -187,7 +187,7 @@ intended to be parsed (or grepped) by tooling.
 
 Slot-by-slot:
 
-- `{label}` — the loop's display name (`ralph_loop`,
+- `{label}` — the loop's display name (`ap_loop`,
   `self_improve`, or `grow_project`).
 - `iteration {N}/{M}` — current iteration count vs. the configured
   `max_iterations`. `N` is the number of completed iterations, so
@@ -221,6 +221,6 @@ no active loop; last {label} {reason} after {N} iterations
 no active loop and no prior run in this session
 ```
 
-This is the only case where `ralph_status` returns neither an
+This is the only case where `ap_status` returns neither an
 active snapshot nor a `last` block. It is safe to call from any
 session, including before any loop has been armed.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,7 +1,7 @@
 # Concepts
 
 !!! note "Stub page (issue #2)"
-    Scaffold only — to be expanded in follow-ups. See the [README](https://github.com/kloba/copilot-ralph-extension#readme) until this page is filled in.
+    Scaffold only — to be expanded in follow-ups. See the [README](https://github.com/kloba/autopilot#readme) until this page is filled in.
 
 Topics planned:
 
@@ -116,7 +116,7 @@ window pressure climb in real time.
 ### What you observe
 
 - **Live cumulative totals** — `ap_status.tokens` (added in
-  issue [#7](https://github.com/kloba/copilot-ralph-extension/issues/7))
+  issue [#7](https://github.com/kloba/autopilot/issues/7))
   exposes `{ input, output, total, max_tokens }` on the active
   snapshot. Counts start at zero and grow with every credited
   iteration. `max_tokens` echoes the configured cap, or is `null`
@@ -197,7 +197,7 @@ Slot-by-slot:
   `paused_for_ms` from the structured snapshot if you need
   active-only time.
 - `, tokens {X}/{Y}` — appears **only when** `max_tokens` was armed
-  (issue [#7](https://github.com/kloba/copilot-ralph-extension/issues/7)).
+  (issue [#7](https://github.com/kloba/autopilot/issues/7)).
   `X` is the cumulative input+output total credited so far; `Y` is
   the configured cap. Loops without a cap omit this segment so
   consumers do not see a misleading `tokens X/null`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -45,13 +45,13 @@ version Copilot CLI ships with.
 ### Why does arming fail with `<owner> is already armed/running/paused`?
 
 Only one loop runs per session at a time. The leading word of the
-refusal — `ralph_loop`, `self_improve`, or `grow_project` — names
-whichever tool armed the *currently active* loop. Call `ralph_stop`
+refusal — `ap_loop`, `self_improve`, or `grow_project` — names
+whichever tool armed the *currently active* loop. Call `ap_stop`
 first, then arm the new one.
 
 If the active loop is paused you'll see `is already paused
-(iteration N/M) — call ralph_stop first.` Despite the wording,
-`ralph_resume` is also valid if you wanted the original loop to
+(iteration N/M) — call ap_stop first.` Despite the wording,
+`ap_resume` is also valid if you wanted the original loop to
 continue rather than be cleared.
 
 ### Why did my loop stop after exactly one iteration?
@@ -71,7 +71,7 @@ Three frequent causes:
 1. The prompt doesn't actually instruct the agent to emit the
    `completion_promise` literally. With a quoted/paraphrased
    completion phrase, only `max_iterations` (or `max_tokens`,
-   `stagnation_limit`, `ralph_stop`) ends the loop.
+   `stagnation_limit`, `ap_stop`) ends the loop.
 2. Stagnation guard is disabled (`stagnation_limit: 0`) and the
    agent oscillates indefinitely. Re-enable with the default
    `stagnation_limit: 3` or higher.
@@ -81,7 +81,7 @@ Three frequent causes:
 
 ### How do I stop a loop that's running away?
 
-Call `ralph_stop` — it returns immediately with the iteration count
+Call `ap_stop` — it returns immediately with the iteration count
 at the moment of the call. The currently-running iteration finishes
 normally; the loop simply doesn't fire on the next `session.idle`.
 You can pass an optional `reason` string that gets recorded on the
@@ -89,17 +89,17 @@ result for later forensics.
 
 ### Pause and resume — what's the difference vs stop?
 
-- `ralph_stop` clears the active loop. The iteration counter is
+- `ap_stop` clears the active loop. The iteration counter is
   gone afterwards.
-- `ralph_pause` keeps the loop alive but skips subsequent
+- `ap_pause` keeps the loop alive but skips subsequent
   `session.idle` triggers. You can chat freely with the agent
   without consuming iterations.
-- `ralph_resume` un-pauses. The iteration counter resumes where
+- `ap_resume` un-pauses. The iteration counter resumes where
   it left off; the stagnation streak is reset (manual chat
   almost always changes context).
 
-`ralph_pause` is idempotent (pausing an already-paused loop is a
-no-op). `ralph_resume` is **not** idempotent — calling it without
+`ap_pause` is idempotent (pausing an already-paused loop is a
+no-op). `ap_resume` is **not** idempotent — calling it without
 a paused loop returns a failure. See [`docs/concepts.md` → Pause /
 resume semantics](concepts.md#pause--resume-semantics) for the full
 state-machine writeup.
@@ -118,7 +118,7 @@ locate it.
 
 Use the bundled TUI: `npx ralph-tui watch <runId>` to follow events
 live, or `ralph-tui list` to see runs the index knows about. See
-README → [Inspecting a running loop](https://github.com/kloba/copilot-ralph-extension#inspecting-a-running-loop-ralph_status-tool)
+README → [Inspecting a running loop](https://github.com/kloba/copilot-ralph-extension#inspecting-a-running-loop-ap_status-tool)
 for the snapshot tool that returns a structured live snapshot
 without leaving the chat.
 
@@ -126,9 +126,9 @@ without leaving the chat.
 
 A resume reports `pausedForMs = max(0, now - pausedAt)`, where
 `pausedAt` is the wall-clock millisecond timestamp captured by the
-last `ralph_pause`. Two cases produce a zero:
+last `ap_pause`. Two cases produce a zero:
 
-- **Same-millisecond resume.** If you fire `ralph_resume` in the
+- **Same-millisecond resume.** If you fire `ap_resume` in the
   same millisecond as the pause (vanishingly rare in practice, but
   easy to hit in fast tests), `now - pausedAt` rounds to `0`.
 - **Backward clock skew.** If the system clock moves backward
@@ -139,7 +139,7 @@ last `ralph_pause`. Two cases produce a zero:
   `total_paused_ms`. Without the clamp, the run's reported
   `durationMs` would be inflated past the true wall-clock elapsed
   time. The same `Math.max(0, …)` guard runs in `finish()` and
-  `ralph_status.paused_for_ms` for symmetry; all three call sites
+  `ap_status.paused_for_ms` for symmetry; all three call sites
   share a single helper so the contract cannot drift.
 
 The `total_paused_ms` accumulated across multiple pause/resume
@@ -154,7 +154,7 @@ trailers — one for the `Copilot` GitHub identity, one for the
 dedicated `copilot-ralph` bot account. The dual-trailer convention
 is baked into the SDLC prompts (`self_improve`, `grow_project`)
 and appended as a rider to the user-supplied prompt for
-`ralph_loop`. See README → [Commit attribution](https://github.com/kloba/copilot-ralph-extension#commit-attribution).
+`ap_loop`. See README → [Commit attribution](https://github.com/kloba/copilot-ralph-extension#commit-attribution).
 
 ### How do I opt out of the second `copilot-ralph` trailer?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,20 +2,20 @@
 
 Short answers to the questions that come up most often when running
 Ralph in anger. Most of these point at a deeper section in the
-[README](https://github.com/kloba/copilot-ralph-extension#readme) or
+[README](https://github.com/kloba/autopilot#readme) or
 at [`docs/concepts.md`](concepts.md) — keep this page narrow and
 link out rather than duplicating prose.
 
 ## Setup
 
-### Why doesn't `/extensions` list `ralph` after install?
+### Why doesn't `/extensions` list `autopilot` after install?
 
 The Copilot CLI loads extensions at startup (and on `/extensions
 reload`). Confirm every shipped `.mjs` is present in the install
 target:
 
-- User-scoped: `~/.copilot/extensions/ralph/` — visible from any cwd.
-- Project-scoped: `<git-root>/.github/extensions/ralph/` — only
+- User-scoped: `~/.copilot/extensions/autopilot/` — visible from any cwd.
+- Project-scoped: `<git-root>/.github/extensions/autopilot/` — only
   visible when you launch Copilot CLI from inside that repo.
 
 Currently shipped files are `extension.mjs`, `handler.mjs`, and
@@ -28,7 +28,7 @@ to the source via `cmp -s`.
 ### How do I install a specific tagged release?
 
 See README → [Option D — Pin a specific tagged
-release](https://github.com/kloba/copilot-ralph-extension#option-d--pin-a-specific-tagged-release).
+release](https://github.com/kloba/autopilot#option-d--pin-a-specific-tagged-release).
 Tags are immutable; release tarballs are SHA-pinned by GitHub,
 so a pinned install never silently shifts under you.
 
@@ -62,7 +62,7 @@ against the assistant's accumulated turn output — if the agent quotes
 the trigger phrase mid-thought (e.g. *"I'll mark this COMPLETE when
 done"*), the loop finishes. Pick a phrase the agent is unlikely to
 mention casually; `RALPH_DONE_42` and similar unusual tokens work
-well. See README → [Limitations](https://github.com/kloba/copilot-ralph-extension#limitations).
+well. See README → [Limitations](https://github.com/kloba/autopilot#limitations).
 
 ### Why does my loop never finish?
 
@@ -108,17 +108,18 @@ state-machine writeup.
 
 ### Where does a running loop's event log live?
 
-By default: `~/.copilot/ralph/runs/<runId>/events.jsonl`. Override
-the runs root with the `RALPH_EVENTS_DIR` environment variable. The
+By default: `~/.copilot/autopilot/runs/<runId>/events.jsonl`. Override
+the runs root with the `AUTOPILOT_EVENTS_DIR` environment variable
+(legacy `RALPH_EVENTS_DIR` is still honored as a fallback). The
 `<runId>` shape is `${label}-${startedAt}` — sortable,
 filesystem-safe, and surfaced in the `armed` event so the TUI can
 locate it.
 
 ### How do I tail a running loop's events?
 
-Use the bundled TUI: `npx ralph-tui watch <runId>` to follow events
-live, or `ralph-tui list` to see runs the index knows about. See
-README → [Inspecting a running loop](https://github.com/kloba/copilot-ralph-extension#inspecting-a-running-loop-ap_status-tool)
+Use the bundled TUI: `npx autopilot watch <runId>` to follow events
+live, or `autopilot list` to see runs the index knows about. See
+README → [Inspecting a running loop](https://github.com/kloba/autopilot#inspecting-a-running-loop-ap_status-tool)
 for the snapshot tool that returns a structured live snapshot
 without leaving the chat.
 
@@ -154,11 +155,11 @@ trailers — one for the `Copilot` GitHub identity, one for the
 dedicated `copilot-ralph` bot account. The dual-trailer convention
 is baked into the SDLC prompts (`self_improve`, `grow_project`)
 and appended as a rider to the user-supplied prompt for
-`ap_loop`. See README → [Commit attribution](https://github.com/kloba/copilot-ralph-extension#commit-attribution).
+`ap_loop`. See README → [Commit attribution](https://github.com/kloba/autopilot#commit-attribution).
 
 ### How do I opt out of the second `copilot-ralph` trailer?
 
-Set `RALPH_NO_ATTRIBUTION=1` in the environment before arming the
+Set `AUTOPILOT_NO_ATTRIBUTION=1` in the environment before arming the
 loop. The opt-out suppresses **only** the second
 `copilot-ralph` trailer; the first `Copilot` trailer always ships.
 Note that the opt-out is honored by the prompt, not enforced by
@@ -169,6 +170,6 @@ it), the trailer can still appear. Audit afterwards with
 ## Anything else?
 
 If your question isn't answered here, open an issue or skim the
-[README](https://github.com/kloba/copilot-ralph-extension#readme)
+[README](https://github.com/kloba/autopilot#readme)
 Troubleshooting and Limitations sections — they cover the
 long-tail edge cases this page intentionally elides.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 An autonomous iterative loop for the GitHub Copilot CLI.
 
 !!! warning "Stub documentation site"
-    This site is the v0 scaffold for [issue #2](https://github.com/kloba/copilot-ralph-extension/issues/2). The pages below mirror the planned navigation but are intentionally short — they will be filled in by follow-up PRs.
+    This site is the v0 scaffold for [issue #2](https://github.com/kloba/autopilot/issues/2). The pages below mirror the planned navigation but are intentionally short — they will be filled in by follow-up PRs.
 
 ## What is this?
 
@@ -17,6 +17,6 @@ The loop is the simplest possible form of agentic autonomy: one prompt, repeated
 
 ## Repository
 
-- [Source on GitHub](https://github.com/kloba/copilot-ralph-extension)
-- [Issue tracker](https://github.com/kloba/copilot-ralph-extension/issues)
-- [Releases](https://github.com/kloba/copilot-ralph-extension/releases)
+- [Source on GitHub](https://github.com/kloba/autopilot)
+- [Issue tracker](https://github.com/kloba/autopilot/issues)
+- [Releases](https://github.com/kloba/autopilot/releases)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Ralph
 
-A Ralph Wiggum-style autonomous loop for the GitHub Copilot CLI.
+An autonomous iterative loop for the GitHub Copilot CLI.
 
 !!! warning "Stub documentation site"
     This site is the v0 scaffold for [issue #2](https://github.com/kloba/copilot-ralph-extension/issues/2). The pages below mirror the planned navigation but are intentionally short — they will be filled in by follow-up PRs.
@@ -11,9 +11,9 @@ Ralph turns the Copilot CLI into a self-driving iteration engine. You arm it wit
 
 See the [Quickstart](quickstart.md) to get going in under a minute.
 
-## Why "Ralph"?
+## Why a loop?
 
-The loop is the simplest possible form of agentic autonomy: one prompt, repeated, until done. Like Ralph Wiggum eating glue — single-minded, persistent, surprisingly effective.
+The loop is the simplest possible form of agentic autonomy: one prompt, repeated, until done — single-minded, persistent, surprisingly effective. The technique is sometimes called "Ralph" after Anthropic's original [Claude Code plugin](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum).
 
 ## Repository
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ An autonomous iterative loop for the GitHub Copilot CLI.
 
 ## What is this?
 
-Ralph turns the Copilot CLI into a self-driving iteration engine. You arm it with a prompt, and it re-fires that prompt every time the agent goes idle until either the agent emits a "done" phrase, you call `ralph_stop`, or a hard cap is reached.
+Ralph turns the Copilot CLI into a self-driving iteration engine. You arm it with a prompt, and it re-fires that prompt every time the agent goes idle until either the agent emits a "done" phrase, you call `ap_stop`, or a hard cap is reached.
 
 See the [Quickstart](quickstart.md) to get going in under a minute.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,13 +14,13 @@ cd copilot-ralph-extension
 ## Arm a loop
 
 ```js
-ralph_loop({ prompt: "Refactor src/auth.js. Emit COMPLETE when done." })
+ap_loop({ prompt: "Refactor src/auth.js. Emit COMPLETE when done." })
 ```
 
 Stop early:
 
 ```js
-ralph_stop({ reason: "changed plan" })
+ap_stop({ reason: "changed plan" })
 ```
 
 See the project [README](https://github.com/kloba/copilot-ralph-extension#readme) for the full reference until these pages are filled in.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,8 +6,8 @@
 ## Install
 
 ```bash
-git clone https://github.com/kloba/copilot-ralph-extension
-cd copilot-ralph-extension
+git clone https://github.com/kloba/autopilot
+cd autopilot
 ./install.sh
 ```
 
@@ -23,4 +23,4 @@ Stop early:
 ap_stop({ reason: "changed plan" })
 ```
 
-See the project [README](https://github.com/kloba/copilot-ralph-extension#readme) for the full reference until these pages are filled in.
+See the project [README](https://github.com/kloba/autopilot#readme) for the full reference until these pages are filled in.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,7 +1,7 @@
 # Recipes
 
 !!! note "Stub page (issue #2)"
-    Scaffold only — to be expanded in follow-ups. See the [README](https://github.com/kloba/copilot-ralph-extension#readme) until this page is filled in.
+    Scaffold only — to be expanded in follow-ups. See the [README](https://github.com/kloba/autopilot#readme) until this page is filled in.
 
 Planned recipes:
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -6,5 +6,5 @@
 This page will eventually feature:
 
 - Recorded demos of long Ralph runs
-- Live dashboard screenshots (see [issue #6](https://github.com/kloba/copilot-ralph-extension/issues/6))
+- Live dashboard screenshots (see [issue #6](https://github.com/kloba/autopilot/issues/6))
 - Real-world projects built or maintained by Ralph

--- a/extension/events-emit.mjs
+++ b/extension/events-emit.mjs
@@ -8,8 +8,8 @@
 // The TUI only consumes whatever lines do land on disk.
 
 import { homedir } from "node:os";
-import { mkdirSync, appendFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, appendFileSync, readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
 
 // Hard cap on a single serialized event line. Excerpts/tokens are
 // truncated to fit so a runaway prompt can't blow up the JSONL file.
@@ -27,23 +27,86 @@ const MAX_EVENT_LINE_BYTES = 16 * 1024;
 // and asserts they agree.
 const MAX_EXCERPT_CHARS = 500;
 
-/** Resolve the runs root, honoring $RALPH_EVENTS_DIR.
+// Print a one-line stderr deprecation notice the FIRST time a given
+// migration trigger fires, then drop a sentinel line under
+// ~/.copilot/autopilot/ so subsequent runs (in this or any later
+// process) stay silent. The sentinel file accumulates one line per
+// distinct `key`, so an environment that hits both the legacy env
+// var and the legacy default path eventually quiets both. Best-
+// effort: every fs/stderr call is try/caught so a read-only home
+// (CI cache, sandbox, etc.) cannot crash the loop.
+function emitDeprecationOnce({ key, message, sentinelPath, fs, stderr }) {
+    try {
+        const content = fs.readFileSync(sentinelPath, "utf8");
+        if (content.split("\n").some((l) => l === key)) return;
+    } catch { /* sentinel missing or unreadable */ }
+    try {
+        stderr.write(message);
+        fs.mkdirSync(dirname(sentinelPath), { recursive: true });
+        fs.appendFileSync(sentinelPath, key + "\n");
+    } catch { /* best-effort */ }
+}
+
+/** Resolve the runs root, preferring $AUTOPILOT_EVENTS_DIR, falling back to
+ *  $RALPH_EVENTS_DIR (deprecated), then to the new default
+ *  ~/.copilot/autopilot/events. If the new default doesn't exist but the old
+ *  ~/.copilot/ralph/runs does, returns the old path with a one-time stderr
+ *  deprecation notice (sentinel-gated under ~/.copilot/autopilot/).
  *
- * The env-var path is `.trim()`-ed before being returned: shells routinely
- * leak trailing whitespace into env vars (heredoc redirects, copy-pasted
- * lines, `RALPH_EVENTS_DIR="$HOME/runs "` from a Makefile), and a path with
- * stray leading/trailing spaces would silently create a runs root with
- * literal spaces in its name — surprising the user and breaking the matching
- * `ralph-tui list` glob. Trimming makes the override robust to that
- * common-shell-papercut without affecting any legitimate use case (paths
- * with intentional surrounding whitespace are essentially never real).
+ * The env-var path is `.trim()`-ed before being returned (same reasoning
+ * as before: trailing whitespace from shell heredocs, Makefile vars, etc.).
  */
-export function resolveRunsRoot(env = process.env) {
-    const override = env?.RALPH_EVENTS_DIR;
-    if (override && typeof override === "string" && override.trim()) {
-        return override.trim();
+export function resolveRunsRoot({
+    env = process.env,
+    os: osArg = { homedir },
+    path: pathArg = { join, dirname },
+    fs: fsArg = { readFileSync, appendFileSync, mkdirSync, existsSync },
+    stderr: stderrArg = process.stderr,
+    sentinelPath: sentinelPathArg,
+} = {}) {
+    const home = osArg.homedir();
+    const pJoin = pathArg.join ?? join;
+    const sentinelPath = sentinelPathArg ?? pJoin(home, ".copilot", "autopilot", ".migration-notice-shown");
+
+    // Primary: $AUTOPILOT_EVENTS_DIR
+    const newOverride = env?.AUTOPILOT_EVENTS_DIR;
+    if (typeof newOverride === "string" && newOverride.trim()) return newOverride.trim();
+
+    // Legacy fallback: $RALPH_EVENTS_DIR (deprecated)
+    const legacyOverride = env?.RALPH_EVENTS_DIR;
+    if (typeof legacyOverride === "string" && legacyOverride.trim()) {
+        emitDeprecationOnce({
+            key: "env:RALPH_EVENTS_DIR",
+            message: "[autopilot] note: env $RALPH_EVENTS_DIR is deprecated, please use $AUTOPILOT_EVENTS_DIR (still honored)\n",
+            sentinelPath,
+            fs: fsArg,
+            stderr: stderrArg,
+        });
+        return legacyOverride.trim();
     }
-    return join(homedir(), ".copilot", "ralph", "runs");
+
+    // Default paths
+    const newDefault = pJoin(home, ".copilot", "autopilot", "events");
+    const oldDefault = pJoin(home, ".copilot", "ralph", "runs");
+
+    // If new default doesn't exist but old does, fall back with a notice
+    let newExists = false;
+    let oldExists = false;
+    try { newExists = fsArg.existsSync(newDefault); } catch { /* swallow */ }
+    try { oldExists = fsArg.existsSync(oldDefault); } catch { /* swallow */ }
+
+    if (!newExists && oldExists) {
+        emitDeprecationOnce({
+            key: `path:${oldDefault}`,
+            message: `[autopilot] note: reading from legacy ~/.copilot/ralph/runs (default is now ~/.copilot/autopilot/events)\n`,
+            sentinelPath,
+            fs: fsArg,
+            stderr: stderrArg,
+        });
+        return oldDefault;
+    }
+
+    return newDefault;
 }
 
 /** `${label}-${startedAt}` — stable, sortable, file-system safe.
@@ -120,7 +183,7 @@ function serialize(ev) {
 export function createEventEmitter({ label, startedAt, env, fs } = {}) {
     const _mkdir = fs?.mkdirSync ?? mkdirSync;
     const _append = fs?.appendFileSync ?? appendFileSync;
-    const root = resolveRunsRoot(env ?? process.env);
+    const root = resolveRunsRoot({ env: env ?? process.env });
     const runId = makeRunId(label, startedAt);
     const dir = join(root, runId);
     const eventsPath = join(dir, "events.jsonl");

--- a/extension/events-emit.mjs
+++ b/extension/events-emit.mjs
@@ -1,4 +1,4 @@
-// Zero-dep JSONL event emitter for ralph_loop / self_improve / grow_project
+// Zero-dep JSONL event emitter for ap_loop / self_improve / grow_project
 // (issue #22). Mirrors the contract in packages/tui/src/{events,writer}.mjs
 // but lives here next to handler.mjs so install.sh can copy it next to
 // extension.mjs without dragging in the whole packages/tui workspace.
@@ -51,13 +51,13 @@ export function resolveRunsRoot(env = process.env) {
  * Lenient by design: this module's contract is "swallow every error
  * so the loop keeps running". A non-finite `startedAt` (undefined /
  * NaN / Infinity / string) would otherwise stringify to e.g.
- * `"ralph_loop-undefined"` and every subsequent invocation with the
+ * `"ap_loop-undefined"` and every subsequent invocation with the
  * same defect would collide on the same per-run directory, silently
  * overwriting events. Substitute `Date.now()` instead so each call
  * still gets a unique, sortable id even under degraded input.
  */
 export function makeRunId(label, startedAt) {
-    const safeLabel = String(label || "ralph_loop").replace(/[^A-Za-z0-9_-]/g, "_");
+    const safeLabel = String(label || "ap_loop").replace(/[^A-Za-z0-9_-]/g, "_");
     const safeTs = Number.isFinite(startedAt) ? startedAt : Date.now();
     return `${safeLabel}-${safeTs}`;
 }
@@ -111,7 +111,7 @@ function serialize(ev) {
  *   - close(): no-op today; reserved for future buffered backends.
  *
  * @param {Object} args
- * @param {string} args.label       Loop kind: ralph_loop | self_improve | grow_project.
+ * @param {string} args.label       Loop kind: ap_loop | self_improve | grow_project.
  * @param {number} args.startedAt   armLoop's Date.now() snapshot.
  * @param {Object} [args.env]       Override process.env (tests).
  * @param {Object} [args.fs]        { mkdirSync, appendFileSync } overrides (tests).

--- a/extension/extension.mjs
+++ b/extension/extension.mjs
@@ -9,7 +9,7 @@ const controller = createRalphController({ events: true });
 
 // joinSession / attach can fail (SDK version mismatch, missing session
 // methods). Without a try/catch the rejection becomes an unhandled
-// promise rejection at module-load and the user sees neither ralph_loop
+// promise rejection at module-load and the user sees neither ap_loop
 // in /extensions nor any clue why. Emit stderr and rethrow.
 function fatal(stage, err) {
     const msg = err && err.message ? err.message : String(err);

--- a/extension/extension.mjs
+++ b/extension/extension.mjs
@@ -1,4 +1,4 @@
-// Extension: ralph
+// Extension: autopilot
 // Hook/event-driven autonomous iterative loop for GitHub Copilot CLI.
 // Inspired by the Stop-hook re-injection pattern.
 
@@ -13,7 +13,7 @@ const controller = createRalphController({ events: true });
 // in /extensions nor any clue why. Emit stderr and rethrow.
 function fatal(stage, err) {
     const msg = err && err.message ? err.message : String(err);
-    process.stderr.write(`ralph extension: failed to ${stage}: ${msg}\n`);
+    process.stderr.write(`autopilot extension: failed to ${stage}: ${msg}\n`);
     throw err;
 }
 

--- a/extension/extension.mjs
+++ b/extension/extension.mjs
@@ -1,5 +1,5 @@
 // Extension: ralph
-// Hook/event-driven Ralph Wiggum iterative loop for GitHub Copilot CLI.
+// Hook/event-driven autonomous iterative loop for GitHub Copilot CLI.
 // Inspired by the Stop-hook re-injection pattern.
 
 import { joinSession } from "@github/copilot-sdk/extension";

--- a/extension/handler.mjs
+++ b/extension/handler.mjs
@@ -1,4 +1,4 @@
-// Hook/event-driven Ralph Wiggum controller for Copilot CLI.
+// Hook/event-driven autonomous-loop controller for Copilot CLI.
 //
 // Architecture: the ralph_loop tool returns immediately after arming the loop.
 // Iterations are driven by listening to `session.idle` events (the root
@@ -1843,7 +1843,7 @@ export function createRalphController(opts = {}) {
         {
             name: "ralph_loop",
             description:
-                `Run a Ralph Wiggum-style autonomous iterative loop. The tool returns immediately after arming the loop; iterations are driven by reacting to each session.idle (root-agent agentic-loop completion) and re-injecting the prompt as a new user message. Each iteration is a real conversation turn — context is retained, and progress is visible inline. Use ralph_stop to cancel an active loop. Tip: instruct the agent in the prompt to emit the completion_promise (default '${DEFAULTS.completion_promise}') when finished, otherwise the loop only stops at max_iterations. Only one loop runs per session; returns failure if a ralph_loop, self_improve, or grow_project loop is already active. Note: the user-supplied prompt is augmented at arm time with a small commit-attribution rider that adds dual Co-authored-by trailers (Copilot + copilot-ralph) to any git commit produced during the loop; set RALPH_NO_ATTRIBUTION=1 in the environment to suppress the second trailer.`,
+                `Run an autonomous iterative loop. The tool returns immediately after arming the loop; iterations are driven by reacting to each session.idle (root-agent agentic-loop completion) and re-injecting the prompt as a new user message. Each iteration is a real conversation turn — context is retained, and progress is visible inline. Use ralph_stop to cancel an active loop. Tip: instruct the agent in the prompt to emit the completion_promise (default '${DEFAULTS.completion_promise}') when finished, otherwise the loop only stops at max_iterations. Only one loop runs per session; returns failure if a ralph_loop, self_improve, or grow_project loop is already active. Note: the user-supplied prompt is augmented at arm time with a small commit-attribution rider that adds dual Co-authored-by trailers (Copilot + copilot-ralph) to any git commit produced during the loop; set RALPH_NO_ATTRIBUTION=1 in the environment to suppress the second trailer.`,
             parameters: {
                 type: "object",
                 properties: {

--- a/extension/handler.mjs
+++ b/extension/handler.mjs
@@ -1,6 +1,6 @@
 // Hook/event-driven autonomous-loop controller for Copilot CLI.
 //
-// Architecture: the ralph_loop tool returns immediately after arming the loop.
+// Architecture: the ap_loop tool returns immediately after arming the loop.
 // Iterations are driven by listening to `session.idle` events (the root
 // agent's "agentic loop fully done" signal) and re-injecting the prompt via
 // `session.send` (fire-and-forget). Using `session.idle` rather than
@@ -24,7 +24,7 @@ import {
 } from "./prompts.mjs";
 
 // Lazy-resolved sync `require` so we can pull child_process only when needed
-// (caffeinate when enabled, git for ralph_status / adaptive-budget, etc.)
+// (caffeinate when enabled, git for ap_status / adaptive-budget, etc.)
 // without paying the import cost up front.
 const moduleRequire = createRequire(import.meta.url);
 
@@ -119,9 +119,9 @@ const DEFAULTS = Object.freeze({
     // to min(max_iterations * 5, MAX_ALLOWED_ITERATIONS) at validation time
     // so the ceiling scales with the user's chosen base budget.
 });
-// self_improve has different max/min defaults than ralph_loop because the
+// self_improve has different max/min defaults than ap_loop because the
 // SDLC loop is meant to run long-haul (whole-repo polish across many
-// categories), while ralph_loop is a generic primitive that often arms
+// categories), while ap_loop is a generic primitive that often arms
 // short, targeted runs. Extract them here so the schema's `default:` hints
 // and the handler's `?? <fallback>` use the SAME source of truth.
 const SELF_IMPROVE_DEFAULTS = Object.freeze({
@@ -175,7 +175,7 @@ const MODEL_CONTEXT_WINDOWS = Object.freeze({
 
 // Issue #7: warning thresholds (percent of context window). Pre-baked
 // so we can iterate a small array instead of computing both edges
-// inline. 95% is the "stronger" warning that suggests ralph_stop.
+// inline. 95% is the "stronger" warning that suggests ap_stop.
 const TOKEN_WARNING_THRESHOLDS = Object.freeze([80, 95]);
 
 
@@ -227,16 +227,16 @@ const BAKED_COPILOT_TRAILER = "Co-authored-by: Copilot <223556219+Copilot@users.
 const BAKED_RALPH_TRAILER = "Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>";
 const BAKED_ATTRIBUTION_OPT_OUT = "RALPH_NO_ATTRIBUTION=1";
 
-// Issue #1 (ralph_loop parity): unlike self_improve / grow_project which
-// embed the COMMIT stage in their full baked SDLC prompt, ralph_loop takes
+// Issue #1 (ap_loop parity): unlike self_improve / grow_project which
+// embed the COMMIT stage in their full baked SDLC prompt, ap_loop takes
 // a user-supplied `prompt` and re-injects it verbatim every iteration. To
 // keep the dual-trailer attribution contract symmetric across all three
-// loop tools, the ralph_loop handler appends this rider to the user's
+// loop tools, the ap_loop handler appends this rider to the user's
 // prompt at arm time. The rider is short on purpose — it ships once per
 // re-injected message and adds to context on every iteration. Worded as
 // a "Controller requirement" so a user prompt that omits commit
 // instructions does not appear to override it; explicitly inert when no
-// commit is created so generic ralph_loop tasks (e.g. log analysis) are
+// commit is created so generic ap_loop tasks (e.g. log analysis) are
 // unaffected.
 const BAKED_RALPH_LOOP_RIDER = `---
 CONTROLLER REQUIREMENT — commit attribution: if this iteration produces any git commit, append BOTH Co-authored-by trailers in this exact order at the end of the commit message (separated from the body by a blank line):
@@ -264,7 +264,7 @@ for (const [label, prompt] of [
 }
 
 // Append the dual-trailer commit-attribution rider to a user-supplied
-// ralph_loop prompt. Returns `{value}` on success or `{error}` when the
+// ap_loop prompt. Returns `{value}` on success or `{error}` when the
 // composed prompt would exceed MAX_PROMPT_CHARS — the rider eats roughly
 // 600 of the 65 536-char budget, so callers near the cap need a clear
 // signal instead of a silent overshoot. The separator is part of the
@@ -275,7 +275,7 @@ function composeRalphLoopPrompt(userPrompt) {
     if (composed.length > MAX_PROMPT_CHARS) {
         const reserved = separator.length + BAKED_RALPH_LOOP_RIDER.length;
         return {
-            error: `ralph_loop: prompt + commit-attribution rider exceeds ${MAX_PROMPT_CHARS} characters (got ${composed.length}; ${reserved} chars reserved for the rider). Shorten the prompt by at least ${composed.length - MAX_PROMPT_CHARS} character${composed.length - MAX_PROMPT_CHARS === 1 ? "" : "s"}.`,
+            error: `ap_loop: prompt + commit-attribution rider exceeds ${MAX_PROMPT_CHARS} characters (got ${composed.length}; ${reserved} chars reserved for the rider). Shorten the prompt by at least ${composed.length - MAX_PROMPT_CHARS} character${composed.length - MAX_PROMPT_CHARS === 1 ? "" : "s"}.`,
         };
     }
     return { value: composed };
@@ -328,8 +328,8 @@ function boundedNoteForLog(text) {
     return collapseNote(truncateNote(text));
 }
 
-// Shared normalizer for the optional `reason` argument of ralph_pause +
-// ralph_stop. Returns the canonical single-line, length-capped form, or
+// Shared normalizer for the optional `reason` argument of ap_pause +
+// ap_stop. Returns the canonical single-line, length-capped form, or
 // `null` when the caller supplied nothing / a non-string / a value that
 // is empty after whitespace flattening. Centralising the logic prevents
 // drift between the two tools — both store `reason` on long-lived state
@@ -357,7 +357,7 @@ function deepFreeze(obj) {
 // manual clock change, daylight savings on a host without monotonic-
 // time backing) cannot credit a negative window. Returns 0 when
 // `pausedAt` is the never-paused sentinel (0). Centralised so all
-// three call sites (finish(), ralph_status, ralph_resume) share the
+// three call sites (finish(), ap_status, ap_resume) share the
 // same skew-guard contract — pre-iter-155 the resume site had drifted
 // to an unclamped form (fixed in iter 154); having one helper makes
 // that drift mechanically impossible to reintroduce.
@@ -412,7 +412,7 @@ function caffeinateFlagsForScope(scope) {
  * @param {number} deps.pid - host process pid (for `-w`)
  * @param {Function} deps.spawnFn - child_process.spawn-compatible
  * @param {(msg: string) => void} deps.log
- * @param {string} deps.label - "ralph_loop" | "self_improve" | "grow_project"
+ * @param {string} deps.label - "ap_loop" | "self_improve" | "grow_project"
  * @returns {(() => void) | null}
  */
 function startCaffeinate({ env, platform, pid, spawnFn, log, label }) {
@@ -452,7 +452,7 @@ function startCaffeinate({ env, platform, pid, spawnFn, log, label }) {
 
 // git snapshot / status helpers (issue #5)
 //
-// `ralph_status` needs to report files changed since the loop was armed.
+// `ap_status` needs to report files changed since the loop was armed.
 // We capture HEAD at arm-time and diff against it on demand. All git calls
 // are best-effort: if the repo isn't a git repo, the binary is missing, or
 // any individual call fails, the corresponding status field is omitted with
@@ -468,7 +468,7 @@ const GIT_TIMEOUT_MS = 2000;
  * @returns {{ ok: boolean, stdout: string, stderr: string, code: number|null }}
  */
 // Shared spawnSync wrapper for the two production gitExec entry points
-// (defaultGitExec for ralph_status / armLoop diagnostics, and
+// (defaultGitExec for ap_status / armLoop diagnostics, and
 // defaultAdaptiveGitExec for the end-of-iteration adaptive-budget
 // signal evaluation). Both call sites need the same total-function
 // guarantees:
@@ -638,7 +638,7 @@ function defaultAdaptiveGitExec(args, cwd) {
     // Adaptive-budget evaluation runs synchronously inside onIdle and
     // is best-effort; a stuck git invocation must not stall the loop.
     // Hence the tighter ADAPTIVE_GIT_TIMEOUT_MS budget vs the
-    // ralph_status default. Shape is identical to defaultGitExec
+    // ap_status default. Shape is identical to defaultGitExec
     // (including the `code` field — `evaluateAdaptiveSignals` only
     // reads `.ok` / `.stdout`, so the extra field is harmless and
     // keeps both entry points to a single helper).
@@ -700,12 +700,12 @@ function isSubAgentEvent(ev) {
  * @typedef {Object} RalphResult
  * @property {string} reason - One of: completion_promise, abort_promise, stagnation, max_iterations, send_error, aborted, user_stopped, detached.
  * @property {number} iterations - Number of iterations completed (post-fire count).
- * @property {string} label - Tool that armed the loop ("ralph_loop", "self_improve", or "grow_project"). Used for the post-loop additionalContext bracket and the "<verb> <label> after N iterations" finish log line.
- * @property {string} preview - Up to PREVIEW_CHARS (500) chars of the LAST iteration's accumulated assistant content. If the content was longer, an ellipsis ("…") is appended (so the truncated form is 501 chars). If finish runs before any iteration produced output (e.g. send_error before iter 1, or ralph_stop right after arm), this is the empty string. Surrogate-safe — never ends on a lone high surrogate.
+ * @property {string} label - Tool that armed the loop ("ap_loop", "self_improve", or "grow_project"). Used for the post-loop additionalContext bracket and the "<verb> <label> after N iterations" finish log line.
+ * @property {string} preview - Up to PREVIEW_CHARS (500) chars of the LAST iteration's accumulated assistant content. If the content was longer, an ellipsis ("…") is appended (so the truncated form is 501 chars). If finish runs before any iteration produced output (e.g. send_error before iter 1, or ap_stop right after arm), this is the empty string. Surrogate-safe — never ends on a lone high surrogate.
  * @property {number} startedAt - Epoch ms when the loop was armed.
  * @property {number} finishedAt - Epoch ms when the loop finished.
  * @property {number} durationMs - Elapsed wall-clock ms from arming to finish, clamped to ≥ 0 (a backward clock jump mid-loop reports 0 instead of a negative).
- * @property {string} [note] - Optional human-readable context: caller-supplied via ralph_stop({reason}), or the underlying error message on send_error, or the SDK abort reason on aborted. Truncated silently to PREVIEW_CHARS (500) (surrogate-safe) — no "…" indicator is appended (unlike `preview`). Notes are flowed inline into single-line log markers and the post-loop additionalContext bracket, where a trailing "…" would be misread as part of the message.
+ * @property {string} [note] - Optional human-readable context: caller-supplied via ap_stop({reason}), or the underlying error message on send_error, or the SDK abort reason on aborted. Truncated silently to PREVIEW_CHARS (500) (surrogate-safe) — no "…" indicator is appended (unlike `preview`). Notes are flowed inline into single-line log markers and the post-loop additionalContext bracket, where a trailing "…" would be misread as part of the message.
  */
 
 // Type name for error messages: distinguishes null/array from generic
@@ -750,7 +750,7 @@ function validateArgShape(toolName, args, knownKeys) {
 }
 
 // Variant of validateArgShape used by tools where "no args" is a valid
-// call (ralph_stop, self_improve, grow_project — all three have only
+// call (ap_stop, self_improve, grow_project — all three have only
 // optional fields). Treats null/undefined as "use defaults" and returns
 // a ready-to-return `failure(...)` result on bad shape, so the caller's
 // call site is just
@@ -762,7 +762,7 @@ function validateOptionalArgShape(label, args, knownKeys) {
     return shape ? failure(shape.error) : null;
 }
 
-// Shared `reason` type-guard for ralph_stop / ralph_pause. Both tools
+// Shared `reason` type-guard for ap_stop / ap_pause. Both tools
 // expose an identical optional `reason: string` parameter that
 // parseUserReason silently coerces non-strings to null. Without this
 // guard a buggy caller passing `reason: 42` (or `reason: false`, or a
@@ -780,24 +780,24 @@ function validateOptionalReasonField(toolName, args) {
 }
 
 // Single source of truth for the "no active loop" failure surfaced by
-// ralph_stop / ralph_pause / ralph_resume (and any future loop-mutating
+// ap_stop / ap_pause / ap_resume (and any future loop-mutating
 // tool). Centralising the wording prevents drift across handlers — every
 // caller uses the same exact string, which downstream tests + agent
 // prompts can pattern-match against without brittle per-tool variants.
 function noActiveLoopFailure(tool) {
-    return failure(`${tool}: no ralph_loop, self_improve, or grow_project is currently running.`);
+    return failure(`${tool}: no ap_loop, self_improve, or grow_project is currently running.`);
 }
 
 // self_improve and grow_project both delegate validation to validateArgs()
-// (which prefixes errors with "ralph_loop:") and then re-prefix the result
+// (which prefixes errors with "ap_loop:") and then re-prefix the result
 // with their own tool name so the user sees the actual tool they called in
 // the error stream. Centralise the swap so a future validation path that
-// forgets the "ralph_loop:" prefix still surfaces the right tool name —
+// forgets the "ap_loop:" prefix still surfaces the right tool name —
 // and so adding a new wrapper tool ("ralph_replay" etc.) inherits the
 // behaviour for free.
 function reprefixRalphLoopError(error, toolName) {
-    return error.startsWith("ralph_loop:")
-        ? error.replace(/^ralph_loop:/, `${toolName}:`)
+    return error.startsWith("ap_loop:")
+        ? error.replace(/^ap_loop:/, `${toolName}:`)
         : `${toolName}: ${error}`;
 }
 
@@ -817,10 +817,10 @@ const RALPH_LOOP_KEYS = new Set([
 const RALPH_STOP_KEYS = new Set(["reason"]);
 const RALPH_PAUSE_KEYS = new Set(["reason"]);
 const RALPH_RESUME_KEYS = new Set([]);
-// ralph_status accepts no arguments. A frozen module-level
+// ap_status accepts no arguments. A frozen module-level
 // constant keeps the call site symmetrical with every other
 // tool's `validateOptionalArgShape(..., RALPH_*_KEYS)` call and
-// avoids allocating a fresh empty Set per ralph_status invocation
+// avoids allocating a fresh empty Set per ap_status invocation
 // (cheap, but the consistency is the point — drift is the bug).
 const RALPH_STATUS_KEYS = new Set([]);
 const SELF_IMPROVE_KEYS = new Set([
@@ -868,15 +868,15 @@ function parseFocus(raw, toolName = "self_improve") {
 // ", when provided," into abort_promise's empty error (it has no default).
 function validatePromiseField(fieldName, raw, { whenProvided = false } = {}) {
     if (typeof raw !== "string") {
-        return { error: `ralph_loop: ${fieldName} must be a string (got ${describeArgType(raw)}).` };
+        return { error: `ap_loop: ${fieldName} must be a string (got ${describeArgType(raw)}).` };
     }
     const trimmed = raw.trim();
     if (!trimmed) {
         const interjection = whenProvided ? ", when provided," : "";
-        return { error: `ralph_loop: ${fieldName}${interjection} must contain at least one non-whitespace character.` };
+        return { error: `ap_loop: ${fieldName}${interjection} must contain at least one non-whitespace character.` };
     }
     if (raw.length > MAX_PROMISE_CHARS) {
-        return { error: `ralph_loop: ${fieldName} exceeds ${MAX_PROMISE_CHARS} characters (got ${raw.length}). Use a short signal phrase.` };
+        return { error: `ap_loop: ${fieldName} exceeds ${MAX_PROMISE_CHARS} characters (got ${raw.length}). Use a short signal phrase.` };
     }
     return { value: trimmed };
 }
@@ -892,35 +892,35 @@ function resolveOptionalPromise(fieldName, raw, fallback, opts) {
 // Range validation stays at the call site since each field's bounds differ.
 function coerceNumberField(fieldName, raw) {
     if (typeof raw !== "number" && typeof raw !== "string") {
-        return { error: `ralph_loop: ${fieldName} must be a number (got ${describeArgType(raw)}).` };
+        return { error: `ap_loop: ${fieldName} must be a number (got ${describeArgType(raw)}).` };
     }
     return { value: Number(raw) };
 }
 
 /**
- * Validate ralph_loop arguments.
+ * Validate ap_loop arguments.
  *
  * @param {RalphArgs} args
  * @returns {{value: object} | {error: string}} Validated values or a single human-readable error.
  */
 export function validateArgs(args) {
-    const shape = validateArgShape("ralph_loop", args, RALPH_LOOP_KEYS);
+    const shape = validateArgShape("ap_loop", args, RALPH_LOOP_KEYS);
     if (shape) return shape;
     if (args.prompt !== undefined && args.prompt !== null && typeof args.prompt !== "string") {
-        return { error: `ralph_loop: prompt must be a string (got ${describeArgType(args.prompt)}).` };
+        return { error: `ap_loop: prompt must be a string (got ${describeArgType(args.prompt)}).` };
     }
     const prompt = (args.prompt ?? "").trim();
     if (!prompt) {
         // Distinguish "missing" from "whitespace-only" — the latter
         // usually signals a templating bug (variable interpolated to "").
         if (!args.prompt) {
-            return { error: "ralph_loop: prompt is required and must be non-empty." };
+            return { error: "ap_loop: prompt is required and must be non-empty." };
         }
-        return { error: "ralph_loop: prompt must contain at least one non-whitespace character (got a whitespace-only string)." };
+        return { error: "ap_loop: prompt must contain at least one non-whitespace character (got a whitespace-only string)." };
     }
     if (prompt.length > MAX_PROMPT_CHARS) {
         return {
-            error: `ralph_loop: prompt exceeds ${MAX_PROMPT_CHARS} characters (got ${prompt.length}). Shorten the prompt or split the work.`,
+            error: `ap_loop: prompt exceeds ${MAX_PROMPT_CHARS} characters (got ${prompt.length}). Shorten the prompt or split the work.`,
         };
     }
 
@@ -930,7 +930,7 @@ export function validateArgs(args) {
     const max = maxC.value;
     if (!Number.isInteger(max) || max < 1 || max > MAX_ALLOWED_ITERATIONS) {
         return {
-            error: `ralph_loop: max_iterations must be an integer in [1, ${MAX_ALLOWED_ITERATIONS}] (got ${displayValue(rawMax)}).`,
+            error: `ap_loop: max_iterations must be an integer in [1, ${MAX_ALLOWED_ITERATIONS}] (got ${displayValue(rawMax)}).`,
         };
     }
 
@@ -940,7 +940,7 @@ export function validateArgs(args) {
     const min = minC.value;
     if (!Number.isInteger(min) || min < 1 || min > max) {
         return {
-            error: `ralph_loop: min_iterations must be an integer in [1, max_iterations=${max}] (got ${displayValue(rawMin)}).`,
+            error: `ap_loop: min_iterations must be an integer in [1, max_iterations=${max}] (got ${displayValue(rawMin)}).`,
         };
     }
 
@@ -955,12 +955,12 @@ export function validateArgs(args) {
     if (abortPromise !== null) {
         if (abortPromise === completionPromise) {
             return {
-                error: `ralph_loop: abort_promise must differ from completion_promise (both are ${JSON.stringify(completionPromise)} — the signal would be ambiguous).`,
+                error: `ap_loop: abort_promise must differ from completion_promise (both are ${JSON.stringify(completionPromise)} — the signal would be ambiguous).`,
             };
         }
         if (abortPromise.includes(completionPromise) || completionPromise.includes(abortPromise)) {
             return {
-                error: `ralph_loop: completion_promise (${JSON.stringify(completionPromise)}) and abort_promise (${JSON.stringify(abortPromise)}) overlap as substrings — whichever check runs first will always fire. Pick disjoint phrases.`,
+                error: `ap_loop: completion_promise (${JSON.stringify(completionPromise)}) and abort_promise (${JSON.stringify(abortPromise)}) overlap as substrings — whichever check runs first will always fire. Pick disjoint phrases.`,
             };
         }
     }
@@ -971,7 +971,7 @@ export function validateArgs(args) {
     const stagnationLimit = stagC.value;
     if (!Number.isInteger(stagnationLimit) || stagnationLimit < 0 || stagnationLimit === 1) {
         return {
-            error: `ralph_loop: stagnation_limit must be 0 (disabled) or an integer ≥ 2 (got ${displayValue(rawStagnation)}). 1 is meaningless because no comparison is possible after a single response.`,
+            error: `ap_loop: stagnation_limit must be 0 (disabled) or an integer ≥ 2 (got ${displayValue(rawStagnation)}). 1 is meaningless because no comparison is possible after a single response.`,
         };
     }
 
@@ -985,7 +985,7 @@ export function validateArgs(args) {
         if (mtC.error) return mtC;
         if (!Number.isInteger(mtC.value) || mtC.value < 1 || mtC.value > 1_000_000_000) {
             return {
-                error: `ralph_loop: max_tokens must be a positive integer ≤ 1e9 (got ${displayValue(args.max_tokens)}).`,
+                error: `ap_loop: max_tokens must be a positive integer ≤ 1e9 (got ${displayValue(args.max_tokens)}).`,
             };
         }
         maxTokens = mtC.value;
@@ -1000,7 +1000,7 @@ export function validateArgs(args) {
     const warnAtPct = wpC.value;
     if (!Number.isInteger(warnAtPct) || warnAtPct < 1 || warnAtPct > 99) {
         return {
-            error: `ralph_loop: warn_at_pct must be an integer in [1, 99] (got ${displayValue(rawWarnPct)}).`,
+            error: `ap_loop: warn_at_pct must be an integer in [1, 99] (got ${displayValue(rawWarnPct)}).`,
         };
     }
 
@@ -1019,7 +1019,7 @@ export function validateArgs(args) {
     let adaptiveBudget = DEFAULTS.adaptive_budget;
     if (rawAdaptive !== undefined && rawAdaptive !== null) {
         if (typeof rawAdaptive !== "boolean") {
-            return { error: `ralph_loop: adaptive_budget must be a boolean (got ${describeArgType(rawAdaptive)}).` };
+            return { error: `ap_loop: adaptive_budget must be a boolean (got ${describeArgType(rawAdaptive)}).` };
         }
         adaptiveBudget = rawAdaptive;
     }
@@ -1036,10 +1036,10 @@ export function validateArgs(args) {
         if (c.error) return c;
         const v = c.value;
         if (!Number.isFinite(v)) {
-            return { error: `ralph_loop: ${fieldName} must be a finite number (got ${displayValue(raw)}).` };
+            return { error: `ap_loop: ${fieldName} must be a finite number (got ${displayValue(raw)}).` };
         }
         if (adaptiveBudget && (!Number.isInteger(v) || v < lo || v > MAX_ALLOWED_ITERATIONS)) {
-            return { error: `ralph_loop: ${fieldName} must be an integer in [${loLabel}, ${MAX_ALLOWED_ITERATIONS}] (got ${displayValue(raw)}).` };
+            return { error: `ap_loop: ${fieldName} must be an integer in [${loLabel}, ${MAX_ALLOWED_ITERATIONS}] (got ${displayValue(raw)}).` };
         }
         return { value: v };
     };
@@ -1058,7 +1058,7 @@ export function validateArgs(args) {
 /**
  * @typedef {Object} ActiveLoopState
  * @property {string} prompt - Validated, trimmed prompt re-fired each iteration.
- * @property {string} label - Tool that armed the loop ("ralph_loop", "self_improve", or "grow_project"). Stamps every per-iteration log line and the finish() log line with the calling tool's name.
+ * @property {string} label - Tool that armed the loop ("ap_loop", "self_improve", or "grow_project"). Stamps every per-iteration log line and the finish() log line with the calling tool's name.
  * @property {number} max - Hard iteration cap (1..MAX_ALLOWED_ITERATIONS).
  * @property {number} min - Iterations that must complete before completion/abort phrases are honored (1..max).
  * @property {string} completionPromise - Trimmed substring whose presence finishes with reason "completion_promise".
@@ -1082,9 +1082,9 @@ export function validateArgs(args) {
  * @property {number} adaptiveMaxTotal - Issue #4: hard ceiling regardless of extensions (≥ originalMax, ≤ MAX_ALLOWED_ITERATIONS).
  * @property {number} originalMax - Issue #4: snapshot of `max` at arm-time so logs/results can report the user-supplied vs effective budget.
  * @property {string[]} adaptiveContentHashes - Issue #4: rolling djb2 hashes of the last ADAPTIVE_WINDOW iterations' assistant content; powers the response-novelty signal.
- * @property {Array<{atIter: number, from: number, to: number, reason: string}>} adaptiveExtensionHistory - Issue #4: append-only log of every extension granted; surfaced in ralph_status and the finish result.
- * @property {boolean} paused - Issue #3: when true, onIdle short-circuits before firing the next iteration. Toggled by ralph_pause / ralph_resume.
- * @property {string|null} pauseReason - Issue #3: optional human-readable reason supplied to ralph_pause; surfaced in logs.
+ * @property {Array<{atIter: number, from: number, to: number, reason: string}>} adaptiveExtensionHistory - Issue #4: append-only log of every extension granted; surfaced in ap_status and the finish result.
+ * @property {boolean} paused - Issue #3: when true, onIdle short-circuits before firing the next iteration. Toggled by ap_pause / ap_resume.
+ * @property {string|null} pauseReason - Issue #3: optional human-readable reason supplied to ap_pause; surfaced in logs.
  * @property {number} pausedAt - Issue #3: epoch ms of the most recent pause; 0 when never paused.
  * @property {number} totalPausedMs - Issue #3: cumulative paused time across all pause/resume cycles, deducted from durationMs so wall-clock reflects active time.
  */
@@ -1114,14 +1114,14 @@ export function createRalphController(opts = {}) {
         pid: opts.caffeinate?.pid ?? process.pid,
         spawnFn: opts.caffeinate?.spawnFn ?? null,
     };
-    // Git dependency injection (issue #5). `ralph_status` calls gitExec(args)
+    // Git dependency injection (issue #5). `ap_status` calls gitExec(args)
     // synchronously; tests replace it with a stub that returns canned results.
     // `cwd` is captured at controller-build time so tests can pin a fake root.
     const gitCwd = opts.git?.cwd ?? process.cwd();
     const gitExecRaw = opts.git?.exec ?? ((args) => defaultGitExec(args, gitCwd));
     // Normalize a throwing gitExec into the same `{ ok: false, ... }` shape
     // that `defaultGitExec` produces on internal failure. This guarantees
-    // every call site (captureGitArmSnapshot, ralph_status's
+    // every call site (captureGitArmSnapshot, ap_status's
     // buildStatusSnapshot, computeFilesChangedBlock, etc.) can treat
     // gitExec as total — no need to wrap each call in try/catch and no
     // way for a misbehaving test injection (or a future production gitExec
@@ -1253,7 +1253,7 @@ export function createRalphController(opts = {}) {
         // so durationMs reflects ACTIVE runtime (matches the typedef:
         // "totalPausedMs ... deducted from durationMs so wall-clock
         // reflects active time"). If finish() fires while the loop is
-        // still paused (e.g. the user calls ralph_stop without resuming),
+        // still paused (e.g. the user calls ap_stop without resuming),
         // also subtract the not-yet-banked current pause window so the
         // result is consistent regardless of pause/resume cadence.
         const currentPauseMs = paused ? pauseElapsedFromAt(pausedAt, finishedAt) : 0;
@@ -1413,7 +1413,7 @@ export function createRalphController(opts = {}) {
                 const usedK = Math.round(used / 1000);
                 const winK = Math.round(window / 1000);
                 if (threshold === 95) {
-                    log(`${a.label}: ⚠ context window critical: ${usedK}k / ${winK}k tokens used (${pct.toFixed(1)}%, model ${usage.model}). Consider ralph_stop to avoid mid-iteration truncation.`);
+                    log(`${a.label}: ⚠ context window critical: ${usedK}k / ${winK}k tokens used (${pct.toFixed(1)}%, model ${usage.model}). Consider ap_stop to avoid mid-iteration truncation.`);
                 } else {
                     log(`${a.label}: ⚠ approaching context window: ${usedK}k / ${winK}k tokens used (${pct.toFixed(1)}%, model ${usage.model}). Consider stopping and restarting with a fresh session.`);
                 }
@@ -1430,7 +1430,7 @@ export function createRalphController(opts = {}) {
         if (isSubAgentEvent(ev)) return;
         // Issue #3 reliability: while paused, the user is chatting freely
         // with the agent — those messages MUST NOT mutate loop state.
-        // The companion ralph_resume reset of lastAssistantContent (iter
+        // The companion ap_resume reset of lastAssistantContent (iter
         // 57) only addressed the completion/abort contamination via
         // content accumulation; this guard additionally prevents pause-
         // time token usage from being credited to the loop's budget
@@ -1493,10 +1493,10 @@ export function createRalphController(opts = {}) {
         // Issue #3: if paused, stop here. The user may still chat freely
         // with the agent in this session — those turns reach the real
         // session.idle but we deliberately do nothing, leaving the loop
-        // counter untouched until ralph_resume re-arms.
+        // counter untouched until ap_resume re-arms.
         if (a.paused) return;
 
-        // The turn that *called* ralph_loop goes idle before any iteration runs.
+        // The turn that *called* ap_loop goes idle before any iteration runs.
         // Use that idle to fire iteration 1; evaluate completion/abort on later ones.
         if (a.pendingFire) {
             a.pendingFire = false;
@@ -1598,7 +1598,7 @@ export function createRalphController(opts = {}) {
     const onAbort = (ev) => {
         // Only react to root-agent aborts — see isSubAgentEvent() rationale.
         // A sub-agent that gets aborted (task / explore / rubber-duck
-        // failure) must NOT tear down the root ralph_loop along with it.
+        // failure) must NOT tear down the root ap_loop along with it.
         if (isSubAgentEvent(ev)) return;
         if (!state.active) return;
         // If the SDK supplies an abort reason in the event payload,
@@ -1622,13 +1622,13 @@ export function createRalphController(opts = {}) {
     }
 
     // Single source of truth for the "another loop is already active"
-    // refusal — used by ralph_loop, self_improve, and grow_project so
+    // refusal — used by ap_loop, self_improve, and grow_project so
     // the message and iteration-counter logic can never drift.
     //
     // Rendering priority: paused > pendingFire > running. A paused loop
     // would otherwise be reported as "running (iteration N/M)", which
-    // misleads the caller — "ralph_stop first" is still the right
-    // remedy, but a `ralph_resume` may also be appropriate, so the
+    // misleads the caller — "ap_stop first" is still the right
+    // remedy, but a `ap_resume` may also be appropriate, so the
     // status string must mention the pause explicitly.
     function activeLoopGuard() {
         if (!state.active) return null;
@@ -1641,16 +1641,16 @@ export function createRalphController(opts = {}) {
         } else {
             status = `running (iteration ${i}/${max})`;
         }
-        return failure(`${state.active.label} is already ${status} — call ralph_stop first.`);
+        return failure(`${state.active.label} is already ${status} — call ap_stop first.`);
     }
 
-    // Shared arming body for ralph_loop, self_improve, and grow_project.
+    // Shared arming body for ap_loop, self_improve, and grow_project.
     // Caller is responsible for the session-attached and already-active
     // guards plus arg validation; this helper mutates state.active and
     // emits the arm log + success result. The `label` is woven through
     // state.active.label, the arm log line, and the success text so
     // every observable artifact reflects which tool armed the loop.
-    function armLoop(parsedValue, label = "ralph_loop") {
+    function armLoop(parsedValue, label = "ap_loop") {
         // Resolve spawnFn lazily so child_process is only required when
         // caffeinate is actually enabled (avoids paying the require cost
         // for every loop arm). Tests inject spawnFn directly via opts.
@@ -1668,7 +1668,7 @@ export function createRalphController(opts = {}) {
             log,
             label,
         });
-        // Snapshot git HEAD/branch at arm-time for ralph_status's
+        // Snapshot git HEAD/branch at arm-time for ap_status's
         // "files changed since loop started" diff. Best-effort — a non-git
         // cwd just means status reports null for the git block.
         const armedGit = captureGitArmSnapshot(gitExec, gitCwd);
@@ -1733,7 +1733,7 @@ export function createRalphController(opts = {}) {
             ts: startedAt,
         });
         return success(
-            `${label} armed (max=${max}${min > 1 ? `, min=${min}` : ""}${adaptiveBudget ? `, adaptive_max_total=${adaptiveMaxTotal}` : ""}). Iterations will run as conversation turns. Use ralph_stop to cancel.`,
+            `${label} armed (max=${max}${min > 1 ? `, min=${min}` : ""}${adaptiveBudget ? `, adaptive_max_total=${adaptiveMaxTotal}` : ""}). Iterations will run as conversation turns. Use ap_stop to cancel.`,
             { armed: true, max, min, adaptive_budget: adaptiveBudget, adaptive_extension: adaptiveExtension, adaptive_max_total: adaptiveMaxTotal },
         );
     }
@@ -1755,7 +1755,7 @@ export function createRalphController(opts = {}) {
                 };
                 if (r.note) out.last.note = r.note;
                 // Issue #7: mirror the live `tokens` block on the
-                // post-finish summary so a user calling ralph_status after
+                // post-finish summary so a user calling ap_status after
                 // the loop ends can still see how many tokens the run
                 // consumed without parsing the terminal result. Skip
                 // byIteration / byModel to match the live snapshot's
@@ -1790,7 +1790,7 @@ export function createRalphController(opts = {}) {
             stagnation_streak: a.streak,
             pending_first_iteration: a.pendingFire,
             // Pause visibility — without these fields, a paused loop is
-            // indistinguishable from a slow / blocked one in ralph_status,
+            // indistinguishable from a slow / blocked one in ap_status,
             // because `iteration` and `elapsed_ms` keep advancing while
             // the loop is silent. `paused_for_ms` is the *current* pause
             // duration (0 when not paused); `total_paused_ms` is the
@@ -1841,9 +1841,9 @@ export function createRalphController(opts = {}) {
 
     const tools = [
         {
-            name: "ralph_loop",
+            name: "ap_loop",
             description:
-                `Run an autonomous iterative loop. The tool returns immediately after arming the loop; iterations are driven by reacting to each session.idle (root-agent agentic-loop completion) and re-injecting the prompt as a new user message. Each iteration is a real conversation turn — context is retained, and progress is visible inline. Use ralph_stop to cancel an active loop. Tip: instruct the agent in the prompt to emit the completion_promise (default '${DEFAULTS.completion_promise}') when finished, otherwise the loop only stops at max_iterations. Only one loop runs per session; returns failure if a ralph_loop, self_improve, or grow_project loop is already active. Note: the user-supplied prompt is augmented at arm time with a small commit-attribution rider that adds dual Co-authored-by trailers (Copilot + copilot-ralph) to any git commit produced during the loop; set RALPH_NO_ATTRIBUTION=1 in the environment to suppress the second trailer.`,
+                `Run an autonomous iterative loop. The tool returns immediately after arming the loop; iterations are driven by reacting to each session.idle (root-agent agentic-loop completion) and re-injecting the prompt as a new user message. Each iteration is a real conversation turn — context is retained, and progress is visible inline. Use ap_stop to cancel an active loop. Tip: instruct the agent in the prompt to emit the completion_promise (default '${DEFAULTS.completion_promise}') when finished, otherwise the loop only stops at max_iterations. Only one loop runs per session; returns failure if a ap_loop, self_improve, or grow_project loop is already active. Note: the user-supplied prompt is augmented at arm time with a small commit-attribution rider that adds dual Co-authored-by trailers (Copilot + copilot-ralph) to any git commit produced during the loop; set RALPH_NO_ATTRIBUTION=1 in the environment to suppress the second trailer.`,
             parameters: {
                 type: "object",
                 properties: {
@@ -1929,7 +1929,7 @@ export function createRalphController(opts = {}) {
                 additionalProperties: false,
             },
             handler: async (args) => {
-                const notAttached = requireAttachedSession("ralph_loop");
+                const notAttached = requireAttachedSession("ap_loop");
                 if (notAttached) return notAttached;
                 const guard = activeLoopGuard();
                 if (guard) return guard;
@@ -1942,9 +1942,9 @@ export function createRalphController(opts = {}) {
             },
         },
         {
-            name: "ralph_stop",
+            name: "ap_stop",
             description:
-                "Cancel a currently-running ralph_loop, self_improve, or grow_project. Returns the iteration count at the moment of stop. Returns failure if no loop is active. Optionally pass a `reason` describing why the loop is being stopped (recorded as `note` on the result).",
+                "Cancel a currently-running ap_loop, self_improve, or grow_project. Returns the iteration count at the moment of stop. Returns failure if no loop is active. Optionally pass a `reason` describing why the loop is being stopped (recorded as `note` on the result).",
             parameters: {
                 type: "object",
                 properties: {
@@ -1957,16 +1957,16 @@ export function createRalphController(opts = {}) {
                 additionalProperties: false,
             },
             handler: async (args) => {
-                if (!state.active) return noActiveLoopFailure("ralph_stop");
-                // ralph_stop's `reason` is optional (null/undefined valid).
+                if (!state.active) return noActiveLoopFailure("ap_stop");
+                // ap_stop's `reason` is optional (null/undefined valid).
                 // Anything else goes through the same shape + unknown-keys
-                // gate as ralph_loop so typos surface loudly.
-                const bad = validateOptionalArgShape("ralph_stop", args, RALPH_STOP_KEYS);
+                // gate as ap_loop so typos surface loudly.
+                const bad = validateOptionalArgShape("ap_stop", args, RALPH_STOP_KEYS);
                 if (bad) return bad;
-                const reasonBad = validateOptionalReasonField("ralph_stop", args);
+                const reasonBad = validateOptionalReasonField("ap_stop", args);
                 if (reasonBad) return reasonBad;
                 const { i, max, label } = state.active;
-                // parseUserReason: shared with ralph_pause. Flattens
+                // parseUserReason: shared with ap_pause. Flattens
                 // multi-line input + caps length + coerces empty to
                 // null. result.note (single-line below) is consumed by
                 // collapseNote-driven additionalContext + terminal event.
@@ -1979,16 +1979,16 @@ export function createRalphController(opts = {}) {
             },
         },
         {
-            name: "ralph_status",
+            name: "ap_status",
             description:
-                "Return a structured live snapshot of the active ralph_loop / self_improve / grow_project (iteration count, elapsed time, configured promises, pause state, live token usage, last response excerpt, files changed since arm-time). Read-only — never mutates loop state. When no loop is active, returns { active: false } plus the previous run's summary if available. Cheap (<10ms typically); safe to call repeatedly.",
+                "Return a structured live snapshot of the active ap_loop / self_improve / grow_project (iteration count, elapsed time, configured promises, pause state, live token usage, last response excerpt, files changed since arm-time). Read-only — never mutates loop state. When no loop is active, returns { active: false } plus the previous run's summary if available. Cheap (<10ms typically); safe to call repeatedly.",
             parameters: {
                 type: "object",
                 properties: {},
                 additionalProperties: false,
             },
             handler: async (args) => {
-                const bad = validateOptionalArgShape("ralph_status", args, RALPH_STATUS_KEYS);
+                const bad = validateOptionalArgShape("ap_status", args, RALPH_STATUS_KEYS);
                 if (bad) return bad;
                 const snapshot = buildStatusSnapshot();
                 // The structured payload is the primary product. The
@@ -2013,25 +2013,25 @@ export function createRalphController(opts = {}) {
             },
         },
         {
-            name: "ralph_pause",
+            name: "ap_pause",
             description:
-                "Pause the active ralph_loop / self_improve / grow_project loop without losing iteration count or conversation context. The currently-running iteration (if any) finishes normally; subsequent session.idle events are short-circuited until ralph_resume is called. While paused, the user may chat freely with the agent — those turns do NOT consume iterations. Idempotent: pausing an already-paused loop is a no-op. Returns failure if no loop is active.",
+                "Pause the active ap_loop / self_improve / grow_project loop without losing iteration count or conversation context. The currently-running iteration (if any) finishes normally; subsequent session.idle events are short-circuited until ap_resume is called. While paused, the user may chat freely with the agent — those turns do NOT consume iterations. Idempotent: pausing an already-paused loop is a no-op. Returns failure if no loop is active.",
             parameters: {
                 type: "object",
                 properties: {
                     reason: {
                         type: "string",
-                        description: `Optional human-readable reason for pausing (≤${PREVIEW_CHARS} chars). Surfaced in logs and ralph_status.`,
+                        description: `Optional human-readable reason for pausing (≤${PREVIEW_CHARS} chars). Surfaced in logs and ap_status.`,
                         maxLength: PREVIEW_CHARS,
                     },
                 },
                 additionalProperties: false,
             },
             handler: async (args) => {
-                if (!state.active) return noActiveLoopFailure("ralph_pause");
-                const bad = validateOptionalArgShape("ralph_pause", args, RALPH_PAUSE_KEYS);
+                if (!state.active) return noActiveLoopFailure("ap_pause");
+                const bad = validateOptionalArgShape("ap_pause", args, RALPH_PAUSE_KEYS);
                 if (bad) return bad;
-                const reasonBad = validateOptionalReasonField("ralph_pause", args);
+                const reasonBad = validateOptionalReasonField("ap_pause", args);
                 if (reasonBad) return reasonBad;
                 const a = state.active;
                 const { i, max, label } = a;
@@ -2041,12 +2041,12 @@ export function createRalphController(opts = {}) {
                         { iterations: i, paused: true, reason: a.pauseReason ?? null },
                     );
                 }
-                // parseUserReason: shared with ralph_stop. Flatten +
+                // parseUserReason: shared with ap_stop. Flatten +
                 // truncate the user-supplied reason at entry so a
                 // multi-line paste (e.g. an Error stack, a blockquote, a
                 // CRLF-terminated input) cannot break the single-line
                 // timeline log marker, the `pause_reason` field rendered
-                // in the ralph_status JSON snapshot, or the `reason` on
+                // in the ap_status JSON snapshot, or the `reason` on
                 // the emitted `pause` event.
                 const reason = parseUserReason(args?.reason);
                 a.paused = true;
@@ -2055,27 +2055,27 @@ export function createRalphController(opts = {}) {
                 log(`⏸ ${label} paused at ${i}/${max}${reason ? ` (${reason})` : ""}`);
                 safeEmit(a, { type: "pause", runId: a.runId, iteration: i, reason, ts: a.pausedAt });
                 return success(
-                    `${label} paused at ${i}/${max}${reason ? ` (${reason})` : ""}. Use ralph_resume to continue.`,
+                    `${label} paused at ${i}/${max}${reason ? ` (${reason})` : ""}. Use ap_resume to continue.`,
                     { iterations: i, paused: true, reason },
                 );
             },
         },
         {
-            name: "ralph_resume",
+            name: "ap_resume",
             description:
-                "Resume a paused ralph_loop / self_improve / grow_project from the same iteration counter. Stagnation streak is reset (manual intervention almost always changes context). Returns failure if no loop is active or the loop is not currently paused. The next session.idle event after resume will fire the next iteration normally.",
+                "Resume a paused ap_loop / self_improve / grow_project from the same iteration counter. Stagnation streak is reset (manual intervention almost always changes context). Returns failure if no loop is active or the loop is not currently paused. The next session.idle event after resume will fire the next iteration normally.",
             parameters: {
                 type: "object",
                 properties: {},
                 additionalProperties: false,
             },
             handler: async (args) => {
-                if (!state.active) return noActiveLoopFailure("ralph_resume");
-                const bad = validateOptionalArgShape("ralph_resume", args, RALPH_RESUME_KEYS);
+                if (!state.active) return noActiveLoopFailure("ap_resume");
+                const bad = validateOptionalArgShape("ap_resume", args, RALPH_RESUME_KEYS);
                 if (bad) return bad;
                 const a = state.active;
                 if (!a.paused) {
-                    return failure(`ralph_resume: ${a.label} is not paused. Use ralph_pause first, or ralph_stop to cancel.`);
+                    return failure(`ap_resume: ${a.label} is not paused. Use ap_pause first, or ap_stop to cancel.`);
                 }
                 const pausedFor = pauseElapsedFromAt(a.pausedAt, Date.now());
                 a.totalPausedMs += pausedFor;
@@ -2097,7 +2097,7 @@ export function createRalphController(opts = {}) {
                 // simply advances to the next iteration. Trade-off: a genuine
                 // completion signal that landed in iter N's response right
                 // before the pause is forfeited, but the user already saw it
-                // via ralph_status.last_response_excerpt and can ralph_stop
+                // via ap_status.last_response_excerpt and can ap_stop
                 // explicitly if they want to honor it.
                 state.lastAssistantContent = "";
                 log(`▶ ${a.label} resumed at ${a.i}/${a.max} (paused for ${pausedFor}ms)`);
@@ -2111,7 +2111,7 @@ export function createRalphController(opts = {}) {
         {
             name: "self_improve",
             description:
-                "Arms ralph_loop with a baked-in, project-agnostic SDLC self-improvement prompt (orient → ideate → critique → baseline → implement → test → commit → push → COMPLETE), suitable for any repo. Optional `focus` string narrows the run to a specific area without altering the SDLC scaffolding. Only one loop runs per session; cancel with ralph_stop. Returns failure if a ralph_loop, self_improve, or grow_project loop is already active.",
+                "Arms ap_loop with a baked-in, project-agnostic SDLC self-improvement prompt (orient → ideate → critique → baseline → implement → test → commit → push → COMPLETE), suitable for any repo. Optional `focus` string narrows the run to a specific area without altering the SDLC scaffolding. Only one loop runs per session; cancel with ap_stop. Returns failure if a ap_loop, self_improve, or grow_project loop is already active.",
             parameters: {
                 type: "object",
                 properties: {
@@ -2209,10 +2209,10 @@ export function createRalphController(opts = {}) {
                 if (parsed.error) {
                     // Re-prefix delegated validateArgs errors via shared
                     // helper so users see self_improve in the error stream
-                    // rather than ralph_loop. The helper handles the
+                    // rather than ap_loop. The helper handles the
                     // defensive fallback (forced "self_improve:" prefix
                     // even if a future validateArgs path forgets the
-                    // ralph_loop: prefix).
+                    // ap_loop: prefix).
                     return failure(reprefixRalphLoopError(parsed.error, "self_improve"));
                 }
                 return armLoop(parsed.value, "self_improve");
@@ -2221,7 +2221,7 @@ export function createRalphController(opts = {}) {
         {
             name: "grow_project",
             description:
-                "Arms ralph_loop with a baked-in SDLC prompt that grows a project from a GitHub-issue backlog (via the `gh` CLI). On the first iter it ideates 5-10 small, well-scoped feature issues; on each subsequent iter it picks one `proposed` issue, ships it end-to-end against a three-part gate (tests green + executable acceptance check + demo invocation), commits with `Closes #N`, and closes the issue. Optional `focus` narrows the run. Only one loop runs per session; cancel with ralph_stop. Returns failure if a ralph_loop, self_improve, or grow_project loop is already active.",
+                "Arms ap_loop with a baked-in SDLC prompt that grows a project from a GitHub-issue backlog (via the `gh` CLI). On the first iter it ideates 5-10 small, well-scoped feature issues; on each subsequent iter it picks one `proposed` issue, ships it end-to-end against a three-part gate (tests green + executable acceptance check + demo invocation), commits with `Closes #N`, and closes the issue. Optional `focus` narrows the run. Only one loop runs per session; cancel with ap_stop. Returns failure if a ap_loop, self_improve, or grow_project loop is already active.",
             parameters: {
                 type: "object",
                 properties: {
@@ -2311,7 +2311,7 @@ export function createRalphController(opts = {}) {
                     // Re-prefix delegated validateArgs errors via shared
                     // helper (mirrors self_improve handling) so users see
                     // grow_project in the error stream rather than
-                    // ralph_loop, with the same defensive fallback.
+                    // ap_loop, with the same defensive fallback.
                     return failure(reprefixRalphLoopError(parsed.error, "grow_project"));
                 }
                 return armLoop(parsed.value, "grow_project");
@@ -2331,7 +2331,7 @@ export function createRalphController(opts = {}) {
             // Collapse whitespace so a multi-line note (e.g. an Error stack from
             // send_error) doesn't break the bracketed context line.
             const noteOneLine = collapseNote(note);
-            const lbl = label ?? "ralph_loop";
+            const lbl = label ?? "ap_loop";
             const ctx = `[${lbl} just finished — iterations=${iterations}, reason=${reason}${noteOneLine ? `, note=${noteOneLine}` : ""}, durationMs=${durationMs}]`;
             log(`${lbl}: injecting post-loop context into next user prompt (reason=${reason}, iterations=${iterations})`);
             return { additionalContext: ctx };

--- a/extension/handler.mjs
+++ b/extension/handler.mjs
@@ -202,30 +202,33 @@ const VERB_BY_REASON = Object.freeze({
 
 
 // Issue #1: every loop-driven commit ships TWO Co-authored-by trailers
-// (Copilot agent + copilot-ralph bot account, with RALPH_NO_ATTRIBUTION=1
-// suppressing the second). Bake the canonical trailer literals here so a
-// future edit to either prompt that drops the bot-account trailer or
-// inverts the order fails at module-load time, not at the next CI run.
-// The order-pin (Copilot first, copilot-ralph second) matters because
-// GitHub's commit UI surfaces the first co-author more prominently.
+// (Copilot agent + copilot-ralph bot account, with AUTOPILOT_NO_ATTRIBUTION=1
+// — or legacy RALPH_NO_ATTRIBUTION=1 — suppressing the second). Bake the
+// canonical trailer literals here so a future edit to either prompt that
+// drops the bot-account trailer or inverts the order fails at module-load
+// time, not at the next CI run. The order-pin (Copilot first, copilot-ralph
+// second) matters because GitHub's commit UI surfaces the first co-author
+// more prominently.
 //
 // Companion surfaces that must stay in lockstep with these literals:
 //   - README.md "Commit attribution" section (canonical user-facing
 //     disclosure, including the public-repo-only searchability caveat,
-//     the RALPH_NO_ATTRIBUTION=1 opt-out, and the order-of-trailers
-//     example block — pinned by the README test in
+//     the AUTOPILOT_NO_ATTRIBUTION=1 / RALPH_NO_ATTRIBUTION=1 opt-out, and
+//     the order-of-trailers example block — pinned by the README test in
 //     test/extension.test.mjs).
 //   - Both PROMPT_SELF_IMPROVE and PROMPT_GROW_PROJECT bodies (the
 //     load-time loop below validates both contain the literals in the
-//     correct order and document the opt-out env var).
+//     correct order and document both opt-out env vars).
 //   - The __test__ exports (BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER,
-//     BAKED_ATTRIBUTION_OPT_OUT) used by the canonical-source pin test.
+//     BAKED_ATTRIBUTION_OPT_OUT, BAKED_ATTRIBUTION_OPT_OUT_PRIMARY) used
+//     by the canonical-source pin test.
 // Renaming any of these literals (e.g. registering the bot under a
 // different login, swapping the noreply domain) requires updating
 // every surface above.
 const BAKED_COPILOT_TRAILER = "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>";
 const BAKED_RALPH_TRAILER = "Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>";
 const BAKED_ATTRIBUTION_OPT_OUT = "RALPH_NO_ATTRIBUTION=1";
+const BAKED_ATTRIBUTION_OPT_OUT_PRIMARY = "AUTOPILOT_NO_ATTRIBUTION=1";
 
 // Issue #1 (ap_loop parity): unlike self_improve / grow_project which
 // embed the COMMIT stage in their full baked SDLC prompt, ap_loop takes
@@ -242,7 +245,7 @@ const BAKED_RALPH_LOOP_RIDER = `---
 CONTROLLER REQUIREMENT — commit attribution: if this iteration produces any git commit, append BOTH Co-authored-by trailers in this exact order at the end of the commit message (separated from the body by a blank line):
   ${BAKED_COPILOT_TRAILER}
   ${BAKED_RALPH_TRAILER}
-The second trailer attributes loop-driven commits to the dedicated copilot-ralph bot account so they are passively searchable across public GitHub. If the environment variable ${BAKED_ATTRIBUTION_OPT_OUT} is set, omit ONLY the second copilot-ralph trailer; the first Copilot trailer always ships. If this iteration creates no commit, ignore this requirement.`;
+The second trailer attributes loop-driven commits to the dedicated copilot-ralph bot account so they are passively searchable across public GitHub. If the environment variable ${BAKED_ATTRIBUTION_OPT_OUT_PRIMARY} (or legacy ${BAKED_ATTRIBUTION_OPT_OUT}) is set, omit ONLY the second copilot-ralph trailer; the first Copilot trailer always ships. If this iteration creates no commit, ignore this requirement.`;
 
 for (const [label, prompt] of [
     ["PROMPT_SELF_IMPROVE", PROMPT_SELF_IMPROVE],
@@ -259,6 +262,11 @@ for (const [label, prompt] of [
     if (!prompt.includes(BAKED_ATTRIBUTION_OPT_OUT)) {
         throw new Error(
             `handler.mjs: ${label} must document the "${BAKED_ATTRIBUTION_OPT_OUT}" opt-out env var alongside the dual Co-authored-by trailers. Issue #1 attribution invariant.`,
+        );
+    }
+    if (!prompt.includes(BAKED_ATTRIBUTION_OPT_OUT_PRIMARY)) {
+        throw new Error(
+            `handler.mjs: ${label} must document the "${BAKED_ATTRIBUTION_OPT_OUT_PRIMARY}" opt-out env var alongside the dual Co-authored-by trailers. Issue #1 attribution invariant.`,
         );
     }
 }
@@ -1843,7 +1851,7 @@ export function createRalphController(opts = {}) {
         {
             name: "ap_loop",
             description:
-                `Run an autonomous iterative loop. The tool returns immediately after arming the loop; iterations are driven by reacting to each session.idle (root-agent agentic-loop completion) and re-injecting the prompt as a new user message. Each iteration is a real conversation turn — context is retained, and progress is visible inline. Use ap_stop to cancel an active loop. Tip: instruct the agent in the prompt to emit the completion_promise (default '${DEFAULTS.completion_promise}') when finished, otherwise the loop only stops at max_iterations. Only one loop runs per session; returns failure if a ap_loop, self_improve, or grow_project loop is already active. Note: the user-supplied prompt is augmented at arm time with a small commit-attribution rider that adds dual Co-authored-by trailers (Copilot + copilot-ralph) to any git commit produced during the loop; set RALPH_NO_ATTRIBUTION=1 in the environment to suppress the second trailer.`,
+                `Run an autonomous iterative loop. The tool returns immediately after arming the loop; iterations are driven by reacting to each session.idle (root-agent agentic-loop completion) and re-injecting the prompt as a new user message. Each iteration is a real conversation turn — context is retained, and progress is visible inline. Use ap_stop to cancel an active loop. Tip: instruct the agent in the prompt to emit the completion_promise (default '${DEFAULTS.completion_promise}') when finished, otherwise the loop only stops at max_iterations. Only one loop runs per session; returns failure if a ap_loop, self_improve, or grow_project loop is already active. Note: the user-supplied prompt is augmented at arm time with a small commit-attribution rider that adds dual Co-authored-by trailers (Copilot + copilot-ralph) to any git commit produced during the loop; set AUTOPILOT_NO_ATTRIBUTION=1 (or legacy RALPH_NO_ATTRIBUTION=1) in the environment to suppress the second trailer.`,
             parameters: {
                 type: "object",
                 properties: {
@@ -2426,4 +2434,4 @@ export function createRalphController(opts = {}) {
     };
 }
 
-export const __test__ = { DEFAULTS, SELF_IMPROVE_DEFAULTS, GROW_PROJECT_DEFAULTS, MAX_ALLOWED_ITERATIONS, PREVIEW_CHARS, MAX_PROMPT_CHARS, MAX_PROMISE_CHARS, MAX_CONTENT_CHARS, MAX_FOCUS_CHARS, PROMPT_SELF_IMPROVE, PROMPT_GROW_PROJECT, BAKED_ABORT_TOKEN, BAKED_BACKLOG_ABORT_TOKEN, BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER, BAKED_ATTRIBUTION_OPT_OUT, BAKED_RALPH_LOOP_RIDER, composeRalphLoopPrompt, previewOf, evaluateAdaptiveSignals, ADAPTIVE_WINDOW, reprefixRalphLoopError, gitAheadBehind, gitUncommittedLines, classifyPorcelainLine, parseUserReason, coerceNumberField, VERSION, compareSemver, VERB_BY_REASON, isCaffeinateEnabled, resolveCaffeinateScope, caffeinateFlagsForScope, describeArgType, displayValue, pauseElapsedFromAt };
+export const __test__ = { DEFAULTS, SELF_IMPROVE_DEFAULTS, GROW_PROJECT_DEFAULTS, MAX_ALLOWED_ITERATIONS, PREVIEW_CHARS, MAX_PROMPT_CHARS, MAX_PROMISE_CHARS, MAX_CONTENT_CHARS, MAX_FOCUS_CHARS, PROMPT_SELF_IMPROVE, PROMPT_GROW_PROJECT, BAKED_ABORT_TOKEN, BAKED_BACKLOG_ABORT_TOKEN, BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER, BAKED_ATTRIBUTION_OPT_OUT, BAKED_ATTRIBUTION_OPT_OUT_PRIMARY, BAKED_RALPH_LOOP_RIDER, composeRalphLoopPrompt, previewOf, evaluateAdaptiveSignals, ADAPTIVE_WINDOW, reprefixRalphLoopError, gitAheadBehind, gitUncommittedLines, classifyPorcelainLine, parseUserReason, coerceNumberField, VERSION, compareSemver, VERB_BY_REASON, isCaffeinateEnabled, resolveCaffeinateScope, caffeinateFlagsForScope, describeArgType, displayValue, pauseElapsedFromAt };

--- a/extension/handler.mjs
+++ b/extension/handler.mjs
@@ -33,7 +33,7 @@ const moduleRequire = createRequire(import.meta.url);
 // which runs in CI on every push. We hard-code the literal here rather
 // than reading `package.json` at runtime because `install.sh` only ships
 // `extension.mjs handler.mjs events-emit.mjs` to `~/.copilot/extensions/
-// ralph/` — a `require("../package.json")` would crash on installed
+// autopilot/` — a `require("../package.json")` would crash on installed
 // copies. The constant is exported so a future "version check on
 // extension load" feature (issue #25) and any tooling that introspects
 // the snapshot has a single source of truth without a torn-read window
@@ -220,15 +220,21 @@ const VERB_BY_REASON = Object.freeze({
 //     load-time loop below validates both contain the literals in the
 //     correct order and document both opt-out env vars).
 //   - The __test__ exports (BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER,
-//     BAKED_ATTRIBUTION_OPT_OUT, BAKED_ATTRIBUTION_OPT_OUT_PRIMARY) used
+//     BAKED_ATTRIBUTION_OPT_OUT, BAKED_ATTRIBUTION_OPT_OUT_LEGACY) used
 //     by the canonical-source pin test.
 // Renaming any of these literals (e.g. registering the bot under a
 // different login, swapping the noreply domain) requires updating
 // every surface above.
 const BAKED_COPILOT_TRAILER = "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>";
 const BAKED_RALPH_TRAILER = "Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>";
-const BAKED_ATTRIBUTION_OPT_OUT = "RALPH_NO_ATTRIBUTION=1";
-const BAKED_ATTRIBUTION_OPT_OUT_PRIMARY = "AUTOPILOT_NO_ATTRIBUTION=1";
+// Primary opt-out env var (project-rename stage 4). The constant NAME
+// keeps the historical _OPT_OUT spelling so existing __test__ exports
+// stay stable; only its VALUE flipped from the legacy RALPH_* form.
+const BAKED_ATTRIBUTION_OPT_OUT = "AUTOPILOT_NO_ATTRIBUTION=1";
+// Legacy opt-out env var, kept as a load-time invariant so prompts
+// continue to document both spellings while existing user scripts
+// that still set RALPH_NO_ATTRIBUTION=1 keep working.
+const BAKED_ATTRIBUTION_OPT_OUT_LEGACY = "RALPH_NO_ATTRIBUTION=1";
 
 // Issue #1 (ap_loop parity): unlike self_improve / grow_project which
 // embed the COMMIT stage in their full baked SDLC prompt, ap_loop takes
@@ -245,7 +251,7 @@ const BAKED_RALPH_LOOP_RIDER = `---
 CONTROLLER REQUIREMENT — commit attribution: if this iteration produces any git commit, append BOTH Co-authored-by trailers in this exact order at the end of the commit message (separated from the body by a blank line):
   ${BAKED_COPILOT_TRAILER}
   ${BAKED_RALPH_TRAILER}
-The second trailer attributes loop-driven commits to the dedicated copilot-ralph bot account so they are passively searchable across public GitHub. If the environment variable ${BAKED_ATTRIBUTION_OPT_OUT_PRIMARY} (or legacy ${BAKED_ATTRIBUTION_OPT_OUT}) is set, omit ONLY the second copilot-ralph trailer; the first Copilot trailer always ships. If this iteration creates no commit, ignore this requirement.`;
+The second trailer attributes loop-driven commits to the dedicated copilot-ralph bot account so they are passively searchable across public GitHub. If the environment variable ${BAKED_ATTRIBUTION_OPT_OUT} (or legacy ${BAKED_ATTRIBUTION_OPT_OUT_LEGACY}) is set, omit ONLY the second copilot-ralph trailer; the first Copilot trailer always ships. If this iteration creates no commit, ignore this requirement.`;
 
 for (const [label, prompt] of [
     ["PROMPT_SELF_IMPROVE", PROMPT_SELF_IMPROVE],
@@ -264,9 +270,9 @@ for (const [label, prompt] of [
             `handler.mjs: ${label} must document the "${BAKED_ATTRIBUTION_OPT_OUT}" opt-out env var alongside the dual Co-authored-by trailers. Issue #1 attribution invariant.`,
         );
     }
-    if (!prompt.includes(BAKED_ATTRIBUTION_OPT_OUT_PRIMARY)) {
+    if (!prompt.includes(BAKED_ATTRIBUTION_OPT_OUT_LEGACY)) {
         throw new Error(
-            `handler.mjs: ${label} must document the "${BAKED_ATTRIBUTION_OPT_OUT_PRIMARY}" opt-out env var alongside the dual Co-authored-by trailers. Issue #1 attribution invariant.`,
+            `handler.mjs: ${label} must document the "${BAKED_ATTRIBUTION_OPT_OUT_LEGACY}" opt-out env var alongside the dual Co-authored-by trailers. Issue #1 attribution invariant.`,
         );
     }
 }
@@ -383,8 +389,11 @@ function pauseElapsedFromAt(pausedAt, now) {
 // the CLI — no orphaned wake-locks.
 //
 // Disabled by default. Enable via env var:
-//     RALPH_CAFFEINATE=1                 → enable, scope = idle (default)
-//     RALPH_CAFFEINATE_SCOPE=idle+display → also block display sleep
+//     AUTOPILOT_CAFFEINATE=1                 → enable, scope = idle (default)
+//     AUTOPILOT_CAFFEINATE_SCOPE=idle+display → also block display sleep
+// The legacy spellings RALPH_CAFFEINATE / RALPH_CAFFEINATE_SCOPE still
+// work as a quiet fallback; the first time either fires per process,
+// a single-line stderr deprecation notice is emitted.
 //
 // On non-darwin platforms or when the binary is missing, the helper degrades
 // to a silent no-op — never fail the loop over a power-management nicety.
@@ -392,16 +401,51 @@ function pauseElapsedFromAt(pausedAt, now) {
 const CAFFEINATE_TRUTHY = new Set(["1", "true", "yes", "on"]);
 const CAFFEINATE_SCOPES = new Set(["idle", "idle+display"]);
 
-function isCaffeinateEnabled(env) {
-    const raw = env?.RALPH_CAFFEINATE;
-    if (typeof raw !== "string") return false;
-    return CAFFEINATE_TRUTHY.has(raw.trim().toLowerCase());
+// One-shot per-process deprecation notices for legacy env-var fallbacks.
+// We deliberately keep this in-memory only (no sentinel file) because the
+// caffeinate / no-attribution surfaces are read often enough during a
+// session that disk-based dedup would add complexity without payoff —
+// the goal is to nudge the user once per CLI run, not once forever.
+const _legacyEnvNoticeFired = new Set();
+function _warnLegacyEnvOnce(legacyName, primaryName, stderr = process.stderr) {
+    if (_legacyEnvNoticeFired.has(legacyName)) return;
+    _legacyEnvNoticeFired.add(legacyName);
+    try {
+        stderr.write?.(`[autopilot] note: env $${legacyName} is deprecated, please use $${primaryName} (still honored)\n`);
+    } catch { /* best-effort */ }
+}
+// Test seam — reset the per-process notice flags so each test starts
+// from a clean slate.
+function _resetLegacyEnvNotices() { _legacyEnvNoticeFired.clear(); }
+
+// Primary $AUTOPILOT_CAFFEINATE; falls back to legacy $RALPH_CAFFEINATE
+// with a one-line stderr deprecation on first fallback firing.
+function isCaffeinateEnabled(env, stderr) {
+    const primary = env?.AUTOPILOT_CAFFEINATE;
+    if (typeof primary === "string") {
+        return CAFFEINATE_TRUTHY.has(primary.trim().toLowerCase());
+    }
+    const legacy = env?.RALPH_CAFFEINATE;
+    if (typeof legacy !== "string") return false;
+    const enabled = CAFFEINATE_TRUTHY.has(legacy.trim().toLowerCase());
+    if (enabled) _warnLegacyEnvOnce("RALPH_CAFFEINATE", "AUTOPILOT_CAFFEINATE", stderr);
+    return enabled;
 }
 
-function resolveCaffeinateScope(env) {
-    const raw = env?.RALPH_CAFFEINATE_SCOPE;
-    if (typeof raw !== "string") return "idle";
-    const v = raw.trim().toLowerCase();
+// Primary $AUTOPILOT_CAFFEINATE_SCOPE; falls back to legacy
+// $RALPH_CAFFEINATE_SCOPE with a one-line stderr deprecation on first
+// fallback firing. Bogus values collapse to "idle" the same way the
+// primary parse does — keep a typo from disabling sleep prevention.
+function resolveCaffeinateScope(env, stderr) {
+    const primary = env?.AUTOPILOT_CAFFEINATE_SCOPE;
+    if (typeof primary === "string") {
+        const v = primary.trim().toLowerCase();
+        return CAFFEINATE_SCOPES.has(v) ? v : "idle";
+    }
+    const legacy = env?.RALPH_CAFFEINATE_SCOPE;
+    if (typeof legacy !== "string") return "idle";
+    _warnLegacyEnvOnce("RALPH_CAFFEINATE_SCOPE", "AUTOPILOT_CAFFEINATE_SCOPE", stderr);
+    const v = legacy.trim().toLowerCase();
     return CAFFEINATE_SCOPES.has(v) ? v : "idle";
 }
 
@@ -421,16 +465,17 @@ function caffeinateFlagsForScope(scope) {
  * @param {Function} deps.spawnFn - child_process.spawn-compatible
  * @param {(msg: string) => void} deps.log
  * @param {string} deps.label - "ap_loop" | "self_improve" | "grow_project"
+ * @param {{ write: Function }} [deps.stderr] - sink for legacy-env deprecation notices
  * @returns {(() => void) | null}
  */
-function startCaffeinate({ env, platform, pid, spawnFn, log, label }) {
-    if (!isCaffeinateEnabled(env)) return null;
+function startCaffeinate({ env, platform, pid, spawnFn, log, label, stderr }) {
+    if (!isCaffeinateEnabled(env, stderr)) return null;
     if (platform !== "darwin") {
         log(`${label}: caffeinate skipped — platform ${platform} not supported (darwin only)`);
         return null;
     }
     if (typeof spawnFn !== "function") return null;
-    const scope = resolveCaffeinateScope(env);
+    const scope = resolveCaffeinateScope(env, stderr);
     const flags = caffeinateFlagsForScope(scope);
     const args = [flags, "-w", String(pid)];
     let child;
@@ -1115,12 +1160,15 @@ export function validateArgs(args) {
 export function createRalphController(opts = {}) {
     // Caffeinate dependency injection (issue #8). Tests pass stubs; production
     // resolves child_process.spawn lazily so the import cost is paid only when
-    // RALPH_CAFFEINATE is actually enabled.
+    // AUTOPILOT_CAFFEINATE (or legacy RALPH_CAFFEINATE) is actually enabled.
     const caffeinateDeps = {
         env: opts.caffeinate?.env ?? process.env,
         platform: opts.caffeinate?.platform ?? process.platform,
         pid: opts.caffeinate?.pid ?? process.pid,
         spawnFn: opts.caffeinate?.spawnFn ?? null,
+        // Tests inject `caffeinate.stderr = { write }` so legacy-env
+        // deprecations don't pollute the tap stream.
+        stderr: opts.caffeinate?.stderr ?? process.stderr,
     };
     // Git dependency injection (issue #5). `ap_status` calls gitExec(args)
     // synchronously; tests replace it with a stub that returns canned results.
@@ -1160,7 +1208,7 @@ export function createRalphController(opts = {}) {
     // armLoop call and attached to state.active.events. `factory` is the
     // injection seam tests use to record without touching disk.
     //   opts.events = false | undefined         → off
-    //   opts.events = true                      → on, default emitter (writes ~/.copilot/ralph/runs)
+    //   opts.events = true                      → on, default emitter (writes ~/.copilot/autopilot/events; legacy ~/.copilot/ralph/runs honored on fallback)
     //   opts.events = { factory }               → on, custom factory({label, startedAt}) → writer
     //   opts.events = { env, fs }               → on, default emitter w/ overrides
     const eventsConfig = (() => {
@@ -1663,7 +1711,7 @@ export function createRalphController(opts = {}) {
         // caffeinate is actually enabled (avoids paying the require cost
         // for every loop arm). Tests inject spawnFn directly via opts.
         let spawnFn = caffeinateDeps.spawnFn;
-        if (!spawnFn && isCaffeinateEnabled(caffeinateDeps.env) && caffeinateDeps.platform === "darwin") {
+        if (!spawnFn && isCaffeinateEnabled(caffeinateDeps.env, caffeinateDeps.stderr) && caffeinateDeps.platform === "darwin") {
             try {
                 ({ spawn: spawnFn } = moduleRequire("node:child_process"));
             } catch { /* swallow — startCaffeinate handles null spawnFn */ }
@@ -1675,6 +1723,7 @@ export function createRalphController(opts = {}) {
             spawnFn,
             log,
             label,
+            stderr: caffeinateDeps.stderr,
         });
         // Snapshot git HEAD/branch at arm-time for ap_status's
         // "files changed since loop started" diff. Best-effort — a non-git
@@ -2434,4 +2483,4 @@ export function createRalphController(opts = {}) {
     };
 }
 
-export const __test__ = { DEFAULTS, SELF_IMPROVE_DEFAULTS, GROW_PROJECT_DEFAULTS, MAX_ALLOWED_ITERATIONS, PREVIEW_CHARS, MAX_PROMPT_CHARS, MAX_PROMISE_CHARS, MAX_CONTENT_CHARS, MAX_FOCUS_CHARS, PROMPT_SELF_IMPROVE, PROMPT_GROW_PROJECT, BAKED_ABORT_TOKEN, BAKED_BACKLOG_ABORT_TOKEN, BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER, BAKED_ATTRIBUTION_OPT_OUT, BAKED_ATTRIBUTION_OPT_OUT_PRIMARY, BAKED_RALPH_LOOP_RIDER, composeRalphLoopPrompt, previewOf, evaluateAdaptiveSignals, ADAPTIVE_WINDOW, reprefixRalphLoopError, gitAheadBehind, gitUncommittedLines, classifyPorcelainLine, parseUserReason, coerceNumberField, VERSION, compareSemver, VERB_BY_REASON, isCaffeinateEnabled, resolveCaffeinateScope, caffeinateFlagsForScope, describeArgType, displayValue, pauseElapsedFromAt };
+export const __test__ = { DEFAULTS, SELF_IMPROVE_DEFAULTS, GROW_PROJECT_DEFAULTS, MAX_ALLOWED_ITERATIONS, PREVIEW_CHARS, MAX_PROMPT_CHARS, MAX_PROMISE_CHARS, MAX_CONTENT_CHARS, MAX_FOCUS_CHARS, PROMPT_SELF_IMPROVE, PROMPT_GROW_PROJECT, BAKED_ABORT_TOKEN, BAKED_BACKLOG_ABORT_TOKEN, BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER, BAKED_ATTRIBUTION_OPT_OUT, BAKED_ATTRIBUTION_OPT_OUT_LEGACY, BAKED_RALPH_LOOP_RIDER, composeRalphLoopPrompt, previewOf, evaluateAdaptiveSignals, ADAPTIVE_WINDOW, reprefixRalphLoopError, gitAheadBehind, gitUncommittedLines, classifyPorcelainLine, parseUserReason, coerceNumberField, VERSION, compareSemver, VERB_BY_REASON, isCaffeinateEnabled, resolveCaffeinateScope, caffeinateFlagsForScope, describeArgType, displayValue, pauseElapsedFromAt, _resetLegacyEnvNotices };

--- a/extension/prompts.mjs
+++ b/extension/prompts.mjs
@@ -3,12 +3,12 @@
 // module so it can be imported by:
 //
 //   - extension/handler.mjs — the in-session loop runner
-//   - packages/tui/src/runner.mjs — the out-of-session ralph-tui run
+//   - packages/tui/src/runner.mjs — the out-of-session autopilot run
 //     driver (each iter is a fresh `copilot -p ...` subprocess)
 //
 // Both runners must ship the IDENTICAL prompt body, otherwise behaviour
 // diverges between `self_improve` / `grow_project` (in-session) and
-// `ralph-tui run --self-improve` / `ralph-tui run --grow-project`
+// `autopilot run --self-improve` / `autopilot run --grow-project`
 // (out-of-session). Centralising the prompt source removes that drift
 // surface entirely.
 //

--- a/extension/prompts.mjs
+++ b/extension/prompts.mjs
@@ -53,7 +53,8 @@ export const BAKED_BACKLOG_ABORT_TOKEN = "ABORT_NO_BACKLOG";
 //   TEST     — re-run; must stay green at same-or-higher count
 //   COMMIT   — conventional-commit prefix + dual Co-authored-by trailers
 //              (Copilot + copilot-ralph bot account; the second trailer
-//              is suppressed when RALPH_NO_ATTRIBUTION=1 is set in env)
+//              is suppressed when AUTOPILOT_NO_ATTRIBUTION=1 — or legacy
+//              RALPH_NO_ATTRIBUTION=1 — is set in env)
 //   PUSH     — git push (non-fatal on push failure)
 //   END      — emit COMPLETE on its own line, or ABORT_NO_IMPROVEMENTS
 export const PROMPT_SELF_IMPROVE = `You are running an autonomous backlog-draining iteration on the project in cwd. Each iteration is a paid premium request — drain as many real backlog items as fit in one turn (a failing CI run, a stale open pull request, an open human-filed issue), each as its own atomic commit with the tree green between them. If after honest investigation no real backlog item is actionable AND no genuine user-visible improvement is identifiable, emit ABORT_NO_IMPROVEMENTS rather than inventing defensive-guard or comment-alignment pseudo-improvements.
@@ -85,7 +86,7 @@ PER-ITERATION SDLC WORKFLOW (each iteration is a paid premium request — pack t
 2. IDEATE.
    PRIORITY ORDER (do not skip a higher tier when a candidate exists in it):
      a. RED CI — if ORIENT surfaced any failing GitHub Actions run on the default branch / current branch HEAD, healing that failure IS the iteration. Reproduce the failure locally if possible, fix the root cause (not the symptom — do not add \`continue-on-error\` or delete the failing job to silence it), and verify the fix re-runs green via \`gh run rerun <run-id>\` or by pushing the fix and watching the new run. If the failure is a flaky test, harden it; if it's an env/dependency drift, pin or update; if it's a legitimate regression, revert or fix forward.
-     b. STALE OPEN PR — if ORIENT surfaced an open PR with failing checks, mergeable=CONFLICTING, an unaddressed review, or extended inactivity, driving that PR to a mergeable state IS the iteration. For PRs you can push to (a branch you authored / loop-authored), rebase onto the default branch, fix forward until checks are green, push, and merge. For PRs authored by someone else, leave a constructive \`gh pr review --comment\` summarising what's blocking — do NOT push to their branch.
+     b. STALE OPEN PR — if ORIENT surfaced an open PR with failing checks, mergeable=CONFLICTING, an unaddressed review, or extended inactivity, driving that PR to MERGED INTO THE DEFAULT BRANCH IS the iteration. "mergeable with green CI" alone is NOT the terminal state — that's one stage short of done. For PRs you can push to (a branch you authored / loop-authored), rebase onto the default branch, fix forward until checks are green, push, AND merge via \`gh pr merge <num> --auto --squash --delete-branch\` (the \`--auto\` flag queues the merge to fire automatically once CI passes — counts as terminal state for this iter even if checks haven't completed yet; if the repo doesn't have auto-merge enabled, fall back to waiting for CI green and running \`gh pr merge <num> --squash --delete-branch\`). Replace \`--squash\` with \`--merge\` or \`--rebase\` if the project's prevailing merge style differs (detect via \`gh pr list --state merged --limit 5 --json mergeCommit,headRefName,title 2>/dev/null || true\` — squashed PRs land as one commit on the default branch with a \`(#NN)\` suffix on the title; merge-commits show up as \`Merge pull request #NN\`; rebase-merges replay the PR's commits without a merge bubble). For PRs authored by someone else (NOT loop-authored), the terminal state is a blocking \`gh pr review --comment\` that summarises the SPECIFIC actionable unblocker (e.g. "rebase needed against \`<sha>\` after the breaking change in \`<file>\`", not "looks good, just needs a rebase") — do NOT push to their branch.
      c. OPEN HUMAN-FILED ISSUE — if ORIENT surfaced an open issue WITHOUT the \`grow-project\` / \`proposed\` label, addressing that issue end-to-end IS the iteration. Pick the oldest one with a clear, scoped fix (lowest number first when ties). Reference the issue via \`Closes #N\` (or \`Refs #N\` if the fix is partial). Issues carrying \`grow-project\` / \`proposed\` belong to the feature-backlog runner — leave them alone here.
      d. ROTATING SDLC HARDENING — ONLY if tiers (a)-(c) are all empty AND a genuine user-visible improvement is identifiable. Pick ONE concrete improvement, rotating across the categories below so the loop covers the whole lifecycle over time:
         - bug fix or edge-case hardening
@@ -96,6 +97,18 @@ PER-ITERATION SDLC WORKFLOW (each iteration is a paid premium request — pack t
         - docs (README, CHANGELOG, comments) accuracy
         - release engineering (version bump rules, CI hints, .gitignore, lockfile)
         Avoid repeating the SDLC category used in the previous 2-3 commits. If you cannot identify a user-visible improvement, emit ABORT_NO_IMPROVEMENTS — defensive guards on hypothetical edge cases, drift-pinning of trivial format strings, and comment / doc alignment churn are NOT acceptable iteration output.
+
+   ABORT_NO_IMPROVEMENTS CONTRACT (read carefully — misuse of this token has historically ended runs while real work was sitting unpicked):
+   ABORT_NO_IMPROVEMENTS is the LITERAL backlog-is-empty signal. Only emit it when ALL of the following are objectively true after honest investigation:
+     - tier (a) RED CI list is empty (no failing GitHub Actions runs on default branch / current HEAD).
+     - tier (b) STALE OPEN PR list is empty (no open PRs with failing checks, mergeable=CONFLICTING, unaddressed reviews, or extended inactivity).
+     - tier (c) OPEN HUMAN-FILED ISSUE list is empty (no open issues without the \`grow-project\` / \`proposed\` labels).
+     - tier (d) yields no genuine user-visible improvement.
+   It is NOT a "this iter feels risky / contested / awkward" escape hatch. Specifically:
+     - "Another agent appears to be editing files in a similar scope" is NOT grounds for ABORT_NO_IMPROVEMENTS — the backlog still has work. Pick a work item whose file scope does NOT overlap with the contested files (skip that one tier-(c) issue, take the next), OR end the iter WITHOUT emitting ABORT_NO_IMPROVEMENTS or COMPLETE so the loop iterates and the next premium request retries with a fresh ORIENT (the contested agent may have finished by then).
+     - "The available work feels too large for one iter" is NOT grounds for ABORT_NO_IMPROVEMENTS — pick a smaller scoped slice of the same work item, or one of the smaller backlog items.
+     - "I'm uncertain how to fix this" is NOT grounds for ABORT_NO_IMPROVEMENTS — open a refining \`gh issue comment\` asking for clarification, then either pick a different backlog item or end the iter without a terminal token.
+   In all the above "blocked but backlog non-empty" situations, the correct outcome is EITHER a different work item picked from the same tier OR ending the iter without a terminal token (no COMPLETE, no ABORT). The loop will iterate to the next premium request, which can re-orient with fresh state.
 
 3. CRITIQUE (rubber-duck pass).
    Before editing, briefly state: the change, the risk it introduces, and one alternative you considered and rejected. Reject your own idea and pick a different one if the risk outweighs the value.
@@ -113,18 +126,30 @@ PER-ITERATION SDLC WORKFLOW (each iteration is a paid premium request — pack t
    Short imperative subject prefixed with the SDLC category (\`fix:\`, \`feat:\`, \`test:\`, \`refactor:\`, \`docs:\`, \`chore:\`, \`ci:\`, \`perf:\`). Always include both trailers:
      Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
      Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>
-   The second trailer attributes the commit to the dedicated \`copilot-ralph\` bot account so loop-driven commits are passively searchable across public GitHub. If the environment variable \`RALPH_NO_ATTRIBUTION=1\` is set, omit ONLY the second \`copilot-ralph\` trailer; the first \`Copilot\` trailer always ships.
+   The second trailer attributes the commit to the dedicated \`copilot-ralph\` bot account so loop-driven commits are passively searchable across public GitHub. If the environment variable \`AUTOPILOT_NO_ATTRIBUTION=1\` (or legacy \`RALPH_NO_ATTRIBUTION=1\`) is set, omit ONLY the second \`copilot-ralph\` trailer; the first \`Copilot\` trailer always ships.
    Write the commit message to a temp file in a SEPARATE shell call before running \`git commit -F\`; combining heredoc + commit in one call has historically failed silently. Prefer "cancel", "tear down", or "stop" in commit messages over forceful-action synonyms that some agent runtimes treat as trigger phrases.
 
-8. PUSH.
+8. PUSH (and MERGE for tier (b) loop-authored PRs).
    \`git push\` to origin. If push fails (no remote, auth, conflict), log it and continue; do not abort the loop on push failure.
+   If the iteration's work item is a tier (b) loop-authored PR, PUSH alone is NOT the terminal state — the iter is incomplete until the PR is MERGED (or auto-merge is armed via \`--auto\`). After pushing, drive the merge:
+     - First try \`gh pr merge <num> --auto --squash --delete-branch\` (replace \`--squash\` with the project's prevailing style — see step 2.b). The \`--auto\` flag queues the merge to fire when CI passes, so even slow CI doesn't waste the turn waiting; auto-merge-armed counts as terminal state for this iter.
+     - If auto-merge is not enabled on the repo, or \`--auto\` errors out, poll \`gh pr view <num> --json statusCheckRollup,mergeable\` once or twice with a short delay between polls; when checks report SUCCESS and mergeable=MERGEABLE, run \`gh pr merge <num> --squash --delete-branch\` (no \`--auto\`).
+     - If neither path completes the merge this iter (CI still failing, branch protection blocking, missing required approval), do NOT emit COMPLETE in step 9 — END the iter without the COMPLETE token so the next premium request iterates and re-picks the same PR from ORIENT. Emitting COMPLETE while a tier (b) PR you have push access to is still OPEN ends the loop one stage short of done.
 
 9. END THE TURN.
-   Emit the literal token COMPLETE on its own line so the loop advances. If no worthwhile improvement exists, emit ABORT_NO_IMPROVEMENTS instead.
+   The iter is complete only when EVERY work item picked this iter has reached its terminal state:
+     - tier (a) RED CI: the failing run is now green (a fix has shipped that re-greens it on the default branch / current HEAD).
+     - tier (b) STALE OPEN PR you have push access to: the PR is MERGED into the default branch, or \`gh pr merge --auto\` has been successfully armed (the merge will fire when CI passes). "mergeable with green CI but not yet merged" is NOT terminal.
+     - tier (b) STALE OPEN PR authored by someone else: a blocking \`gh pr review --comment\` summarising the specific actionable unblocker has been posted.
+     - tier (c) OPEN HUMAN-FILED ISSUE: a commit referencing the issue with \`Closes #N\` (or \`Refs #N\` for partial fixes) has shipped and pushed.
+     - tier (d) ROTATING SDLC HARDENING: the improvement has shipped as a commit and pushed.
+   When every picked work item has reached its terminal state, emit the literal token COMPLETE on its own line so the loop terminates with reason=complete. Do NOT pivot to a different work item in the same iter while a previously-picked work item is short of terminal state — finish what you started. If a tier (b) merge could not complete this iter (auto-merge unavailable AND CI didn't go green during the short poll), end the iter WITHOUT emitting COMPLETE — the loop will iterate to the next premium request and re-pick the same PR from ORIENT. Emitting COMPLETE while a tier (b) PR is pushed-but-unmerged is a contract violation that ends the loop one stage short of done. If after honest investigation no work item is actionable in the first place, emit ABORT_NO_IMPROVEMENTS.
 
 HARD RULES:
 - Stay in cwd; do not edit unrelated repos.
 - Tier (d) is a fallback, not a default. A run that exclusively produces tier (d) commits is a failure mode — the agent is mining the codebase for non-issues. When (a)-(c) are empty and no user-visible (d) improvement is identifiable, ABORT.
+- A tier (b) iter that pushes a fix without driving the PR to MERGED (or auto-merge armed via \`--auto\`) is a failure mode — the work item is one stage short of done. Either complete the merge this iter or end the iter WITHOUT emitting COMPLETE so the next premium request can re-pick the PR from ORIENT. Emitting COMPLETE while a tier (b) PR you have push access to is still OPEN is a contract violation that ends the loop one stage short of done.
+- ABORT_NO_IMPROVEMENTS is the LITERAL backlog-is-empty signal — only emit it when tiers (a), (b), (c) are objectively empty AND no genuine (d) improvement is identifiable. Concurrent-agent activity, a contested file scope, or "this work feels too large / unclear" are NOT grounds for ABORT_NO_IMPROVEMENTS. When work exists but is blocked from THIS particular iter, either (i) pick a different non-blocked work item from the same or next tier, or (ii) end the iter without emitting ABORT or COMPLETE so the loop iterates and re-orients on the next premium request.
 - Each iteration is a paid premium request. Pack the turn — drain multiple backlog items in one iter as separate atomic commits when feasible, rather than burning a fresh premium request on each tiny commit. The tree must stay green between commits; if a commit reveals a regression in a later commit's scope, fix it inline before closing the iter.
 - Do not introduce new top-level dependencies, frameworks, or build systems unless that introduction IS the improvement and the rubber-duck critique justified it.
 - Do not delete or rewrite the project's existing license, README, or CHANGELOG wholesale; surgical edits only.`;
@@ -197,7 +222,7 @@ PER-ITERATION SDLC WORKFLOW (each iteration is a paid premium request — ship c
       Closes #N
       Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
       Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>
-    The second \`Co-authored-by\` trailer attributes the commit to the dedicated \`copilot-ralph\` bot account so loop-driven commits are passively searchable across public GitHub. If the environment variable \`RALPH_NO_ATTRIBUTION=1\` is set, omit ONLY the \`copilot-ralph\` trailer; the \`Closes #N\` and \`Copilot\` trailers always ship.
+    The second \`Co-authored-by\` trailer attributes the commit to the dedicated \`copilot-ralph\` bot account so loop-driven commits are passively searchable across public GitHub. If the environment variable \`AUTOPILOT_NO_ATTRIBUTION=1\` (or legacy \`RALPH_NO_ATTRIBUTION=1\`) is set, omit ONLY the \`copilot-ralph\` trailer; the \`Closes #N\` and \`Copilot\` trailers always ship.
     Write the commit message to a temp file in a SEPARATE shell call before running \`git commit -F\`; combining heredoc + commit in one call has historically failed silently. Prefer "cancel", "tear down", or "stop" in commit messages over forceful-action synonyms that some agent runtimes treat as trigger phrases.
 
 11. PUSH.

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Install copilot-ralph-extension to user-scoped Copilot CLI extensions dir.
+# Install autopilot to user-scoped Copilot CLI extensions dir.
 # Usage: ./install.sh [--project] [--dry-run] [--version|-V] [--help|-h]
-#   default:        ~/.copilot/extensions/ralph
-#   --project:      .github/extensions/ralph in current git repo
+#   default:        ~/.copilot/extensions/autopilot
+#   --project:      .github/extensions/autopilot in current git repo
 #   --dry-run:      show what would be installed without writing anything
 #   --version, -V:  print the extension version and exit
 #   --help, -h:     show this message
@@ -83,7 +83,7 @@ for arg in "$@"; do
       # above). A user/CI script that wants to know "which version
       # would this script install?" can now do so without parsing
       # `--dry-run` output or reading handler.mjs themselves.
-      echo "copilot-ralph-extension v$VERSION"
+      echo "autopilot v$VERSION"
       exit 0
       ;;
     --dry-run)
@@ -121,7 +121,7 @@ FILES=(events-emit.mjs prompts.mjs handler.mjs extension.mjs)
 # package.json) avoids a dependency on `node` / a JSON parser at
 # install time and keeps the version surface a single source of
 # truth — handler.mjs's constant is what the running extension
-# reports via `ralph_status`. The empty-version guard up there
+# reports via `ap_status`. The empty-version guard up there
 # fails the install loudly if a future refactor breaks the
 # declaration shape rather than printing "v" to the user.
 
@@ -158,7 +158,7 @@ if [[ "$SEEN_PROJECT" == "1" ]]; then
   # this script anyway, so the builtin is always available).
   if ! command -v git >/dev/null 2>&1; then
     echo "Error: --project requires the 'git' binary in PATH, but it was not found." >&2
-    echo "  Hint: install git, or omit --project to install into the user-scoped path (~/.copilot/extensions/ralph)." >&2
+    echo "  Hint: install git, or omit --project to install into the user-scoped path (~/.copilot/extensions/autopilot)." >&2
     exit 1
   fi
   GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
@@ -166,7 +166,7 @@ if [[ "$SEEN_PROJECT" == "1" ]]; then
     echo "Error: --project requires being inside a git repo." >&2
     exit 1
   fi
-  TARGET_DIR="$GIT_ROOT/.github/extensions/ralph"
+  TARGET_DIR="$GIT_ROOT/.github/extensions/autopilot"
 else
   # User-scoped install needs $HOME. Surface a friendly error if it's
   # unset (cron / minimal docker / weird CI) instead of letting `set -u`
@@ -175,7 +175,7 @@ else
     echo "Error: \$HOME is not set; cannot determine user-scoped install path. Pass --project to install into the current git repo instead." >&2
     exit 1
   fi
-  TARGET_DIR="$HOME/.copilot/extensions/ralph"
+  TARGET_DIR="$HOME/.copilot/extensions/autopilot"
 fi
 
 if [[ "$DRY_RUN" == "1" ]]; then
@@ -352,6 +352,6 @@ for f in "${FILES[@]}"; do
   fi
 done
 
-echo "✅ Installed ralph extension v$VERSION to $TARGET_DIR/"
+echo "✅ Installed autopilot v$VERSION to $TARGET_DIR/"
 echo ""
 echo "Restart Copilot CLI (or run /extensions reload) to activate."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,17 +1,20 @@
-# MkDocs Material configuration for the Ralph documentation site.
-# Tracked in issue #2: https://github.com/kloba/copilot-ralph-extension/issues/2
+# MkDocs Material configuration for the autopilot documentation site.
+# Tracked in issue #2: https://github.com/kloba/autopilot/issues/2
 #
 # Build locally:
 #   pip install mkdocs-material
 #   mkdocs serve   # http://127.0.0.1:8000
 #
 # Deploys via .github/workflows/docs.yml on pushes to main.
+#
+# Legacy RALPH_* env-var names are still read for one release with a one-line stderr deprecation notice.
+# Legacy ~/.copilot/ralph[ -tui]/runs paths are still read on first run with a one-line stderr migration notice; new runs write to the autopilot* paths.
 
-site_name: Ralph
+site_name: autopilot
 site_description: An autonomous iterative loop for the GitHub Copilot CLI.
-site_url: https://kloba.github.io/copilot-ralph-extension/
-repo_url: https://github.com/kloba/copilot-ralph-extension
-repo_name: kloba/copilot-ralph-extension
+site_url: https://kloba.github.io/autopilot/
+repo_url: https://github.com/kloba/autopilot
+repo_name: kloba/autopilot
 edit_uri: edit/main/docs/
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@
 # Deploys via .github/workflows/docs.yml on pushes to main.
 
 site_name: Ralph
-site_description: A Ralph Wiggum-style autonomous loop for the GitHub Copilot CLI.
+site_description: An autonomous iterative loop for the GitHub Copilot CLI.
 site_url: https://kloba.github.io/copilot-ralph-extension/
 repo_url: https://github.com/kloba/copilot-ralph-extension
 repo_name: kloba/copilot-ralph-extension

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "copilot-ralph-extension",
   "version": "0.6.0",
-  "description": "Ralph Wiggum-style autonomous iterative loop for GitHub Copilot CLI, implemented as an in-session extension.",
+  "description": "Autonomous iterative loop for GitHub Copilot CLI, implemented as an in-session extension.",
   "type": "module",
   "private": true,
   "author": "Taras Kloba",
@@ -17,7 +17,6 @@
     "github-copilot",
     "copilot-cli",
     "extension",
-    "ralph-wiggum",
     "agent",
     "iterative-loop",
     "autonomous"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "copilot-ralph-extension",
+  "name": "autopilot",
   "version": "0.6.0",
   "description": "Autonomous iterative loop for GitHub Copilot CLI, implemented as an in-session extension.",
   "type": "module",
@@ -23,10 +23,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kloba/copilot-ralph-extension.git"
+    "url": "git+https://github.com/kloba/autopilot.git"
   },
   "bugs": {
-    "url": "https://github.com/kloba/copilot-ralph-extension/issues"
+    "url": "https://github.com/kloba/autopilot/issues"
   },
-  "homepage": "https://github.com/kloba/copilot-ralph-extension#readme"
+  "homepage": "https://github.com/kloba/autopilot#readme"
 }

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -50,7 +50,8 @@ the next slice; if its module isn't installed, `watch` falls back to
 node packages/tui/bin/tui.mjs --help
 
 # 2. List recorded runs (writes from extension/events-emit.mjs end up
-#    in $RALPH_EVENTS_DIR or ~/.copilot/autopilot/events).
+#    in $AUTOPILOT_EVENTS_DIR or ~/.copilot/autopilot/events; legacy
+#    $RALPH_EVENTS_DIR is still honored).
 node packages/tui/bin/tui.mjs list
 
 # 3. Replay a finished run as plain log lines.
@@ -113,7 +114,7 @@ Tips:
 ## Override the runs root
 
 ```sh
-export RALPH_EVENTS_DIR=/tmp/ralph-runs
+export AUTOPILOT_EVENTS_DIR=/tmp/autopilot-runs
 node packages/tui/bin/tui.mjs list
 ```
 
@@ -123,20 +124,25 @@ Useful for:
 * CI jobs that want to assert on a specific run without depending on
   the user's home directory.
 * Replaying a captured `events.jsonl` from a teammate (drop their
-  file at `$RALPH_EVENTS_DIR/<runId>/events.jsonl`).
+  file at `$AUTOPILOT_EVENTS_DIR/<runId>/events.jsonl`).
+
+Legacy `RALPH_*` env-var names are still read for one release with a one-line stderr deprecation notice.
+
+Legacy `~/.copilot/ralph[ -tui]/runs` paths are still read on first run with a one-line stderr migration notice; new runs write to the autopilot* paths.
 
 ## Auto-upgrade for each `run`
 
 Long-haul `autopilot run` loops (e.g. `--self-improve` draining a
 backlog over hours) often want to start on the freshest source. The
-repo ships `scripts/ralph-tui-fresh.sh` — a thin Bash wrapper that
+repo ships `scripts/autopilot-fresh.sh` — a thin Bash wrapper that
 runs `git pull --quiet --ff-only` from the repo root *only* when the
 first arg is `run`, then `exec`s `node packages/tui/bin/tui.mjs`
-with the same args.
+with the same args. The old `scripts/ralph-tui-fresh.sh` path stays
+as a deprecating wrapper.
 
 ```sh
 # In ~/.zshrc or ~/.bashrc — point at your local clone:
-alias autopilot="$HOME/repos/autopilot/scripts/ralph-tui-fresh.sh"
+alias autopilot="$HOME/repos/autopilot/scripts/autopilot-fresh.sh"
 
 # Then long-haul runs auto-upgrade before iter 1:
 autopilot run --self-improve --continue

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -1,8 +1,8 @@
-# `@copilot-ralph-extension/tui` — Live TUI for ralph_loop
+# `@autopilot/tui` — Live TUI for ap_loop
 
-> Terminal visualizer for live `ralph_loop` / `self_improve` /
+> Terminal visualizer for live `ap_loop` / `self_improve` /
 > `grow_project` runs (issue #22). Tails a JSONL event stream the
-> loop handler writes to `~/.copilot/ralph/runs/<runId>/events.jsonl`
+> loop handler writes to `~/.copilot/autopilot/events/<runId>/events.jsonl`
 > and renders a live timeline, detail pane, and controls.
 
 The TUI is **opt-in** — the core extension keeps working with zero
@@ -12,28 +12,28 @@ to *watch* a loop run.
 ## Subcommands
 
 ```text
-ralph-tui list [--json] [--limit N]  Show recorded runs (newest first).
+autopilot list [--json] [--limit N]  Show recorded runs (newest first).
                                      `--json` emits the index as a JSON
                                      array for scripting/dashboards;
                                      `--limit N` caps the table.
-ralph-tui replay <runId>             Print every event in a past run.
-ralph-tui watch [runId] [--plain]    Tail the given run (or the most
+autopilot replay <runId>             Print every event in a past run.
+autopilot watch [runId] [--plain]    Tail the given run (or the most
                                      recent one if omitted) in real time.
-ralph-tui doctor                     Diagnose the runs directory + writer
+autopilot doctor                     Diagnose the runs directory + writer
                                      wiring (permissions, malformed
                                      JSONL, stale lockfiles, broken
                                      symlinks).
-ralph-tui prune [--older-than D]     Remove runs older than DURATION
+autopilot prune [--older-than D]     Remove runs older than DURATION
         [--dry-run]                  (e.g. 30d / 12h / 5m; default 30d).
                                      `--dry-run` lists what would go
                                      without touching the filesystem.
-ralph-tui stats                      Aggregate stats across the run
+autopilot stats                      Aggregate stats across the run
                                      index (run count, total iterations,
                                      p50/p95 durations, top SDLC tools).
-ralph-tui where                      Print the resolved runs root path
+autopilot where                      Print the resolved runs root path
                                      so a contributor can `cd` into it.
-ralph-tui --help     | -h            Show usage.
-ralph-tui --version  | -V            Print the ralph-tui package version.
+autopilot --help     | -h            Show usage.
+autopilot --version  | -V            Print the autopilot package version.
 ```
 
 `--plain` is **auto-enabled when stdout is not a TTY** so CI logs and
@@ -50,7 +50,7 @@ the next slice; if its module isn't installed, `watch` falls back to
 node packages/tui/bin/tui.mjs --help
 
 # 2. List recorded runs (writes from extension/events-emit.mjs end up
-#    in $RALPH_EVENTS_DIR or ~/.copilot/ralph/runs).
+#    in $RALPH_EVENTS_DIR or ~/.copilot/autopilot/events).
 node packages/tui/bin/tui.mjs list
 
 # 3. Replay a finished run as plain log lines.
@@ -98,7 +98,7 @@ asciinema rec demo.cast \
   --command 'node packages/tui/bin/tui.mjs watch --plain' \
   --idle-time-limit 1.0 \
   --rows 24 --cols 100 \
-  --title 'ralph self_improve — live'
+  --title 'autopilot self_improve — live'
 ```
 
 Tips:
@@ -127,7 +127,7 @@ Useful for:
 
 ## Auto-upgrade for each `run`
 
-Long-haul `ralph-tui run` loops (e.g. `--self-improve` draining a
+Long-haul `autopilot run` loops (e.g. `--self-improve` draining a
 backlog over hours) often want to start on the freshest source. The
 repo ships `scripts/ralph-tui-fresh.sh` — a thin Bash wrapper that
 runs `git pull --quiet --ff-only` from the repo root *only* when the
@@ -136,14 +136,14 @@ with the same args.
 
 ```sh
 # In ~/.zshrc or ~/.bashrc — point at your local clone:
-alias ralph-tui="$HOME/repos/copilot-ralph-extension/scripts/ralph-tui-fresh.sh"
+alias autopilot="$HOME/repos/autopilot/scripts/ralph-tui-fresh.sh"
 
 # Then long-haul runs auto-upgrade before iter 1:
-ralph-tui run --self-improve --continue
+autopilot run --self-improve --continue
 
 # Quick read-only subcommands skip the upgrade (no `git pull` cost):
-ralph-tui list
-ralph-tui watch
+autopilot list
+autopilot watch
 ```
 
 Why this is safe:

--- a/packages/tui/bin/tui.mjs
+++ b/packages/tui/bin/tui.mjs
@@ -106,11 +106,14 @@ OPTIONS
   --version, -V  Print the ralph-tui package version and exit.
 
 ENV
-  RALPH_EVENTS_DIR  Override the runs root (default ~/.copilot/ralph/runs).
-  RALPH_TUI_RUNS_DIR  Override the run-state root used by
-                    \`ralph-tui run\` (default ~/.copilot/ralph-tui/runs).
-  RALPH_TUI_COPILOT_BIN  Override the \`copilot\` executable used by
+  AUTOPILOT_EVENTS_DIR  Override the runs root (default ~/.copilot/autopilot/events).
+                    Legacy: RALPH_EVENTS_DIR still honored (deprecated).
+  AUTOPILOT_RUNS_DIR  Override the run-state root used by
+                    \`ralph-tui run\` (default ~/.copilot/autopilot/runs).
+                    Legacy: RALPH_TUI_RUNS_DIR still honored (deprecated).
+  AUTOPILOT_COPILOT_BIN  Override the \`copilot\` executable used by
                     \`ralph-tui run\` (default \`copilot\` on $PATH).
+                    Legacy: RALPH_TUI_COPILOT_BIN still honored (deprecated).
 `;
 
 /** Minimal argv parser. Returns { cmd, positional[], flags{} }.
@@ -461,7 +464,7 @@ export function cmdDoctor() {
     if (!healthy) {
         process.stderr.write(
             `ralph-tui doctor: critical problem detected (root=${root}). `
-            + `Check filesystem permissions and RALPH_EVENTS_DIR.\n`,
+            + `Check filesystem permissions and AUTOPILOT_EVENTS_DIR.\n`,
         );
         return 1;
     }

--- a/packages/tui/bin/tui.mjs
+++ b/packages/tui/bin/tui.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Stdlib-only CLI entry for the ralph TUI (issue #22).
+// Stdlib-only CLI entry for the autopilot TUI (issue #22).
 //
 // Subcommands (keep in sync with the USAGE constant below — pinned by
 // `tui.mjs header comment lists every USAGE subcommand` in
@@ -21,7 +21,7 @@
 //                                durations, top SDLC tools).
 //   where                      — print the resolved runs root path so
 //                                a contributor can `cd` into it.
-//   run                        — drive a ralph_loop / self_improve /
+//   run                        — drive an ap_loop / self_improve /
 //                                grow_project loop OUT-OF-SESSION by
 //                                spawning each iter as a fresh
 //                                `copilot -p ...` subprocess. Choose
@@ -54,25 +54,25 @@ import { readEventsFile, tailEventsFile } from "../src/tail.mjs";
 import { formatEventLine } from "../src/plain.mjs";
 
 const USAGE = `\
-ralph-tui — terminal visualizer for ralph_loop runs (issue #22).
+autopilot — terminal visualizer for ap_loop runs (issue #22).
 
 USAGE
-  ralph-tui list [--json] [--limit N]
-  ralph-tui replay <runId>
-  ralph-tui watch [runId] [--plain]
-  ralph-tui doctor
-  ralph-tui prune [--older-than 30d] [--dry-run]
-  ralph-tui stats
-  ralph-tui where
-  ralph-tui run (--self-improve | --grow-project | --prompt TEXT)
+  autopilot list [--json] [--limit N]
+  autopilot replay <runId>
+  autopilot watch [runId] [--plain]
+  autopilot doctor
+  autopilot prune [--older-than 30d] [--dry-run]
+  autopilot stats
+  autopilot where
+  autopilot run (--self-improve | --grow-project | --prompt TEXT)
                 (--continue | --fresh)
                 [--max N] [--focus TEXT] [--headless | --plain]
                 [--completion-promise TOKEN] [--abort-promise TOKEN]
-  ralph-tui run --pause <runId>
-  ralph-tui run --resume <runId>
-  ralph-tui run --stop <runId>
-  ralph-tui run --status <runId>
-  ralph-tui --help | -h
+  autopilot run --pause <runId>
+  autopilot run --resume <runId>
+  autopilot run --stop <runId>
+  autopilot run --status <runId>
+  autopilot --help | -h
 
 OPTIONS
   --plain     Emit log lines instead of an interactive UI (auto-enabled
@@ -86,7 +86,7 @@ OPTIONS
   --dry-run   For \`prune\`: list what would be removed; delete nothing.
   --self-improve  For \`run\`: drive the baked self_improve SDLC prompt.
   --grow-project  For \`run\`: drive the baked grow_project SDLC prompt.
-  --prompt TEXT   For \`run\`: drive a ralph_loop-style custom prompt.
+  --prompt TEXT   For \`run\`: drive an ap_loop-style custom prompt.
   --continue  For \`run\`: every iter resumes the same Copilot session
               (in-extension parity; context grows monotonically).
   --fresh     For \`run\`: every iter starts a brand-new Copilot session
@@ -103,16 +103,16 @@ OPTIONS
               an early abort. Defaults to the baked abort token of the
               chosen prompt mode (or none for --prompt).
   --help, -h  Show this help.
-  --version, -V  Print the ralph-tui package version and exit.
+  --version, -V  Print the autopilot package version and exit.
 
 ENV
   AUTOPILOT_EVENTS_DIR  Override the runs root (default ~/.copilot/autopilot/events).
                     Legacy: RALPH_EVENTS_DIR still honored (deprecated).
   AUTOPILOT_RUNS_DIR  Override the run-state root used by
-                    \`ralph-tui run\` (default ~/.copilot/autopilot/runs).
+                    \`autopilot run\` (default ~/.copilot/autopilot/runs).
                     Legacy: RALPH_TUI_RUNS_DIR still honored (deprecated).
   AUTOPILOT_COPILOT_BIN  Override the \`copilot\` executable used by
-                    \`ralph-tui run\` (default \`copilot\` on $PATH).
+                    \`autopilot run\` (default \`copilot\` on $PATH).
                     Legacy: RALPH_TUI_COPILOT_BIN still honored (deprecated).
 `;
 
@@ -124,10 +124,10 @@ ENV
  *  --completion-promise, --abort-promise, --pause, --resume, --stop,
  *  --status). When adding a new value flag, append it to
  *  `VALUE_FLAGS` AND update the USAGE block above so
- *  `ralph-tui --help` keeps matching the parser. */
+ *  `autopilot --help` keeps matching the parser. */
 const VALUE_FLAGS = new Set(["older-than", "limit", "max", "focus", "prompt", "completion-promise", "abort-promise", "pause", "resume", "stop", "status"]);
 
-/** Default `--max` iterations per loop mode for `ralph-tui run`.
+/** Default `--max` iterations per loop mode for `autopilot run`.
  *
  *  `self-improve` has no fixed scope: the agent's job is to drain the
  *  entire backlog (failing CI runs, stale PRs, open issues, latent
@@ -261,7 +261,7 @@ export function installStdinAbortListener(onAbort) {
 }
 
 function fail(msg, code = 2) {
-    process.stderr.write(`ralph-tui: ${msg}\n`);
+    process.stderr.write(`autopilot: ${msg}\n`);
     process.exit(code);
 }
 
@@ -271,7 +271,7 @@ function fail(msg, code = 2) {
  *  handler already prints its own line — printing twice would just
  *  be noise.
  *
- *  Field bug from a real run: pressing `q` in `ralph-tui run` left
+ *  Field bug from a real run: pressing `q` in `autopilot run` left
  *  the static last Ink frame on screen with no further output, since
  *  the runner only checks `stopRequested` between iters and won't
  *  kill the in-flight copilot subprocess. Users perceived this as
@@ -293,7 +293,7 @@ export function formatAbortMessage(reason) {
     // installed in cmdRun — don't double up.
     if (reason === "signal_SIGINT") return null;
     const label = reason === "user_quit" ? "q" : reason;
-    return `\nralph-tui run: ${label} received — finishing current iteration, then stopping. Hit Ctrl-C to abort hard.\n`;
+    return `\nautopilot run: ${label} received — finishing current iteration, then stopping. Hit Ctrl-C to abort hard.\n`;
 }
 
 function cmdList(opts = {}) {
@@ -320,7 +320,7 @@ function cmdList(opts = {}) {
     if (!entries.length) {
         process.stdout.write(
             `No runs found.\nRoot: ${resolveRunsRoot()}\n`
-            + `Arm a ralph_loop / self_improve / grow_project run, then re-run \`ralph-tui list\`.\n`,
+            + `Arm an ap_loop / self_improve / grow_project run, then re-run \`autopilot list\`.\n`,
         );
         return 0;
     }
@@ -357,7 +357,7 @@ function safeResolveEventsPath(label, runId) {
 
 export function cmdReplay(runId) {
     if (!runId) {
-        fail("replay: <runId> is required (try `ralph-tui list` first)");
+        fail("replay: <runId> is required (try `autopilot list` first)");
         return 2;
     }
     const path = safeResolveEventsPath("replay", runId);
@@ -463,7 +463,7 @@ export function cmdDoctor() {
     process.stdout.write(lines.join("\n") + "\n");
     if (!healthy) {
         process.stderr.write(
-            `ralph-tui doctor: critical problem detected (root=${root}). `
+            `autopilot doctor: critical problem detected (root=${root}). `
             + `Check filesystem permissions and AUTOPILOT_EVENTS_DIR.\n`,
         );
         return 1;
@@ -532,7 +532,7 @@ export function cmdWhere() {
     return 0;
 }
 
-// `ralph-tui run` dispatcher. Splits into:
+// `autopilot run` dispatcher. Splits into:
 //   sibling sub-commands: --pause / --resume / --stop / --status <runId>
 //                         (mutate or read state.json of an existing run)
 //   driver:               --self-improve / --grow-project / --prompt
@@ -540,7 +540,7 @@ export function cmdWhere() {
 //                          process, with SIGINT/SIGTERM mapped to a
 //                          graceful stop request)
 export async function cmdRun(flags) {
-    // Lazy-imported so a `ralph-tui list` invocation doesn't pay the
+    // Lazy-imported so a `autopilot list` invocation doesn't pay the
     // child_process / runner-module init cost.
     const runner = await import("../src/runner.mjs");
 
@@ -551,7 +551,7 @@ export async function cmdRun(flags) {
     if (sibling) {
         const runId = flags[sibling];
         if (!runId || runId === true) {
-            fail(`run --${sibling}: <runId> is required (e.g. --${sibling} ralph-tui-self-improve-1700000000000)`);
+            fail(`run --${sibling}: <runId> is required (e.g. --${sibling} autopilot-self-improve-1700000000000)`);
             return 2;
         }
         try {
@@ -633,12 +633,12 @@ export async function cmdRun(flags) {
     const installSignal = (sig) => {
         const handler = () => {
             if (stopOnce) {
-                process.stderr.write(`\nralph-tui run: second ${sig} — aborting hard.\n`);
+                process.stderr.write(`\nautopilot run: second ${sig} — aborting hard.\n`);
                 process.exit(130);
             }
             stopOnce = true;
-            process.stderr.write(`\nralph-tui run: ${sig} received — finishing current iteration, then stopping. Hit ${sig} again to abort hard.\n`);
-            // We don't yet know the runId until runRalphTui has emitted
+            process.stderr.write(`\nautopilot run: ${sig} received — finishing current iteration, then stopping. Hit ${sig} again to abort hard.\n`);
+            // We don't yet know the runId until runAutopilot has emitted
             // it; the runner reads state.json each iter so flipping the
             // file is sufficient. We resolve the runId via the running
             // promise's bookkeeping below.
@@ -717,7 +717,7 @@ export async function cmdRun(flags) {
         })
         : () => {};
     try {
-        const result = await runner.runRalphTui({
+        const result = await runner.runAutopilot({
             mode,
             contextMode,
             prompt: promptText,
@@ -726,7 +726,7 @@ export async function cmdRun(flags) {
             completionPromise,
             abortPromise: abortPromise ?? undefined,
             // When the TUI is mounted, Ink owns the terminal — any
-            // `runRalphTui` writes to stdout (e.g. the `# iter N/M`
+            // `runAutopilot` writes to stdout (e.g. the `# iter N/M`
             // banner) interleave with Ink's frames and corrupt the
             // render. Pipe runner stdout to a no-op sink in TUI
             // mode; stderr stays attached so unrecoverable errors
@@ -771,7 +771,7 @@ export async function cmdRun(flags) {
                         })
                             .then((inst) => { runUiInstance = inst; })
                             .catch((err) => {
-                                process.stderr.write(`ralph-tui run: TUI mount failed (${err?.message ?? err}); continuing in headless mode.\n`);
+                                process.stderr.write(`autopilot run: TUI mount failed (${err?.message ?? err}); continuing in headless mode.\n`);
                             });
                     }
                 }
@@ -823,7 +823,7 @@ export async function cmdRun(flags) {
 export async function main(argv = process.argv.slice(2)) {
     const { cmd, positional, flags } = parseArgv(argv);
     if (flags.version) {
-        process.stdout.write(`ralph-tui ${readTuiVersion()}\n`);
+        process.stdout.write(`autopilot ${readTuiVersion()}\n`);
         return 0;
     }
     if (flags.help || cmd === "help" || (!cmd && !positional.length)) {
@@ -846,13 +846,13 @@ export async function main(argv = process.argv.slice(2)) {
 }
 
 // Only run main() when invoked as a script (not when imported by tests).
-// `npm link` installs the bin as a symlink (e.g. /opt/homebrew/bin/ralph-tui
+// `npm link` installs the bin as a symlink (e.g. /opt/homebrew/bin/autopilot
 // → …/packages/tui/bin/tui.mjs); resolve it through realpath so the
 // "is this the entry point?" check survives the indirection. Kept fully
 // synchronous so this module body has no top-level await — Node 22+ emits
 // "Detected unsettled top-level await" when `process.exit()` fires from
 // the main() promise chain before the implicit module-evaluation TLA is
-// observed as settled (issue: spurious warning in `ralph-tui run` exit).
+// observed as settled (issue: spurious warning in `autopilot run` exit).
 let isDirectRun = false;
 try {
     if (process.argv[1]) {
@@ -873,10 +873,10 @@ if (isDirectRun) {
         // sees the actionable error, not a stack trace. Genuinely
         // unexpected failures keep the full stack for debuggability.
         if (err instanceof TypeError) {
-            process.stderr.write(`ralph-tui: ${err.message}\n`);
+            process.stderr.write(`autopilot: ${err.message}\n`);
             process.exit(2);
         }
-        process.stderr.write(`ralph-tui: ${err?.stack ?? err}\n`);
+        process.stderr.write(`autopilot: ${err?.stack ?? err}\n`);
         process.exit(1);
     });
 }

--- a/packages/tui/package-lock.json
+++ b/packages/tui/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@copilot-ralph-extension/tui",
+  "name": "@autopilot/tui",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@copilot-ralph-extension/tui",
+      "name": "@autopilot/tui",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -15,7 +15,7 @@
         "react": "^19.2.5"
       },
       "bin": {
-        "ralph-tui": "bin/tui.mjs"
+        "autopilot": "bin/tui.mjs"
       },
       "devDependencies": {
         "ink-testing-library": "^4.0.0"

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -9,7 +9,6 @@
     "github-copilot",
     "copilot-cli",
     "extension",
-    "ralph-wiggum",
     "tui",
     "ink",
     "observability"

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@copilot-ralph-extension/tui",
+  "name": "@autopilot/tui",
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Terminal UI for visualizing live ralph_loop / self_improve / grow_project runs (issue #22).",
+  "description": "Terminal UI for visualizing live ap_loop / self_improve / grow_project runs (issue #22).",
   "author": "Taras Kloba",
   "keywords": [
     "github-copilot",
@@ -15,15 +15,15 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kloba/copilot-ralph-extension.git",
+    "url": "git+https://github.com/kloba/autopilot.git",
     "directory": "packages/tui"
   },
   "bugs": {
-    "url": "https://github.com/kloba/copilot-ralph-extension/issues"
+    "url": "https://github.com/kloba/autopilot/issues"
   },
-  "homepage": "https://github.com/kloba/copilot-ralph-extension#readme",
+  "homepage": "https://github.com/kloba/autopilot#readme",
   "bin": {
-    "ralph-tui": "./bin/tui.mjs"
+    "autopilot": "./bin/tui.mjs"
   },
   "main": "./src/events.mjs",
   "exports": {

--- a/packages/tui/src/components/App.mjs
+++ b/packages/tui/src/components/App.mjs
@@ -1,4 +1,4 @@
-// <App> — top-level Ink component for `ralph-tui watch`.
+// <App> — top-level Ink component for `autopilot watch`.
 //
 // Owns the events array (fed from tailEventsFile) and runs foldEvents()
 // to compute the snapshot every render. Uses React.createElement (no
@@ -29,11 +29,11 @@ const h = React.createElement;
  * @param {string} [props.runId]      Display label for the header.
  * @param {(reason: string) => void} [props.onUserAbort] Optional
  *        callback fired when the user requests to abort via Ctrl-C
- *        or `q`. When provided (issue #48 slice 8 — `ralph-tui run`
+ *        or `q`. When provided (issue #48 slice 8 — `autopilot run`
  *        TUI mount), the caller can hook this to call
  *        `runner.stopRun(runId, …)` so the driver gets a graceful
  *        stop request instead of being orphaned mid-iter when the
- *        TUI tears down. Read-only callers (`ralph-tui watch`)
+ *        TUI tears down. Read-only callers (`autopilot watch`)
  *        omit it; the App still exits but no driver action occurs.
  */
 export default function App({ eventStream, events: initial = [], runId, onUserAbort }) {
@@ -84,7 +84,7 @@ export default function App({ eventStream, events: initial = [], runId, onUserAb
                     }
                 }
             } catch (err) {
-                process.stderr.write(`ralph-tui: tail error: ${err?.message ?? err}\n`);
+                process.stderr.write(`autopilot: tail error: ${err?.message ?? err}\n`);
                 exit(err);
             }
         })();

--- a/packages/tui/src/components/Controls.mjs
+++ b/packages/tui/src/components/Controls.mjs
@@ -1,4 +1,4 @@
-// <Controls> — bottom hint row for `ralph-tui watch`.
+// <Controls> — bottom hint row for `autopilot watch`.
 //
 // Uses React.createElement (no JSX) so the file runs in plain Node ESM.
 

--- a/packages/tui/src/components/Header.mjs
+++ b/packages/tui/src/components/Header.mjs
@@ -161,10 +161,18 @@ export default function Header({ snapshot }) {
           )
         : null;
 
+    // Issue #54 slice 1 — heading "Run" sits as the first child
+    // inside the bordered Box, matching the existing inside-border
+    // heading convention used by Timeline / DetailPane / TasksPane.
+    // The status badge (RUN / DONE / PAUSE) lives in the topRow
+    // right of the heading, so the heading is the user-facing pane
+    // label rather than a duplicate of the status.
+    const heading = h(Text, { bold: true, underline: true }, "Run");
+
     return h(Box, {
         borderStyle: "round",
         borderColor: "blue",
         paddingX: 1,
         flexDirection: "column",
-    }, topRow, workItemRow, backlogRow);
+    }, heading, topRow, workItemRow, backlogRow);
 }

--- a/packages/tui/src/components/Header.mjs
+++ b/packages/tui/src/components/Header.mjs
@@ -1,4 +1,4 @@
-// <Header> — top status banner for `ralph-tui watch` (issue #22).
+// <Header> — top status banner for `autopilot watch` (issue #22).
 //
 // Issue #48 slice 7: extended with a backlog row (open issues / open
 // PRs / red CI runs) so the user can see the loop's external scope at

--- a/packages/tui/src/components/StagesRow.mjs
+++ b/packages/tui/src/components/StagesRow.mjs
@@ -122,11 +122,18 @@ export default function StagesRow({ snapshot }) {
         }
     }
 
+    // Issue #54 slice 1 — heading "Stages" matches the inside-
+    // border convention used by the rest of the panes (Timeline /
+    // DetailPane / TasksPane).
+    const heading = h(Text, { bold: true, underline: true }, "Stages");
+
     return h(Box, {
         borderStyle: "single",
         borderColor: "gray",
         paddingX: 1,
-        flexDirection: "row",
-        flexWrap: "wrap",
-    }, ...pills);
+        flexDirection: "column",
+    },
+        heading,
+        h(Box, { flexDirection: "row", flexWrap: "wrap" }, ...pills),
+    );
 }

--- a/packages/tui/src/components/SubstagesPane.mjs
+++ b/packages/tui/src/components/SubstagesPane.mjs
@@ -35,11 +35,16 @@ export default function SubstagesPane({ snapshot, maxRows = 12 }) {
     const active = snapshot?.activeStage ?? null;
     const subs = snapshot?.currentStageSubstages ?? [];
 
-    const titleText = active
+    // Issue #54 slice 1 — heading "Activity" decouples the pane
+    // title from the `▸ STAGE_NAME` line, which now sits as the
+    // first body row. Matches the inside-border heading convention
+    // used by Timeline / DetailPane / TasksPane.
+    const heading = h(Text, { bold: true, underline: true }, "Activity");
+
+    const stageRowText = active
         ? `▸ ${active.name}  (substage activity)`
         : "▸ (no active stage)";
-
-    const title = h(Text, { bold: true, color: "cyan" }, titleText);
+    const stageRow = h(Text, { bold: true, color: "cyan" }, stageRowText);
 
     let body;
     if (!subs || subs.length === 0) {
@@ -74,5 +79,5 @@ export default function SubstagesPane({ snapshot, maxRows = 12 }) {
         borderColor: "gray",
         paddingX: 1,
         flexDirection: "column",
-    }, title, body);
+    }, heading, stageRow, body);
 }

--- a/packages/tui/src/components/TasksPane.mjs
+++ b/packages/tui/src/components/TasksPane.mjs
@@ -121,6 +121,9 @@ const STATE_COLOR = {
 };
 
 export default function TasksPane({ snapshot }) {
+    // Issue #54 slice 1 — heading "Tasks" matches the inside-border
+    // convention used by Timeline / DetailPane / LastCommit.
+    const heading = h(Text, { bold: true, underline: true }, "Tasks");
     const rows = computeTaskRows(snapshot);
     if (rows.length === 0) {
         return h(Box, {
@@ -129,6 +132,7 @@ export default function TasksPane({ snapshot }) {
             paddingX: 1,
             flexDirection: "column",
         },
+            heading,
             h(Text, { dimColor: true }, "tasks: (no task list yet)"),
         );
     }
@@ -157,5 +161,5 @@ export default function TasksPane({ snapshot }) {
         borderColor: "gray",
         paddingX: 1,
         flexDirection: "column",
-    }, ...elements);
+    }, heading, ...elements);
 }

--- a/packages/tui/src/components/Timeline.mjs
+++ b/packages/tui/src/components/Timeline.mjs
@@ -64,12 +64,29 @@ export default function Timeline({ snapshot, limit = DEFAULT_LIMIT }) {
             : kind === "pending" ? "cyan"
             : kind === "stagnant" ? "yellow"
             : "red";
+        // Issue #54 slice 2a — surface live excerpt for in-flight
+        // iters. When the iter has an excerpt set (mid-iter
+        // streaming via `usage_update` excerpt field, or post-iter
+        // `iteration_end`), render it. When the iter is in-flight
+        // (endedAt == null) and no excerpt has streamed yet, show
+        // a `(working…)` placeholder so the row signals progress
+        // rather than looking broken with `(no excerpt)`. Finished
+        // iters with no excerpt fall back to the historical
+        // placeholder so replay-fidelity for old runs is intact.
+        let excerptCell;
+        if (it.excerpt) {
+            excerptCell = h(Text, { dimColor: true }, truncate(it.excerpt, 80));
+        } else if (it.endedAt == null) {
+            excerptCell = h(Text, { dimColor: true }, "(working…)");
+        } else {
+            excerptCell = h(Text, { dimColor: true }, "(no excerpt)");
+        }
         return h(Box, { key: it.iteration, flexDirection: "row" },
             h(Text, { color }, GLYPH[kind]),
             h(Text, null, " "),
             h(Text, null, "#" + pad(it.iteration, totalWidth)),
             h(Text, null, "  "),
-            h(Text, { dimColor: true }, it.excerpt ? truncate(it.excerpt, 80) : "(no excerpt)"),
+            excerptCell,
         );
     });
 

--- a/packages/tui/src/components/Timeline.mjs
+++ b/packages/tui/src/components/Timeline.mjs
@@ -1,4 +1,4 @@
-// <Timeline> — scrolling iteration list for `ralph-tui watch` (issue #22).
+// <Timeline> — scrolling iteration list for `autopilot watch` (issue #22).
 //
 // Renders the most recent N iterations newest-first. Pure component;
 // uses React.createElement (no JSX) so it runs in plain Node ESM.

--- a/packages/tui/src/events.mjs
+++ b/packages/tui/src/events.mjs
@@ -1,4 +1,4 @@
-// Event contract for the ralph TUI (issue #22).
+// Event contract for the autopilot TUI (issue #22).
 //
 // The loop handler (extension/handler.mjs) writes one JSON object per line
 // to ~/.copilot/session-state/<id>/events.jsonl. The TUI tails that file,
@@ -26,7 +26,7 @@
  * @property {EventType} type
  * @property {number} ts            Epoch ms when the event was emitted.
  * @property {string} runId         Stable per-loop identifier (label + startedAt).
- * @property {string} [label]       "ralph_loop" | "self_improve" | "grow_project".
+ * @property {string} [label]       "ap_loop" | "self_improve" | "grow_project".
  * @property {number} [iteration]   1-indexed iteration counter.
  * @property {number} [maxIterations]
  * @property {number} [minIterations]

--- a/packages/tui/src/events.mjs
+++ b/packages/tui/src/events.mjs
@@ -731,6 +731,32 @@ export function foldEvents(events) {
                 if (Number.isFinite(ev.premiumRequests) && ev.premiumRequests >= 0) {
                     snap.premiumRequests = ev.premiumRequests;
                 }
+                // Issue #54 slice 2a — live Timeline excerpt. The
+                // runner streams root-agent `assistant.message`
+                // content into `usage_update` events whenever 80+
+                // new chars accumulate so the in-flight iter row
+                // shows live progress instead of `(working…)`. Both
+                // `snap.lastExcerpt` (run-scope) and
+                // `iterations[last].excerpt` (per-iter) are updated
+                // together, gated by the same `endedAt == null` +
+                // iter-match check so a late event landing after
+                // `iteration_end` (e.g. delayed delivery during the
+                // iter rollover) cannot regress either surface to a
+                // stale value. The closed iter's excerpt stays as
+                // the canonical post-iter reduction wrote it, and
+                // lastExcerpt stays on the most-recent observed
+                // iter — preserving Detail/Timeline parity.
+                if (typeof ev.excerpt === "string" && ev.excerpt) {
+                    const last = snap.iterations[snap.iterations.length - 1];
+                    if (
+                        last
+                        && last.endedAt == null
+                        && (!Number.isFinite(ev.iteration) || last.iteration === ev.iteration)
+                    ) {
+                        last.excerpt = ev.excerpt;
+                        snap.lastExcerpt = ev.excerpt;
+                    }
+                }
                 break;
             }
             case "pause":

--- a/packages/tui/src/plain.mjs
+++ b/packages/tui/src/plain.mjs
@@ -1,7 +1,7 @@
-// Plain-mode renderer for the ralph TUI (issue #22).
+// Plain-mode renderer for the autopilot TUI (issue #22).
 //
 // The Ink-based watch UI (slice 5) requires a TTY plus user-space npm
-// dependencies. CI logs, asciinema recordings, and `ralph-tui watch
+// dependencies. CI logs, asciinema recordings, and `autopilot watch
 // --plain` need a non-interactive stream of human-readable lines that
 // preserves *every* event's information without ANSI tricks.
 //
@@ -196,7 +196,7 @@ export function formatEventLine(ev) {
     }
     if (typeof ev.reason === "string" && ev.reason) {
         // JSON.stringify the reason iff it contains whitespace, so a
-        // user-supplied multi-word reason from ralph_pause / ralph_stop
+        // user-supplied multi-word reason from ap_pause / ap_stop
         // (e.g. "user requested" or a flattened multi-line paste) stays
         // a single awk-parseable token in the rendered log line. Baked
         // single-token reasons (completion_promise, abort_promise,

--- a/packages/tui/src/run-ui.mjs
+++ b/packages/tui/src/run-ui.mjs
@@ -1,7 +1,7 @@
-// `ralph-tui run` interactive entry point (issue #48 slice 8).
+// `autopilot run` interactive entry point (issue #48 slice 8).
 //
 // Mounts the Ink-rendered <App /> against the events.jsonl file that
-// runRalphTui is concurrently writing to. Imported dynamically by
+// runAutopilot is concurrently writing to. Imported dynamically by
 // bin/tui.mjs so a fresh checkout without `npm install` falls back to
 // plain (headless) mode rather than crashing on the `ink` import.
 //

--- a/packages/tui/src/runner.mjs
+++ b/packages/tui/src/runner.mjs
@@ -1,5 +1,5 @@
-// `ralph-tui run` driver — out-of-session sibling of the in-extension
-// ralph_loop / self_improve / grow_project tools.
+// `autopilot run` driver — out-of-session sibling of the in-extension
+// ap_loop / self_improve / grow_project tools.
 //
 // Why a separate driver? Because the in-extension loop runs as part of
 // the user's current Copilot session — so the LLM context grows
@@ -7,7 +7,7 @@
 // in-session loop (the user sees every iter inline, and pause/resume
 // mid-session lets the user chat with the agent), but it also creates
 // a context-rot failure mode where late iterations are dominated by
-// early-iteration noise. The `ralph-tui run` driver runs each
+// early-iteration noise. The `autopilot run` driver runs each
 // iteration as a fresh `copilot -p ...` subprocess so:
 //
 //   --continue   resume the same Copilot session every iter (parity
@@ -28,7 +28,7 @@
 //     iter 1 and reused via `--resume=<sessionId>` for iter 2+ when
 //     the driver is in --continue mode.
 //
-// Pause/resume/stop are out-of-band: a sibling `ralph-tui run --pause
+// Pause/resume/stop are out-of-band: a sibling `autopilot run --pause
 // <runId>` flips a flag in the run's state.json (CAS-protected via
 // lockfile so concurrent pause+stop don't lose updates), and the
 // driver re-reads state at each iter boundary. The current child
@@ -72,7 +72,7 @@ export { PROMPT_SELF_IMPROVE, PROMPT_GROW_PROJECT, COMPLETION_PROMISE, BAKED_ABO
 // would be rejected by handler.mjs is also rejected here.
 export const MAX_FOCUS_CHARS = 2000;
 
-// Cap on the user-supplied --prompt string for ralph_loop-style runs.
+// Cap on the user-supplied --prompt string for ap_loop-style runs.
 // Mirrors the in-extension MAX_PROMPT_CHARS.
 export const MAX_PROMPT_CHARS = 65536;
 
@@ -350,9 +350,9 @@ export function composePrompt({ mode, prompt, focus }) {
 
 /** Mode → label used by the event emitter and the run directory name. */
 function labelForMode(mode) {
-    if (mode === "self-improve") return "ralph-tui-self-improve";
-    if (mode === "grow-project") return "ralph-tui-grow-project";
-    if (mode === "prompt") return "ralph-tui-prompt";
+    if (mode === "self-improve") return "autopilot-self-improve";
+    if (mode === "grow-project") return "autopilot-grow-project";
+    if (mode === "prompt") return "autopilot-prompt";
     throw new TypeError(`labelForMode: unknown mode "${mode}"`);
 }
 
@@ -637,7 +637,7 @@ export function looksLikeGitCommit(command) {
  *  invocation) and runs at most once per observed `git commit`.
  *
  *  Tests inject their own `gitExec` to stub repo state without
- *  shelling out — see `runRalphTui({ gitExec, … })`. */
+ *  shelling out — see `runAutopilot({ gitExec, … })`. */
 function defaultGitExec({ args, cwd, env }) {
     try {
         const r = nodeSpawnSync("git", args, {
@@ -1078,7 +1078,7 @@ export function runOneIteration({
         });
 
         // Expose the child handle to the caller for SIGINT plumbing
-        // via the resolve hook; runRalphTui registers a stop-watcher
+        // via the resolve hook; runAutopilot registers a stop-watcher
         // before awaiting.
         if (typeof onLine === "function" && onLine.__captureChild) {
             onLine.__captureChild(child, () => { killed = true; });
@@ -1118,7 +1118,7 @@ export function runOneIteration({
  *   onIteration         Callback fired between iters with state.
  *   stdout, stderr      Stream sinks for human-readable output.
  */
-export async function runRalphTui(opts) {
+export async function runAutopilot(opts) {
     const {
         mode,
         contextMode,
@@ -1148,22 +1148,22 @@ export async function runRalphTui(opts) {
     } = opts;
 
     if (mode !== "self-improve" && mode !== "grow-project" && mode !== "prompt") {
-        throw new TypeError(`runRalphTui: invalid mode "${mode}"`);
+        throw new TypeError(`runAutopilot: invalid mode "${mode}"`);
     }
     if (contextMode !== "continue" && contextMode !== "fresh") {
-        throw new TypeError(`runRalphTui: contextMode must be "continue" or "fresh"`);
+        throw new TypeError(`runAutopilot: contextMode must be "continue" or "fresh"`);
     }
     if (mode === "prompt" && (!prompt || typeof prompt !== "string")) {
-        throw new TypeError(`runRalphTui: --prompt requires a non-empty string when mode === "prompt"`);
+        throw new TypeError(`runAutopilot: --prompt requires a non-empty string when mode === "prompt"`);
     }
     if (mode === "prompt" && prompt.length > MAX_PROMPT_CHARS) {
-        throw new TypeError(`runRalphTui: prompt exceeds ${MAX_PROMPT_CHARS} characters`);
+        throw new TypeError(`runAutopilot: prompt exceeds ${MAX_PROMPT_CHARS} characters`);
     }
     if (!Number.isInteger(max) || max < 1 || max > MAX_ALLOWED_ITERATIONS) {
-        throw new TypeError(`runRalphTui: max must be an integer in [1, ${MAX_ALLOWED_ITERATIONS}], got ${max}`);
+        throw new TypeError(`runAutopilot: max must be an integer in [1, ${MAX_ALLOWED_ITERATIONS}], got ${max}`);
     }
     const focusCheck = validateFocus(focus);
-    if (focusCheck.error) throw new TypeError(`runRalphTui: ${focusCheck.error}`);
+    if (focusCheck.error) throw new TypeError(`runAutopilot: ${focusCheck.error}`);
 
     const startedAt = now();
     const label = labelForMode(mode);
@@ -1190,7 +1190,7 @@ export async function runRalphTui(opts) {
         totalPausedMs: 0,
     }, env);
 
-    // Emit the canonical `armed` event so `ralph-tui list/stats`
+    // Emit the canonical `armed` event so `autopilot list/stats`
     // pick up this run.
     emitter.write({
         type: "armed",
@@ -1703,7 +1703,7 @@ export async function runRalphTui(opts) {
         } catch (err) {
             terminationReason = "error";
             terminationNote = err?.message ?? String(err);
-            stderr.write?.(`ralph-tui run: subprocess error: ${terminationNote}\n`);
+            stderr.write?.(`autopilot run: subprocess error: ${terminationNote}\n`);
             // Even on subprocess error, fold in any iter-live usage
             // counters (the child may have emitted some
             // assistant.message events before crashing) so the final
@@ -1833,7 +1833,7 @@ export async function runRalphTui(opts) {
         if (result.exitCode !== 0) {
             terminationReason = "subprocess_failed";
             terminationNote = `copilot exited with code ${result.exitCode}: ${result.stderr.slice(0, 500)}`;
-            stderr.write?.(`ralph-tui run: ${terminationNote}\n`);
+            stderr.write?.(`autopilot run: ${terminationNote}\n`);
             break;
         }
 

--- a/packages/tui/src/runner.mjs
+++ b/packages/tui/src/runner.mjs
@@ -38,8 +38,8 @@
 
 import { spawn as nodeSpawn, spawnSync as nodeSpawnSync } from "node:child_process";
 import { homedir } from "node:os";
-import { mkdirSync, readFileSync, writeFileSync, renameSync, existsSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync, renameSync, existsSync, rmSync, appendFileSync } from "node:fs";
+import { join, dirname } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 
 import {
@@ -94,18 +94,105 @@ const MAX_LOCK_RETRIES = 200; // 5s worst-case
 
 // ─── State-file CAS ────────────────────────────────────────────────
 
-/** Resolve the state-files root, honoring $RALPH_TUI_RUNS_DIR. */
-export function resolveStateRoot(env = process.env) {
-    const override = env?.RALPH_TUI_RUNS_DIR;
-    if (override && typeof override === "string" && override.trim()) {
-        return override.trim();
+// Print a one-line stderr deprecation notice the FIRST time a given
+// migration trigger fires, then drop a sentinel line under
+// ~/.copilot/autopilot/. Mirror of the helpers in
+// extension/events-emit.mjs and packages/tui/src/writer.mjs — the
+// three surfaces share a sentinel so a user only sees each notice
+// once across all three call sites.
+function emitDeprecationOnce({ key, message, sentinelPath, fs, stderr }) {
+    try {
+        const content = fs.readFileSync(sentinelPath, "utf8");
+        if (content.split("\n").some((l) => l === key)) return;
+    } catch { /* sentinel missing or unreadable */ }
+    try {
+        stderr.write(message);
+        fs.mkdirSync(dirname(sentinelPath), { recursive: true });
+        fs.appendFileSync(sentinelPath, key + "\n");
+    } catch { /* best-effort */ }
+}
+
+/** Resolve the state-files root, preferring $AUTOPILOT_RUNS_DIR, falling back
+ *  to $RALPH_TUI_RUNS_DIR (deprecated), then to ~/.copilot/autopilot/runs. */
+export function resolveStateRoot({
+    env = process.env,
+    fs: fsArg = { readFileSync, existsSync, mkdirSync, appendFileSync },
+    stderr: stderrArg = process.stderr,
+    sentinelPath: sentinelPathArg,
+} = {}) {
+    const sentinelPath = sentinelPathArg ?? join(homedir(), ".copilot", "autopilot", ".migration-notice-shown");
+
+    // Primary: $AUTOPILOT_RUNS_DIR
+    const newOverride = env?.AUTOPILOT_RUNS_DIR;
+    if (typeof newOverride === "string" && newOverride.trim()) return newOverride.trim();
+
+    // Legacy fallback: $RALPH_TUI_RUNS_DIR (deprecated)
+    const legacyOverride = env?.RALPH_TUI_RUNS_DIR;
+    if (typeof legacyOverride === "string" && legacyOverride.trim()) {
+        emitDeprecationOnce({
+            key: "env:RALPH_TUI_RUNS_DIR",
+            message: "[autopilot] note: env $RALPH_TUI_RUNS_DIR is deprecated, please use $AUTOPILOT_RUNS_DIR (still honored)\n",
+            sentinelPath,
+            fs: fsArg,
+            stderr: stderrArg,
+        });
+        return legacyOverride.trim();
     }
-    return join(homedir(), ".copilot", "ralph-tui", "runs");
+
+    // Default paths
+    const newDefault = join(homedir(), ".copilot", "autopilot", "runs");
+    const oldDefault = join(homedir(), ".copilot", "ralph-tui", "runs");
+
+    let newExists = false;
+    let oldExists = false;
+    try { newExists = fsArg.existsSync(newDefault); } catch { /* swallow */ }
+    try { oldExists = fsArg.existsSync(oldDefault); } catch { /* swallow */ }
+
+    if (!newExists && oldExists) {
+        emitDeprecationOnce({
+            key: `path:${oldDefault}`,
+            message: `[autopilot] note: reading from legacy ~/.copilot/ralph-tui/runs (default is now ~/.copilot/autopilot/runs)\n`,
+            sentinelPath,
+            fs: fsArg,
+            stderr: stderrArg,
+        });
+        return oldDefault;
+    }
+
+    return newDefault;
+}
+
+/** Resolve the copilot binary path, preferring $AUTOPILOT_COPILOT_BIN, falling
+ *  back to $RALPH_TUI_COPILOT_BIN (deprecated), then "copilot". */
+export function resolveCopilotBin({
+    env = process.env,
+    fs: fsArg = { readFileSync, existsSync, mkdirSync, appendFileSync },
+    stderr: stderrArg = process.stderr,
+    sentinelPath: sentinelPathArg,
+} = {}) {
+    const sentinelPath = sentinelPathArg ?? join(homedir(), ".copilot", "autopilot", ".migration-notice-shown");
+
+    const newOverride = env?.AUTOPILOT_COPILOT_BIN;
+    if (typeof newOverride === "string" && newOverride.trim()) return newOverride.trim();
+
+    const legacyOverride = env?.RALPH_TUI_COPILOT_BIN;
+    if (typeof legacyOverride === "string" && legacyOverride.trim()) {
+        emitDeprecationOnce({
+            key: "env:RALPH_TUI_COPILOT_BIN",
+            message: "[autopilot] note: env $RALPH_TUI_COPILOT_BIN is deprecated, please use $AUTOPILOT_COPILOT_BIN (still honored)\n",
+            sentinelPath,
+            fs: fsArg,
+            stderr: stderrArg,
+        });
+        return legacyOverride.trim();
+    }
+
+    return "copilot";
 }
 
 /** Path to a run's state.json. */
 export function resolveStatePath(runId, env = process.env) {
-    return join(resolveStateRoot(env), runId, "state.json");
+    return join(resolveStateRoot({ env }), runId, "state.json");
 }
 
 /** Acquire a directory-based lock for the state file, retrying on EEXIST.
@@ -174,7 +261,7 @@ export function updateState(runId, mutator, env = process.env) {
 /** Initial state-file write; creates the run directory.  */
 function initState(runId, initial, env = process.env) {
     const statePath = resolveStatePath(runId, env);
-    const dir = join(resolveStateRoot(env), runId);
+    const dir = join(resolveStateRoot({ env }), runId);
     mkdirSync(dir, { recursive: true });
     const lockPath = acquireLock(statePath);
     try {
@@ -926,7 +1013,7 @@ export function runOneIteration({
     extraArgs = [],
     onLine, // optional callback per parsed event (for live feedback)
 }) {
-    const bin = copilotBin ?? env.RALPH_TUI_COPILOT_BIN ?? "copilot";
+    const bin = copilotBin ?? resolveCopilotBin({ env });
     const args = ["-p", prompt, "--allow-all-tools", "--output-format", "json"];
     if (resumeSessionId) args.push(`--resume=${resumeSessionId}`);
     else if (sessionName) args.push("-n", sessionName);
@@ -1018,7 +1105,8 @@ export function runOneIteration({
  *   abortPromise        Default = abort token of the chosen mode.
  *   spawn               Inject for tests.
  *   copilotBin          Inject for tests. Falls back to
- *                       $RALPH_TUI_COPILOT_BIN, then "copilot".
+ *                       $AUTOPILOT_COPILOT_BIN, then $RALPH_TUI_COPILOT_BIN
+ *                       (legacy), then "copilot".
  *   env, fs, now        Inject for tests.
  *   eventEmitter        Inject for tests; otherwise createEventEmitter
  *                       is invoked.

--- a/packages/tui/src/runner.mjs
+++ b/packages/tui/src/runner.mjs
@@ -558,6 +558,14 @@ function defaultGitExec({ args, cwd, env }) {
             env,
             encoding: "utf8",
             stdio: ["ignore", "pipe", "pipe"],
+            // Issue #54 slice 2c — arm-time replay shells out to git
+            // before the first iter renders. A 200 ms ceiling protects
+            // against a wedged git repo (lock file, hung credential
+            // helper) silently delaying the run.start path; the
+            // emitCommitObservedFromHead caller already swallows null,
+            // so a timeout just means "skip the LastCommit pane on
+            // mount" rather than crash.
+            timeout: 200,
         });
         if (r.status !== 0) return null;
         return typeof r.stdout === "string" ? r.stdout : null;
@@ -1108,6 +1116,34 @@ export async function runRalphTui(opts) {
         mode,
     });
 
+    // Issue #54 slice 2c — replay HEAD on mount so the LastCommit
+    // pane is never empty when commits exist on disk. Without this
+    // emit, a fresh run that hasn't yet made a commit (e.g. iter 0,
+    // or the first few iters of a `--prompt` run that doesn't touch
+    // git) shows an empty pane even though `git log -1` has plenty
+    // to surface. Carries `iteration: 0` so foldEvents lays the
+    // arm-time HEAD into `snap.lastCommit` before any iter has run;
+    // a later `commit_observed` from the iter loop simply
+    // overwrites it (which is the desired behaviour — newest commit
+    // wins). When `gitExec` is null (test runner without a stub) or
+    // the cwd isn't a repo, `readHeadCommit` returns null and we
+    // silently skip — the pane stays empty exactly like before.
+    try {
+        const armHead = readHeadCommit({ gitExec, cwd, env });
+        if (armHead) {
+            emitter.write({
+                type: "commit_observed",
+                ts: now(),
+                runId,
+                label,
+                iteration: 0,
+                sha: armHead.sha,
+                subject: armHead.subject,
+                trailers: armHead.trailers,
+            });
+        }
+    } catch { /* serialization rejection — skip */ }
+
     if (onRunId) {
         try { onRunId(runId); } catch { /* swallow */ }
     }
@@ -1442,6 +1478,20 @@ export async function runRalphTui(opts) {
         // reconciliation pulls everything back into agreement.
         let iterLiveOutputTokens = 0;
         let iterLivePremiumRequests = null;
+        // Issue #54 slice 2a — per-iter accumulator of root-agent
+        // assistant content used for live Timeline excerpt updates.
+        // Concatenates each `assistant.message.data.content` chunk
+        // (root agent only — sub-agent excerpts would clobber the
+        // user-visible iter narration). Capped at LIVE_EXCERPT_BYTES
+        // chars at emit time (events.mjs serializer also caps at 500
+        // surrogate-safely as defence in depth). Reset implicitly
+        // because the whole `onLine` closure is rebuilt per-iter.
+        let iterLiveExcerpt = "";
+        let iterLiveExcerptLastEmittedLen = 0;
+        // 80 chars ≈ one Timeline row's worth of new content. Below
+        // this we don't bother emitting — Timeline truncates to 80
+        // anyway, so a smaller delta would be invisible to the user.
+        const LIVE_EXCERPT_THRESHOLD = 80;
         const onLine = (rawEvent) => {
             // `runOneIteration` already wraps this in try/catch so a
             // throw here is silently swallowed — but a swallowed
@@ -1464,6 +1514,16 @@ export async function runRalphTui(opts) {
             try {
                 if (rawEvent && rawEvent.type === "assistant.message" && rawEvent.data && !rawEvent.agentId) {
                     const tok = Number(rawEvent.data.outputTokens);
+                    // Issue #54 slice 2a — accumulate root-agent
+                    // content for live Timeline excerpt streaming.
+                    // Done independently of the tokens path so a
+                    // root-agent message with no outputTokens (e.g.
+                    // a streamed-in-parts assistant message where
+                    // only the final chunk carries the cumulative
+                    // delta) still feeds the excerpt accumulator.
+                    if (typeof rawEvent.data.content === "string" && rawEvent.data.content.length > 0) {
+                        iterLiveExcerpt += rawEvent.data.content;
+                    }
                     if (Number.isFinite(tok) && tok > 0) {
                         iterLiveOutputTokens += tok;
                         const ev = {
@@ -1477,7 +1537,48 @@ export async function runRalphTui(opts) {
                         if (runPremiumRequests !== null || iterLivePremiumRequests !== null) {
                             ev.premiumRequests = (runPremiumRequests ?? 0) + (iterLivePremiumRequests ?? 0);
                         }
+                        // Piggyback live excerpt onto this same
+                        // event whenever we have new content. The
+                        // FIRST excerpt fires as soon as ANY content
+                        // accumulates so a terse iter (1-79 chars)
+                        // doesn't show `(working…)` for the whole
+                        // duration. Subsequent updates apply the
+                        // 80-char delta threshold so we don't churn
+                        // the event stream. Reusing the existing
+                        // usage_update keeps the event stream lean
+                        // (no separate excerpt-only event type) and
+                        // decouples emit cadence from token cadence.
+                        const newChars = iterLiveExcerpt.length - iterLiveExcerptLastEmittedLen;
+                        const isFirstExcerpt = iterLiveExcerptLastEmittedLen === 0 && iterLiveExcerpt.length > 0;
+                        if (isFirstExcerpt || newChars >= LIVE_EXCERPT_THRESHOLD) {
+                            ev.excerpt = iterLiveExcerpt.slice(0, 500);
+                            iterLiveExcerptLastEmittedLen = iterLiveExcerpt.length;
+                        }
                         emitter.write(ev);
+                    } else {
+                        const newChars = iterLiveExcerpt.length - iterLiveExcerptLastEmittedLen;
+                        const isFirstExcerpt = iterLiveExcerptLastEmittedLen === 0 && iterLiveExcerpt.length > 0;
+                        if (isFirstExcerpt || newChars >= LIVE_EXCERPT_THRESHOLD) {
+                            // No tokens, but new content worth
+                            // surfacing. Emit an excerpt-bearing
+                            // usage_update so the Timeline row
+                            // updates even when the agent is between
+                            // token-bearing message boundaries.
+                            const ev = {
+                                type: "usage_update",
+                                ts: now(),
+                                runId,
+                                label,
+                                iteration: iter,
+                                tokens: { input: 0, output: runOutputTokens + iterLiveOutputTokens },
+                                excerpt: iterLiveExcerpt.slice(0, 500),
+                            };
+                            if (runPremiumRequests !== null || iterLivePremiumRequests !== null) {
+                                ev.premiumRequests = (runPremiumRequests ?? 0) + (iterLivePremiumRequests ?? 0);
+                            }
+                            iterLiveExcerptLastEmittedLen = iterLiveExcerpt.length;
+                            emitter.write(ev);
+                        }
                     }
                 } else if (rawEvent && rawEvent.type === "result") {
                     const pr = Number(rawEvent.usage?.premiumRequests);

--- a/packages/tui/src/tail.mjs
+++ b/packages/tui/src/tail.mjs
@@ -1,4 +1,4 @@
-// Stdlib-only JSONL file reader / tailer for the ralph TUI (issue #22).
+// Stdlib-only JSONL file reader / tailer for the autopilot TUI (issue #22).
 //
 // readEventsFile() reads a complete events.jsonl synchronously — used by
 // `replay` for fixed historical runs and by tests.

--- a/packages/tui/src/watch.mjs
+++ b/packages/tui/src/watch.mjs
@@ -1,4 +1,4 @@
-// `ralph-tui watch` interactive entry point (issue #22).
+// `autopilot watch` interactive entry point (issue #22).
 //
 // Mounts the Ink-rendered <App /> against a live tailed events.jsonl.
 // Imported dynamically by bin/tui.mjs so a fresh checkout without

--- a/packages/tui/src/writer.mjs
+++ b/packages/tui/src/writer.mjs
@@ -1,9 +1,9 @@
-// JSONL event writer for the ralph TUI (issue #22).
+// JSONL event writer for the autopilot TUI (issue #22).
 //
 // The loop handler in extension/handler.mjs imports createEventWriter() and
 // calls writer.emit(ev) at iteration boundaries. The writer keeps a single
 // append-mode file descriptor open per run and maintains a sibling
-// `runs/index.jsonl` so `ralph-tui list` can enumerate past runs without
+// `runs/index.jsonl` so `autopilot list` can enumerate past runs without
 // scanning every per-run directory.
 //
 // Design constraints:
@@ -265,7 +265,7 @@ export function createEventWriter({
     };
 
     const recordIndex = (ev) => {
-        // index.jsonl carries one line per `armed` event so `ralph-tui list`
+        // index.jsonl carries one line per `armed` event so `autopilot list`
         // can enumerate runs in reverse-chronological order without
         // recursing into every run dir. Replays do NOT add a row — only the
         // initial arm marks a run's existence.
@@ -335,7 +335,7 @@ export function createEventWriter({
 /**
  * Read the run index (created lazily by createEventWriter on first
  * `armed` event) and return the parsed entries newest-first. Used by
- * `ralph-tui list` and tests.
+ * `autopilot list` and tests.
  *
  * Missing index file → empty list (a fresh machine with no past runs).
  */
@@ -397,7 +397,7 @@ export function aggregateRuns({
             // a huge numeric literal (e.g. `1e500`) parses as Infinity in
             // JS — without `Number.isFinite` it would propagate to
             // `iters.max = Infinity` and `iters.mean = NaN`/Infinity,
-            // silently breaking `ralph-tui stats`. The writer never emits
+            // silently breaking `autopilot stats`. The writer never emits
             // Infinity (JSON.stringify(Infinity) = "null"), so this only
             // bites for hand-edited rows; treat them like the other
             // malformed cases above and skip the iteration value.
@@ -416,7 +416,7 @@ export function aggregateRuns({
     // throws "Maximum call stack size exceeded" once iterCounts grows
     // past ~150k entries (Node's argument-count limit). A long-lived
     // user with daily self_improve runs would eventually hit that
-    // ceiling and `ralph-tui stats` would silently crash. Reduce
+    // ceiling and `autopilot stats` would silently crash. Reduce
     // handles arbitrary array sizes in O(n) without the spread.
     const max = iterCounts.length
         ? iterCounts.reduce((a, b) => (a > b ? a : b), 0)

--- a/packages/tui/src/writer.mjs
+++ b/packages/tui/src/writer.mjs
@@ -24,17 +24,83 @@ import osDefault from "node:os";
 
 import { MAX_EVENT_LINE_BYTES, makeRunId, serializeEvent } from "./events.mjs";
 
+// Print a one-line stderr deprecation notice the FIRST time a given
+// migration trigger fires, then drop a sentinel line under
+// ~/.copilot/autopilot/ so subsequent runs (in this or any later
+// process) stay silent. Mirror of the helper in
+// extension/events-emit.mjs — the two surfaces resolve from the same
+// sentinel so a single legacy default-path read silences both.
+function emitDeprecationOnce({ key, message, sentinelPath, fs, stderr }) {
+    try {
+        const content = fs.readFileSync(sentinelPath, "utf8");
+        if (content.split("\n").some((l) => l === key)) return;
+    } catch { /* sentinel missing or unreadable */ }
+    try {
+        stderr.write(message);
+        fs.mkdirSync(pathDefault.dirname(sentinelPath), { recursive: true });
+        fs.appendFileSync(sentinelPath, key + "\n");
+    } catch { /* best-effort */ }
+}
+
 /**
- * Resolve the on-disk root for ralph TUI run metadata.
+ * Resolve the on-disk root for autopilot TUI run metadata.
  *
- *   $RALPH_EVENTS_DIR if set (absolute path expected; surfaced verbatim
+ *   $AUTOPILOT_EVENTS_DIR if set (absolute path expected; surfaced verbatim
  *   so users can pin a tmp dir in CI).
- *   else `${HOME}/.copilot/ralph/runs`.
+ *   else $RALPH_EVENTS_DIR if set (deprecated; one-time stderr notice).
+ *   else `${HOME}/.copilot/autopilot/events` (new default).
+ *   If new default doesn't exist but `${HOME}/.copilot/ralph/runs` does,
+ *   falls back to the old path with a deprecation notice.
  */
-export function resolveRunsRoot({ env = process.env, os = osDefault, path = pathDefault } = {}) {
-    const override = env.RALPH_EVENTS_DIR;
-    if (typeof override === "string" && override.length > 0) return override;
-    return path.join(os.homedir(), ".copilot", "ralph", "runs");
+export function resolveRunsRoot({
+    env = process.env,
+    os = osDefault,
+    path = pathDefault,
+    fs = fsDefault,
+    stderr = process.stderr,
+    sentinelPath: sentinelPathArg,
+} = {}) {
+    const home = os.homedir();
+    const sentinelPath = sentinelPathArg ?? path.join(home, ".copilot", "autopilot", ".migration-notice-shown");
+
+    // Primary: $AUTOPILOT_EVENTS_DIR
+    const newOverride = env.AUTOPILOT_EVENTS_DIR;
+    if (typeof newOverride === "string" && newOverride.length > 0) return newOverride;
+
+    // Legacy fallback: $RALPH_EVENTS_DIR (deprecated)
+    const legacyOverride = env.RALPH_EVENTS_DIR;
+    if (typeof legacyOverride === "string" && legacyOverride.length > 0) {
+        emitDeprecationOnce({
+            key: "env:RALPH_EVENTS_DIR",
+            message: "[autopilot] note: env $RALPH_EVENTS_DIR is deprecated, please use $AUTOPILOT_EVENTS_DIR (still honored)\n",
+            sentinelPath,
+            fs,
+            stderr,
+        });
+        return legacyOverride;
+    }
+
+    // Default paths
+    const newDefault = path.join(home, ".copilot", "autopilot", "events");
+    const oldDefault = path.join(home, ".copilot", "ralph", "runs");
+
+    let newExists = false;
+    let oldExists = false;
+    try { newExists = fs.existsSync(newDefault); } catch { /* swallow */ }
+    try { oldExists = fs.existsSync(oldDefault); } catch { /* swallow */ }
+
+    if (!newExists && oldExists) {
+        emitDeprecationOnce({
+            key: `path:${oldDefault}`,
+            message: `[autopilot] note: reading from legacy ~/.copilot/ralph/runs (default is now ~/.copilot/autopilot/events)\n`,
+            sentinelPath,
+            fs,
+            stderr,
+        });
+        return oldDefault;
+    }
+
+    return newDefault;
 }
 
 /**

--- a/packages/tui/test/bin.test.mjs
+++ b/packages/tui/test/bin.test.mjs
@@ -346,9 +346,9 @@ test("bin list (no --limit): all runs preserved", () => {
 });
 
 test("bin where: prints default runs root", () => {
-    const r = runBin(["where"], { RALPH_EVENTS_DIR: "" });  // empty -> default
+    const r = runBin(["where"], { AUTOPILOT_EVENTS_DIR: "", RALPH_EVENTS_DIR: "" });  // empty -> default
     assert.equal(r.status, 0);
-    assert.match(r.stdout, /\.copilot\/ralph\/runs\n$/);
+    assert.match(r.stdout, /\.copilot\/autopilot\/events\n$/);
 });
 
 test("bin where: honours RALPH_EVENTS_DIR override", () => {

--- a/packages/tui/test/bin.test.mjs
+++ b/packages/tui/test/bin.test.mjs
@@ -525,8 +525,8 @@ test("packages/tui/package.json carries repository/bugs/author metadata aligned 
     assert.equal(tuiPkg.repository.type, "git", "repository.type must be 'git'");
     assert.ok(
         typeof tuiPkg.repository.url === "string"
-            && tuiPkg.repository.url.includes("kloba/copilot-ralph-extension"),
-        "TUI repository.url must reference the canonical kloba/copilot-ralph-extension repo",
+            && tuiPkg.repository.url.includes("kloba/autopilot"),
+        "TUI repository.url must reference the canonical kloba/autopilot repo",
     );
     assert.equal(
         tuiPkg.repository.directory,

--- a/packages/tui/test/bin.test.mjs
+++ b/packages/tui/test/bin.test.mjs
@@ -13,7 +13,7 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const BIN = resolve(REPO_ROOT, "bin", "tui.mjs");
 
 function tmp() {
-    return mkdtempSync(join(tmpdir(), "ralph-bin-"));
+    return mkdtempSync(join(tmpdir(), "autopilot-bin-"));
 }
 
 function runBin(args, env) {
@@ -29,9 +29,9 @@ test("parseArgv: --help short-circuits", () => {
 });
 
 test("parseArgv: subcommand and positional", () => {
-    const r = parseArgv(["replay", "ralph_loop-1"]);
+    const r = parseArgv(["replay", "ap_loop-1"]);
     assert.equal(r.cmd, "replay");
-    assert.deepEqual(r.positional, ["ralph_loop-1"]);
+    assert.deepEqual(r.positional, ["ap_loop-1"]);
 });
 
 test("parseArgv: --plain flag", () => {
@@ -45,7 +45,7 @@ test("bin --help: prints USAGE and exits 0", () => {
     const r = runBin(["--help"]);
     assert.equal(r.status, 0);
     assert.match(r.stdout, /USAGE/);
-    assert.match(r.stdout, /ralph-tui list/);
+    assert.match(r.stdout, /autopilot list/);
 });
 
 test("bin list: empty runs root prints helpful message", () => {
@@ -60,7 +60,7 @@ test("bin list: enumerates seeded runs newest-first", () => {
     const dir = tmp();
     const idx = join(dir, "index.jsonl");
     writeFileSync(idx,
-        JSON.stringify({ type: "armed", ts: 1000, runId: "ralph_loop-1000", label: "ralph_loop", maxIterations: 5, minIterations: 1 }) + "\n"
+        JSON.stringify({ type: "armed", ts: 1000, runId: "ap_loop-1000", label: "ap_loop", maxIterations: 5, minIterations: 1 }) + "\n"
         + JSON.stringify({ type: "armed", ts: 2000, runId: "self_improve-2000", label: "self_improve", maxIterations: 100, minIterations: 5 }) + "\n",
     );
     const r = runBin(["list"], { RALPH_EVENTS_DIR: dir });
@@ -69,7 +69,7 @@ test("bin list: enumerates seeded runs newest-first", () => {
     // Header + 2 runs.
     assert.equal(lines.length, 3);
     assert.match(lines[1], /self_improve-2000/, "newest first");
-    assert.match(lines[2], /ralph_loop-1000/);
+    assert.match(lines[2], /ap_loop-1000/);
     rmSync(dir, { recursive: true, force: true });
 });
 
@@ -86,7 +86,7 @@ test("bin list --json: emits parseable run index newest-first", () => {
     const dir = tmp();
     const idx = join(dir, "index.jsonl");
     writeFileSync(idx,
-        JSON.stringify({ type: "armed", ts: 1000, runId: "ralph_loop-1000", label: "ralph_loop", maxIterations: 5, minIterations: 1 }) + "\n"
+        JSON.stringify({ type: "armed", ts: 1000, runId: "ap_loop-1000", label: "ap_loop", maxIterations: 5, minIterations: 1 }) + "\n"
         + JSON.stringify({ type: "armed", ts: 2000, runId: "self_improve-2000", label: "self_improve", maxIterations: 100, minIterations: 5 }) + "\n",
     );
     const r = runBin(["list", "--json"], { RALPH_EVENTS_DIR: dir });
@@ -95,7 +95,7 @@ test("bin list --json: emits parseable run index newest-first", () => {
     assert.ok(Array.isArray(parsed));
     assert.equal(parsed.length, 2);
     assert.equal(parsed[0].runId, "self_improve-2000", "newest first");
-    assert.equal(parsed[1].runId, "ralph_loop-1000");
+    assert.equal(parsed[1].runId, "ap_loop-1000");
     for (const e of parsed) {
         assert.ok(typeof e.runId === "string");
         assert.ok(typeof e.ts === "number");
@@ -105,19 +105,19 @@ test("bin list --json: emits parseable run index newest-first", () => {
 
 test("bin replay: prints all events for a run", () => {
     const dir = tmp();
-    const runDir = join(dir, "ralph_loop-1");
+    const runDir = join(dir, "ap_loop-1");
     mkdirSync(runDir);
     const ev = join(runDir, "events.jsonl");
     writeFileSync(ev,
-        JSON.stringify({ type: "armed", ts: 1, runId: "ralph_loop-1", maxIterations: 3, minIterations: 1 }) + "\n"
-        + JSON.stringify({ type: "iteration_start", ts: 2, runId: "ralph_loop-1", iteration: 1 }) + "\n"
-        + JSON.stringify({ type: "complete", ts: 3, runId: "ralph_loop-1", reason: "completion_promise", iteration: 1 }) + "\n",
+        JSON.stringify({ type: "armed", ts: 1, runId: "ap_loop-1", maxIterations: 3, minIterations: 1 }) + "\n"
+        + JSON.stringify({ type: "iteration_start", ts: 2, runId: "ap_loop-1", iteration: 1 }) + "\n"
+        + JSON.stringify({ type: "complete", ts: 3, runId: "ap_loop-1", reason: "completion_promise", iteration: 1 }) + "\n",
     );
-    const r = runBin(["replay", "ralph_loop-1"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["replay", "ap_loop-1"], { RALPH_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
-    assert.match(r.stdout, /armed\s+ralph_loop-1/);
+    assert.match(r.stdout, /armed\s+ap_loop-1/);
     assert.match(r.stdout, /iter\+/);
-    assert.match(r.stdout, /done\s+ralph_loop-1.*reason=completion_promise/);
+    assert.match(r.stdout, /done\s+ap_loop-1.*reason=completion_promise/);
     rmSync(dir, { recursive: true, force: true });
 });
 
@@ -182,18 +182,18 @@ function seedRun(root, runId, ts) {
     const runDir = join(root, runId);
     mkSync2(runDir, { recursive: true });
     writeFileSync(join(runDir, "events.jsonl"), JSON.stringify({ type: "armed", ts, runId }) + "\n");
-    return JSON.stringify({ type: "armed", ts, runId, label: "ralph_loop", maxIterations: 5, minIterations: 1 });
+    return JSON.stringify({ type: "armed", ts, runId, label: "ap_loop", maxIterations: 5, minIterations: 1 });
 }
 
 test("bin prune --dry-run: lists would-remove without deleting", () => {
     const dir = tmp();
-    const old = seedRun(dir, "ralph_loop-old", 1);  // ts=1ms epoch ⇒ very old
-    const fresh = seedRun(dir, "ralph_loop-fresh", Date.now());
+    const old = seedRun(dir, "ap_loop-old", 1);  // ts=1ms epoch ⇒ very old
+    const fresh = seedRun(dir, "ap_loop-fresh", Date.now());
     writeFileSync(join(dir, "index.jsonl"), old + "\n" + fresh + "\n");
     const r = runBin(["prune", "--older-than", "365d", "--dry-run"], { RALPH_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     assert.match(r.stdout, /dry-run.*would remove 1/);
-    assert.match(r.stdout, /would remove ralph_loop-old/);
+    assert.match(r.stdout, /would remove ap_loop-old/);
     // file still present
     const list = runBin(["list", "--json"], { RALPH_EVENTS_DIR: dir });
     assert.equal(JSON.parse(list.stdout).length, 2);
@@ -202,8 +202,8 @@ test("bin prune --dry-run: lists would-remove without deleting", () => {
 
 test("bin prune --older-than 0m: removes every run", () => {
     const dir = tmp();
-    const a = seedRun(dir, "ralph_loop-a", Date.now() - 1000);
-    const b = seedRun(dir, "ralph_loop-b", Date.now() - 2000);
+    const a = seedRun(dir, "ap_loop-a", Date.now() - 1000);
+    const b = seedRun(dir, "ap_loop-b", Date.now() - 2000);
     writeFileSync(join(dir, "index.jsonl"), a + "\n" + b + "\n");
     const r = runBin(["prune", "--older-than", "0m"], { RALPH_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
@@ -241,13 +241,13 @@ test("bin stats: empty index prints No runs found", () => {
 
 test("bin stats: aggregates by tool, reason and iterations", () => {
     const dir = tmp();
-    // Two runs: one ralph_loop completing, one self_improve aborting.
-    const r1 = "ralph_loop-100";
+    // Two runs: one ap_loop completing, one self_improve aborting.
+    const r1 = "ap_loop-100";
     const r2 = "self_improve-200";
     mkdirSync(join(dir, r1), { recursive: true });
     mkdirSync(join(dir, r2), { recursive: true });
     writeFileSync(join(dir, r1, "events.jsonl"),
-        JSON.stringify({ type: "armed", ts: 100, runId: r1, label: "ralph_loop" }) + "\n"
+        JSON.stringify({ type: "armed", ts: 100, runId: r1, label: "ap_loop" }) + "\n"
         + JSON.stringify({ type: "iteration_start", ts: 101, runId: r1, iteration: 1 }) + "\n"
         + JSON.stringify({ type: "iteration_end", ts: 102, runId: r1, iteration: 1 }) + "\n"
         + JSON.stringify({ type: "complete", ts: 103, runId: r1, reason: "completion_promise", iteration: 3 }) + "\n",
@@ -257,7 +257,7 @@ test("bin stats: aggregates by tool, reason and iterations", () => {
         + JSON.stringify({ type: "abort", ts: 201, runId: r2, reason: "max_tokens", iteration: 7 }) + "\n",
     );
     writeFileSync(join(dir, "index.jsonl"),
-        JSON.stringify({ type: "armed", ts: 100, runId: r1, label: "ralph_loop", maxIterations: 5, minIterations: 1 }) + "\n"
+        JSON.stringify({ type: "armed", ts: 100, runId: r1, label: "ap_loop", maxIterations: 5, minIterations: 1 }) + "\n"
         + JSON.stringify({ type: "armed", ts: 200, runId: r2, label: "self_improve", maxIterations: 100, minIterations: 5 }) + "\n",
     );
     const r = runBin(["stats"], { RALPH_EVENTS_DIR: dir });
@@ -267,7 +267,7 @@ test("bin stats: aggregates by tool, reason and iterations", () => {
     assert.match(r.stdout, /By reason/);
     assert.match(r.stdout, /Iterations/);
     assert.match(r.stdout, /runs: 2/);
-    assert.match(r.stdout, /ralph_loop: 1/);
+    assert.match(r.stdout, /ap_loop: 1/);
     assert.match(r.stdout, /self_improve: 1/);
     assert.match(r.stdout, /complete:completion_promise: 1/);
     assert.match(r.stdout, /abort:max_tokens: 1/);
@@ -286,13 +286,13 @@ test("bin --version: prints version matching package.json", () => {
     const r = runBin(["--version"]);
     assert.equal(r.status, 0);
     const pkg = JSON.parse(readFileSync2(resolve(REPO_ROOT, "package.json"), "utf8"));
-    assert.equal(r.stdout.trim(), `ralph-tui ${pkg.version}`);
+    assert.equal(r.stdout.trim(), `autopilot ${pkg.version}`);
 });
 
 test("bin -V: same as --version", () => {
     const r = runBin(["-V"]);
     assert.equal(r.status, 0);
-    assert.match(r.stdout, /^ralph-tui \d/);
+    assert.match(r.stdout, /^autopilot \d/);
 });
 
 test("bin --help: mentions --version", () => {
@@ -302,7 +302,7 @@ test("bin --help: mentions --version", () => {
 
 function seedThreeRuns(dir) {
     writeFileSync(join(dir, "index.jsonl"),
-        JSON.stringify({ type: "armed", ts: 1000, runId: "ralph_loop-1000", label: "ralph_loop", maxIterations: 5, minIterations: 1 }) + "\n"
+        JSON.stringify({ type: "armed", ts: 1000, runId: "ap_loop-1000", label: "ap_loop", maxIterations: 5, minIterations: 1 }) + "\n"
         + JSON.stringify({ type: "armed", ts: 2000, runId: "self_improve-2000", label: "self_improve", maxIterations: 100, minIterations: 5 }) + "\n"
         + JSON.stringify({ type: "armed", ts: 3000, runId: "grow_project-3000", label: "grow_project", maxIterations: 50, minIterations: 1 }) + "\n",
     );
@@ -367,12 +367,12 @@ test("bin where: works even when directory does not exist", () => {
 
 test("bin --help: mentions where", () => {
     const r = runBin(["--help"]);
-    assert.match(r.stdout, /ralph-tui where/);
+    assert.match(r.stdout, /autopilot where/);
 });
 
 test("tui.mjs has no top-level await (Node 22+ unsettled-TLA warning regression guard)", async () => {
     // Iter regression: the entry-point check used `await import("node:fs")`
-    // and `await import("node:url")` at the top level. On `ralph-tui run`,
+    // and `await import("node:url")` at the top level. On `autopilot run`,
     // when main() resolved and the `.then(process.exit)` chain fired,
     // Node 22+ printed `ExperimentalWarning: Detected unsettled top-level
     // await at file://…/bin/tui.mjs:<EOF-line>` to stderr — a spurious
@@ -459,13 +459,13 @@ test("tui.mjs header comment lists every USAGE subcommand (drift guard)", async 
         [...headerBlock[0].matchAll(/^\/\/\s{3}([a-z]+)\b/gm)].map((m) => m[1])
     );
 
-    // USAGE subcommands: lines beginning `  ralph-tui <cmd>` inside the
+    // USAGE subcommands: lines beginning `  autopilot <cmd>` inside the
     // `const USAGE = \`…\`;` template literal. Skip the `--help` /
     // `--version` lines.
     const usageBlock = src.match(/const USAGE = `([\s\S]+?)`;/);
     assert.ok(usageBlock, "could not locate the USAGE constant in tui.mjs");
     const usageCmds = new Set(
-        [...usageBlock[1].matchAll(/^\s{2}ralph-tui\s+([a-z]+)\b/gm)].map((m) => m[1])
+        [...usageBlock[1].matchAll(/^\s{2}autopilot\s+([a-z]+)\b/gm)].map((m) => m[1])
     );
 
     // Pin: every USAGE subcommand must appear in the header. (We allow
@@ -543,13 +543,13 @@ test("packages/tui/README.md Subcommands block lists every shipped subcommand + 
     // forcing the test to track exact byte offsets.
     const slice = readme.slice(i, i + 4000);
     const required = [
-        "ralph-tui list",
-        "ralph-tui replay",
-        "ralph-tui watch",
-        "ralph-tui doctor",
-        "ralph-tui prune",
-        "ralph-tui stats",
-        "ralph-tui where",
+        "autopilot list",
+        "autopilot replay",
+        "autopilot watch",
+        "autopilot doctor",
+        "autopilot prune",
+        "autopilot stats",
+        "autopilot where",
         "--help",
         "--version",
         "--json",
@@ -572,7 +572,7 @@ test("packages/tui/package.json carries repository/bugs/author metadata aligned 
     // the root package.json carries (iter 151 added the missing
     // root `author`, but the workspace package was forgotten).
     // For a sub-package shipped via the dogfood install path AND
-    // documented as `npx ralph-tui` in docs/faq.md, the missing
+    // documented as `npx autopilot` in docs/faq.md, the missing
     // metadata silently degrades the registry listing if the
     // `private: true` flag is ever flipped (e.g. a future release
     // branch that publishes the TUI to npm separately). Adding
@@ -630,7 +630,7 @@ test("cmdReplay: path-traversal runId routes through fail() with clean error (no
     // path-traversal runIds (`../etc/passwd`, runIds with `\0`, runIds
     // with `\\`, `.`, `..`). Pre-iter-167 `cmdReplay` and `cmdWatch`
     // called the resolver without catching, so a user supplying
-    // `ralph-tui replay ../etc/passwd` saw a raw stack trace instead
+    // `autopilot replay ../etc/passwd` saw a raw stack trace instead
     // of a clean error message. The fix is to catch TypeError at the
     // bin layer and route through `fail()` (clean stderr line + exit
     // code 2). Pin both the no-throw contract and the user-visible
@@ -762,7 +762,7 @@ test("VALUE_FLAGS JSDoc comment lists every flag actually in the set (drift guar
     }
 });
 
-// ─── Issue #48 slice 3: scope-driven default for `ralph-tui run --max` ──
+// ─── Issue #48 slice 3: scope-driven default for `autopilot run --max` ──
 
 import { defaultMaxIterationsFor } from "../bin/tui.mjs";
 import * as __runner from "../src/runner.mjs";
@@ -835,7 +835,7 @@ test("run-ui module is importable and exports mountRunUi (no top-level Ink impor
 
 // ─── Issue #48 / user-bug: q keypress fallback ─────────────────────
 //
-// Field bug from a real run: pressing `q` in `ralph-tui run` echoed
+// Field bug from a real run: pressing `q` in `autopilot run` echoed
 // to the terminal as cooked-mode characters instead of unmounting
 // the Ink App — meaning Ink's useInput silently failed to enter raw
 // mode for that environment. installStdinAbortListener is the
@@ -866,7 +866,7 @@ test("installStdinAbortListener: returns a no-op cleanup when stdin is NOT a TTY
 test("formatAbortMessage: q press → user-visible 'q received' line on stderr", () => {
     const msg = formatAbortMessage("user_quit");
     assert.ok(typeof msg === "string", "user_quit must return a string");
-    assert.match(msg, /^\nralph-tui run: q received — finishing current iteration, then stopping\. Hit Ctrl-C to abort hard\.\n$/);
+    assert.match(msg, /^\nautopilot run: q received — finishing current iteration, then stopping\. Hit Ctrl-C to abort hard\.\n$/);
 });
 
 test("formatAbortMessage: SIGINT path returns null (signal handler prints its own line)", () => {

--- a/packages/tui/test/components.test.mjs
+++ b/packages/tui/test/components.test.mjs
@@ -31,8 +31,8 @@ const skip = inkAvailable ? false : "ink-testing-library not installed (cd packa
 test("Header shows status badge, label, run id and iter counter", { skip }, () => {
     const snapshot = {
         status: "running",
-        label: "ralph_loop",
-        runId: "ralph_loop-1700000000000",
+        label: "ap_loop",
+        runId: "ap_loop-1700000000000",
         iteration: 3,
         maxIterations: 100,
         minIterations: 5,
@@ -41,7 +41,7 @@ test("Header shows status badge, label, run id and iter counter", { skip }, () =
     const { lastFrame } = render(React.createElement(Header, { snapshot }));
     const out = lastFrame();
     assert.match(out, /RUN/);
-    assert.match(out, /ralph_loop/);
+    assert.match(out, /ap_loop/);
     assert.match(out, /1700000000000/);
     assert.match(out, /iter/);
     assert.match(out, /3/);
@@ -98,8 +98,8 @@ test("DetailPane shows tokens, reason, and last excerpt", { skip }, () => {
 
 test("Header: shows premium counter when snapshot.premiumRequests is set", { skip }, () => {
     const snapshot = {
-        status: "running", label: "ralph_loop",
-        runId: "ralph_loop-1700000000000",
+        status: "running", label: "ap_loop",
+        runId: "ap_loop-1700000000000",
         iteration: 2, maxIterations: 10,
         tokens: { input: 0, output: 415 },
         premiumRequests: 7,
@@ -110,8 +110,8 @@ test("Header: shows premium counter when snapshot.premiumRequests is set", { ski
 
 test("Header: hides premium counter when premiumRequests is null", { skip }, () => {
     const snapshot = {
-        status: "running", label: "ralph_loop",
-        runId: "ralph_loop-1700000000000",
+        status: "running", label: "ap_loop",
+        runId: "ap_loop-1700000000000",
         iteration: 1, maxIterations: 10,
         tokens: { input: 0, output: 0 },
         premiumRequests: null,
@@ -155,13 +155,13 @@ test("Controls hint row shows idle indicator when not running", { skip }, () => 
 
 test("App renders all four panes from a static event log", { skip }, () => {
     const events = [
-        { type: "armed", runId: "r1", label: "ralph_loop", maxIterations: 10, minIterations: 1, ts: 1 },
+        { type: "armed", runId: "r1", label: "ap_loop", maxIterations: 10, minIterations: 1, ts: 1 },
         { type: "iteration_start", runId: "r1", iteration: 1, ts: 2 },
         { type: "iteration_end", runId: "r1", iteration: 1, excerpt: "did some work", tokens: { input: 3, output: 4 }, ts: 3 },
         { type: "iteration_start", runId: "r1", iteration: 2, ts: 4 },
     ];
     const out = render(React.createElement(App, { events, runId: "r1" })).lastFrame();
-    assert.match(out, /ralph_loop/);
+    assert.match(out, /ap_loop/);
     assert.match(out, /Timeline/);
     assert.match(out, /Detail/);
     assert.match(out, /quit/);
@@ -273,7 +273,7 @@ test("Header renders backlog row when snapshot.backlog is present", { skip }, ()
 test("Header omits backlog row when snapshot.backlog is null", { skip }, () => {
     const snapshot = {
         status: "running",
-        label: "ralph_loop",
+        label: "ap_loop",
         runId: "abc",
         iteration: 1,
         maxIterations: 100,
@@ -302,7 +302,7 @@ test("Header renders ∞ when maxIterations equals runaway-guard ceiling", { ski
 test("Header still shows literal max when below the runaway-guard ceiling", { skip }, () => {
     const snapshot = {
         status: "running",
-        label: "ralph_loop",
+        label: "ap_loop",
         runId: "abc",
         iteration: 3,
         maxIterations: 50,
@@ -510,10 +510,10 @@ test("App.onUserAbort fires on Ctrl-C with 'signal_SIGINT' reason (issue #48 sli
 });
 
 test("App without onUserAbort still exits on q (read-only watch mode)", { skip }, async () => {
-    // ralph-tui watch supplies no onUserAbort — the App must still
+    // autopilot watch supplies no onUserAbort — the App must still
     // tear down cleanly without throwing on the missing callback.
     const inst = render(React.createElement(App, {
-        events: [{ type: "armed", runId: "r1", label: "ralph_loop", maxIterations: 100, ts: 1 }],
+        events: [{ type: "armed", runId: "r1", label: "ap_loop", maxIterations: 100, ts: 1 }],
         runId: "r1",
     }));
     await new Promise((r) => setImmediate(r));

--- a/packages/tui/test/components.test.mjs
+++ b/packages/tui/test/components.test.mjs
@@ -787,3 +787,116 @@ test("App: 3-level layout — work item header, plan stages, tasks pane, last co
     assert.match(out, /deadbee/);
     assert.match(out, /land 3-level renderer/);
 });
+
+// ─── Issue #54: panel headings + live excerpt + replay-on-mount ──────
+
+test("Issue #54 slice 1: Header renders 'Run' heading inside the bordered Box", { skip }, () => {
+    const snapshot = {
+        status: "running",
+        label: "self_improve",
+        runId: "r1700000000000",
+        iteration: 1,
+        maxIterations: 5,
+        minIterations: 1,
+        tokens: { input: 0, output: 0 },
+    };
+    const out = render(React.createElement(Header, { snapshot })).lastFrame();
+    // The heading must appear before the status badge / iter counter
+    // line so users see "Run" as the pane label, not buried below.
+    assert.match(out, /Run/);
+    const runIdx = out.indexOf("Run");
+    const iterIdx = out.indexOf("iter");
+    assert.ok(runIdx >= 0 && iterIdx > runIdx, "Run heading appears before iter counter");
+});
+
+test("Issue #54 slice 1: Timeline renders 'Timeline' heading", { skip }, () => {
+    const out = render(React.createElement(Timeline, { snapshot: { iterations: [] } })).lastFrame();
+    assert.match(out, /Timeline/);
+});
+
+test("Issue #54 slice 1: StagesRow renders 'Stages' heading", { skip }, async () => {
+    const StagesRow = (await import("../src/components/StagesRow.mjs")).default;
+    const snapshot = {
+        currentPlan: { stages: ["DIAG", "FIX", "TEST", "COMMIT", "PUSH", "END"] },
+        activeStage: { stage: 2, name: "FIX" },
+        recentStages: [{ stage: 1, name: "DIAG" }],
+    };
+    const out = render(React.createElement(StagesRow, { snapshot })).lastFrame();
+    assert.match(out, /Stages/);
+    // Heading sits ABOVE the pill row.
+    const headingIdx = out.indexOf("Stages");
+    const pillIdx = out.indexOf("DIAG");
+    assert.ok(headingIdx >= 0 && pillIdx > headingIdx, "Stages heading before pills");
+});
+
+test("Issue #54 slice 1: TasksPane renders 'Tasks' heading", { skip }, async () => {
+    const TasksPane = (await import("../src/components/TasksPane.mjs")).default;
+    // Empty-rows path.
+    const out1 = render(React.createElement(TasksPane, { snapshot: {} })).lastFrame();
+    assert.match(out1, /Tasks/);
+    // Rendered-rows path.
+    const snapshot = {
+        currentPlan: { stages: ["DIAG"] },
+        activeStage: { stage: 1, name: "DIAG" },
+        currentTaskList: { stage: "DIAG", items: ["read code", "form hypothesis"] },
+        taskInFlight: { stage: "DIAG", sub: 1, desc: "read code" },
+        recentTasks: [],
+    };
+    const out2 = render(React.createElement(TasksPane, { snapshot })).lastFrame();
+    assert.match(out2, /Tasks/);
+    const headingIdx = out2.indexOf("Tasks");
+    const taskIdx = out2.indexOf("read code");
+    assert.ok(headingIdx >= 0 && taskIdx > headingIdx, "Tasks heading before task rows");
+});
+
+test("Issue #54 slice 1: SubstagesPane renders 'Activity' heading separate from STAGE marker", { skip }, async () => {
+    const SubstagesPane = (await import("../src/components/SubstagesPane.mjs")).default;
+    const snapshot = {
+        activeStage: { stage: 2, name: "FIX" },
+        currentStageSubstages: [],
+    };
+    const out = render(React.createElement(SubstagesPane, { snapshot })).lastFrame();
+    // Heading is "Activity" (NOT "STAGE: FIX" — that lives in the body row).
+    assert.match(out, /Activity/);
+    // The stage-marker body row still surfaces the active stage name.
+    assert.match(out, /FIX/);
+    // Heading appears BEFORE the stage marker row.
+    const headingIdx = out.indexOf("Activity");
+    const stageIdx = out.indexOf("FIX");
+    assert.ok(headingIdx >= 0 && stageIdx > headingIdx, "Activity heading before STAGE marker row");
+});
+
+test("Issue #54 slice 2a: Timeline shows '(working…)' for in-flight iter with no excerpt", { skip }, () => {
+    const snapshot = {
+        iterations: [
+            { iteration: 1, endedAt: 1, excerpt: "first" },
+            { iteration: 2, endedAt: null, excerpt: null },
+        ],
+    };
+    const out = render(React.createElement(Timeline, { snapshot })).lastFrame();
+    assert.match(out, /first/);
+    assert.match(out, /working…/);
+    // Finished iters with no excerpt still get the historical
+    // "(no excerpt)" placeholder — replay fidelity for old runs.
+    const snapshot2 = {
+        iterations: [{ iteration: 1, endedAt: 1, excerpt: null }],
+    };
+    const out2 = render(React.createElement(Timeline, { snapshot: snapshot2 })).lastFrame();
+    assert.match(out2, /no excerpt/);
+});
+
+test("Issue #54 slice 2a: Timeline shows live-streamed excerpt on the in-flight iter", { skip }, () => {
+    // Excerpt streamed via usage_update during the iter — endedAt is
+    // still null, but excerpt is now non-empty. Timeline must
+    // render the excerpt (truncated to 80 chars) instead of
+    // "(working…)".
+    const snapshot = {
+        iterations: [
+            { iteration: 1, endedAt: null, excerpt: "ORIENT: scanning the backlog for stale CI runs" },
+        ],
+    };
+    const out = render(React.createElement(Timeline, { snapshot })).lastFrame();
+    assert.match(out, /ORIENT: scanning the backlog/);
+    assert.doesNotMatch(out, /working…/);
+    assert.doesNotMatch(out, /no excerpt/);
+});

--- a/packages/tui/test/events.test.mjs
+++ b/packages/tui/test/events.test.mjs
@@ -55,7 +55,7 @@ test("EVENT_TYPES is the closed set documented in the issue", () => {
 });
 
 test("makeRunId combines label + startedAt", () => {
-    assert.equal(makeRunId("ralph_loop", 1700000000000), "ralph_loop-1700000000000");
+    assert.equal(makeRunId("ap_loop", 1700000000000), "ap_loop-1700000000000");
 });
 
 test("makeRunId rejects bad input", () => {
@@ -64,7 +64,7 @@ test("makeRunId rejects bad input", () => {
 });
 
 test("serializeEvent: minimal happy path round-trips through parseEventLine", () => {
-    const ev = { type: "armed", ts: 1, runId: "r-1", label: "ralph_loop", maxIterations: 20, minIterations: 5 };
+    const ev = { type: "armed", ts: 1, runId: "r-1", label: "ap_loop", maxIterations: 20, minIterations: 5 };
     const line = serializeEvent(ev);
     const back = parseEventLine(line);
     assert.deepEqual(back, ev);
@@ -126,7 +126,7 @@ test("parseEventLine: bad input type throws (programmer error, not data error)",
 
 test("foldEvents: armed → iteration_start/end → complete produces expected snapshot", () => {
     const events = [
-        { type: "armed", ts: 100, runId: "r1", label: "ralph_loop", maxIterations: 20, minIterations: 5 },
+        { type: "armed", ts: 100, runId: "r1", label: "ap_loop", maxIterations: 20, minIterations: 5 },
         { type: "iteration_start", ts: 110, runId: "r1", iteration: 1 },
         { type: "iteration_end", ts: 120, runId: "r1", iteration: 1, excerpt: "hello", tokens: { input: 100, output: 50 } },
         { type: "iteration_start", ts: 130, runId: "r1", iteration: 2 },
@@ -135,7 +135,7 @@ test("foldEvents: armed → iteration_start/end → complete produces expected s
     ];
     const snap = foldEvents(events);
     assert.equal(snap.runId, "r1");
-    assert.equal(snap.label, "ralph_loop");
+    assert.equal(snap.label, "ap_loop");
     assert.equal(snap.status, "complete");
     assert.equal(snap.reason, "completion_promise");
     assert.equal(snap.iteration, 2);
@@ -169,7 +169,7 @@ test("foldEvents: pause / resume toggle status without losing progress", () => {
 
 test("foldEvents: stagnation event records streak", () => {
     const snap = foldEvents([
-        { type: "armed", ts: 1, runId: "r", label: "ralph_loop" },
+        { type: "armed", ts: 1, runId: "r", label: "ap_loop" },
         { type: "iteration_start", ts: 2, runId: "r", iteration: 1 },
         { type: "stagnation", ts: 3, runId: "r", streak: 3 },
     ]);
@@ -187,7 +187,7 @@ test("foldEvents: abort sets status + reason", () => {
 
 test("foldEvents: a fresh `armed` resets iterations array (replay-with-multiple-runs case)", () => {
     const snap = foldEvents([
-        { type: "armed", ts: 1, runId: "r1", label: "ralph_loop" },
+        { type: "armed", ts: 1, runId: "r1", label: "ap_loop" },
         { type: "iteration_start", ts: 2, runId: "r1", iteration: 1 },
         { type: "iteration_end", ts: 3, runId: "r1", iteration: 1, excerpt: "old" },
         { type: "complete", ts: 4, runId: "r1", reason: "max_iterations" },
@@ -370,7 +370,7 @@ test("serializeEvent: reason field is capped at 500 chars (defensive symmetry wi
     const lineOver = serializeEvent({
         type: "abort",
         ts: 1_000_000,
-        runId: "ralph_loop-cap",
+        runId: "ap_loop-cap",
         reason: overflow,
     });
     const parsedOver = JSON.parse(lineOver);
@@ -384,7 +384,7 @@ test("serializeEvent: reason field is capped at 500 chars (defensive symmetry wi
     const lineSmall = serializeEvent({
         type: "abort",
         ts: 1_000_000,
-        runId: "ralph_loop-cap",
+        runId: "ap_loop-cap",
         reason: small,
     });
     const parsedSmall = JSON.parse(lineSmall);
@@ -402,7 +402,7 @@ test("serializeEvent: reason field is capped at 500 chars (defensive symmetry wi
     const lineTricky = serializeEvent({
         type: "abort",
         ts: 1_000_000,
-        runId: "ralph_loop-cap",
+        runId: "ap_loop-cap",
         reason: tricky,
     });
     const parsedTricky = JSON.parse(lineTricky);
@@ -589,7 +589,7 @@ test("SDLC_STAGES_GROW_PROJECT: every stage name appears in PROMPT_GROW_PROJECT"
 test("stagesForLabel: maps labels to their canonical lists; unknown → null", () => {
     assert.equal(stagesForLabel("self_improve"), SDLC_STAGES_SELF_IMPROVE);
     assert.equal(stagesForLabel("grow_project"), SDLC_STAGES_GROW_PROJECT);
-    assert.equal(stagesForLabel("ralph_loop"), null, "ralph_loop / custom-prompt mode has no fixed stage list");
+    assert.equal(stagesForLabel("ap_loop"), null, "ap_loop / custom-prompt mode has no fixed stage list");
     assert.equal(stagesForLabel(undefined), null);
     assert.equal(stagesForLabel(""), null);
 });

--- a/packages/tui/test/events.test.mjs
+++ b/packages/tui/test/events.test.mjs
@@ -1272,3 +1272,68 @@ test("foldEvents: iteration_end with tokens + premiumRequests pins snapshot to c
     assert.equal(snap.tokens.output, 350);
     assert.equal(snap.premiumRequests, 5);
 });
+
+// ─── Issue #54 slice 2a: usage_update with excerpt → live Timeline ────
+
+test("Issue #54 slice 2a: usage_update with excerpt round-trips through serializer", () => {
+    const ev = {
+        type: "usage_update",
+        ts: 1700000000000,
+        runId: "r",
+        label: "self_improve",
+        iteration: 3,
+        tokens: { input: 0, output: 250 },
+        excerpt: "ORIENT: scanning the backlog for stale CI runs",
+    };
+    const line = serializeEvent(ev);
+    const parsed = parseEventLine(line);
+    assert.equal(parsed.type, "usage_update");
+    assert.equal(parsed.excerpt, "ORIENT: scanning the backlog for stale CI runs");
+    assert.equal(parsed.tokens.output, 250);
+});
+
+test("Issue #54 slice 2a: foldEvents — usage_update with excerpt updates iter[last].excerpt when iter is in-flight", () => {
+    const events = [
+        { type: "armed", ts: 100, runId: "r", label: "self_improve" },
+        { type: "iteration_start", ts: 200, runId: "r", iteration: 1 },
+        { type: "usage_update", ts: 300, runId: "r", iteration: 1,
+          tokens: { input: 0, output: 50 },
+          excerpt: "ORIENT: scanning the backlog" },
+    ];
+    const snap = foldEvents(events);
+    assert.equal(snap.iterations.length, 1);
+    assert.equal(snap.iterations[0].excerpt, "ORIENT: scanning the backlog");
+    assert.equal(snap.iterations[0].endedAt, null, "iter still in-flight");
+    assert.equal(snap.lastExcerpt, "ORIENT: scanning the backlog");
+});
+
+test("Issue #54 slice 2a: foldEvents — usage_update excerpt does NOT clobber a closed iter's excerpt", () => {
+    // After iteration_end has closed iter 1, a stray late
+    // usage_update should leave iter 1's excerpt intact (replay
+    // fidelity). snap.lastExcerpt may still update — that's a
+    // run-scope field, not an iter-scope one — but the per-iter
+    // excerpt history is preserved.
+    const events = [
+        { type: "armed", ts: 100, runId: "r", label: "self_improve" },
+        { type: "iteration_start", ts: 200, runId: "r", iteration: 1 },
+        { type: "iteration_end", ts: 300, runId: "r", iteration: 1,
+          excerpt: "FINAL: iter-1 done", tokens: { input: 0, output: 100 } },
+        { type: "usage_update", ts: 400, runId: "r", iteration: 1,
+          tokens: { input: 0, output: 100 }, excerpt: "STRAY late update" },
+    ];
+    const snap = foldEvents(events);
+    assert.equal(snap.iterations[0].excerpt, "FINAL: iter-1 done",
+        "closed iter excerpt is not overwritten by post-end usage_update");
+});
+
+test("Issue #54 slice 2a: foldEvents — usage_update with empty/missing excerpt is a no-op for iter excerpt", () => {
+    const events = [
+        { type: "armed", ts: 100, runId: "r", label: "self_improve" },
+        { type: "iteration_start", ts: 200, runId: "r", iteration: 1 },
+        // iter starts with excerpt: null (per iteration_start init)
+        { type: "usage_update", ts: 300, runId: "r", iteration: 1,
+          tokens: { input: 0, output: 50 } },
+    ];
+    const snap = foldEvents(events);
+    assert.equal(snap.iterations[0].excerpt, null);
+});

--- a/packages/tui/test/plain.test.mjs
+++ b/packages/tui/test/plain.test.mjs
@@ -18,11 +18,11 @@ test("formatEventLine: armed includes max/min", () => {
     const line = formatEventLine({
         type: "armed",
         ts: 0,
-        runId: "ralph_loop-0",
+        runId: "ap_loop-0",
         maxIterations: 5,
         minIterations: 2,
     });
-    assert.match(line, /00:00:00\.000\s+armed\s+ralph_loop-0/);
+    assert.match(line, /00:00:00\.000\s+armed\s+ap_loop-0/);
     assert.match(line, /min=2/);
 });
 
@@ -95,7 +95,7 @@ test("formatEventLine: caps long excerpt at 80 chars", () => {
 });
 
 test("formatEventLine: pause renders verb=pause + iteration + reason", () => {
-    // Issue #3: ralph_pause emits `{ type: "pause", runId, iteration,
+    // Issue #3: ap_pause emits `{ type: "pause", runId, iteration,
     // reason, ts }`. The plain renderer must surface verb / runId /
     // iteration / reason so a `tail -f`'d stream of events lets a
     // human (or `awk`) know which iteration paused and why. Pin the
@@ -104,11 +104,11 @@ test("formatEventLine: pause renders verb=pause + iteration + reason", () => {
     const line = formatEventLine({
         type: "pause",
         ts: 3723456,
-        runId: "ralph_loop-7",
+        runId: "ap_loop-7",
         iteration: 4,
         reason: "user requested",
     });
-    assert.match(line, /^01:02:03\.456\s+pause\s+ralph_loop-7/);
+    assert.match(line, /^01:02:03\.456\s+pause\s+ap_loop-7/);
     assert.match(line, /iter=4/);
     // Multi-word user reasons are JSON-quoted so a `tail -f` consumer
     // (awk / grep -o columns) sees one token after `reason=` instead
@@ -117,7 +117,7 @@ test("formatEventLine: pause renders verb=pause + iteration + reason", () => {
 });
 
 test("formatEventLine: pause with null reason omits the reason segment", () => {
-    // ralph_pause without a reason emits `reason: null`. The renderer
+    // ap_pause without a reason emits `reason: null`. The renderer
     // must skip the segment entirely (not render `reason=null`) so
     // empty-reason pause lines stay tidy in the plain log.
     const line = formatEventLine({
@@ -133,7 +133,7 @@ test("formatEventLine: pause with null reason omits the reason segment", () => {
 });
 
 test("formatEventLine: resume renders verb=resume + iteration + pausedForMs", () => {
-    // ralph_resume emits `{ type: "resume", runId, iteration,
+    // ap_resume emits `{ type: "resume", runId, iteration,
     // pausedForMs, ts }`. The plain renderer surfaces verb / runId /
     // iteration / pausedForMs so a `tail -f`'d log of events lets a
     // human (or `awk`) see exactly how long the loop slept — without
@@ -143,11 +143,11 @@ test("formatEventLine: resume renders verb=resume + iteration + pausedForMs", ()
     const line = formatEventLine({
         type: "resume",
         ts: 0,
-        runId: "ralph_loop-3",
+        runId: "ap_loop-3",
         iteration: 5,
         pausedForMs: 1234,
     });
-    assert.match(line, /resume\s+ralph_loop-3/);
+    assert.match(line, /resume\s+ap_loop-3/);
     assert.match(line, /iter=5/);
     assert.match(line, /pausedForMs=1234/);
 });
@@ -254,11 +254,11 @@ test("formatEventLine: iteration_start renders verb=iter+ + iter=", () => {
     const line = formatEventLine({
         type: "iteration_start",
         ts: 0,
-        runId: "ralph_loop-7",
+        runId: "ap_loop-7",
         iteration: 7,
         maxIterations: 100,
     });
-    assert.match(line, /\biter\+\s+ralph_loop-7\b/);
+    assert.match(line, /\biter\+\s+ap_loop-7\b/);
     assert.match(line, /iter=7\/100/);
     // No tokens / excerpt on iteration_start — those land on the
     // matching iteration_end.
@@ -281,12 +281,12 @@ test("formatEventLine: abort verb renders + reason= + note=", () => {
     const line = formatEventLine({
         type: "abort",
         ts: 0,
-        runId: "ralph_loop-9",
+        runId: "ap_loop-9",
         iterations: 12,
         reason: "stagnation",
         note: "3 identical responses",
     });
-    assert.match(line, /\babort\s+ralph_loop-9\b/);
+    assert.match(line, /\babort\s+ap_loop-9\b/);
     assert.match(line, /reason=stagnation/);
     assert.match(line, /note="3 identical responses"/);
     assert.doesNotMatch(line, /\biter=/, "abort events do not carry per-iter index");
@@ -302,18 +302,18 @@ test("formatEventLine: abort with abort_promise reason renders cleanly", () => {
     const line = formatEventLine({
         type: "abort",
         ts: 0,
-        runId: "ralph_loop-1",
+        runId: "ap_loop-1",
         iterations: 5,
         reason: "abort_promise",
     });
-    assert.match(line, /\babort\s+ralph_loop-1\b/);
+    assert.match(line, /\babort\s+ap_loop-1\b/);
     assert.match(line, /reason=abort_promise/);
     assert.doesNotMatch(line, /note=/, "absent note must not render an empty segment");
 });
 
 test("formatEventLine: reason= field quotes whitespace-bearing user reasons but not baked tokens", () => {
     // Iter 137 fix: pause/stop events with a user-supplied reason
-    // (via ralph_pause / ralph_stop) routinely contain spaces — the
+    // (via ap_pause / ap_stop) routinely contain spaces — the
     // user types "lunch break", "context-window pressure", or
     // similar. Pre-iter-137 the renderer emitted them unquoted, so
     // the line collapsed multiple tokens after `reason=` and
@@ -333,7 +333,7 @@ test("formatEventLine: reason= field quotes whitespace-bearing user reasons but 
     const baked = formatEventLine({
         type: "abort",
         ts: 1_000_000,
-        runId: "ralph_loop-baked",
+        runId: "ap_loop-baked",
         iterations: 3,
         reason: "completion_promise",
     });
@@ -345,7 +345,7 @@ test("formatEventLine: reason= field quotes whitespace-bearing user reasons but 
     const userText = formatEventLine({
         type: "pause",
         ts: 1_000_000,
-        runId: "ralph_loop-user",
+        runId: "ap_loop-user",
         iteration: 7,
         reason: "context window pressure",
     });
@@ -365,7 +365,7 @@ test("formatEventLine: reason= field quotes whitespace-bearing user reasons but 
     const tabbed = formatEventLine({
         type: "pause",
         ts: 1_000_000,
-        runId: "ralph_loop-tab",
+        runId: "ap_loop-tab",
         iteration: 1,
         reason: "lunch\tbreak",
     });

--- a/packages/tui/test/runner.test.mjs
+++ b/packages/tui/test/runner.test.mjs
@@ -1,4 +1,4 @@
-// Tests for `ralph-tui run` driver (packages/tui/src/runner.mjs).
+// Tests for `autopilot run` driver (packages/tui/src/runner.mjs).
 //
 // Strategy:
 //   - Pure helpers (validateFocus, composePrompt, reduceCopilotEvents)
@@ -32,7 +32,7 @@ import {
     resumeRun,
     stopRun,
     statusRun,
-    runRalphTui,
+    runAutopilot,
     runOneIteration,
     PROMPT_SELF_IMPROVE,
     PROMPT_GROW_PROJECT,
@@ -48,7 +48,7 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "
 const FAKE_COPILOT = resolve(dirname(fileURLToPath(import.meta.url)), "fixtures", "fake-copilot.mjs");
 
 function tmp() {
-    return mkdtempSync(join(tmpdir(), "ralph-tui-runner-"));
+    return mkdtempSync(join(tmpdir(), "autopilot-runner-"));
 }
 
 function makeEnv(extra = {}) {
@@ -430,26 +430,26 @@ test("updateState: increments version monotonically under sequential writes", ()
 
 // ───────────── Validation ─────────────
 
-test("runRalphTui: rejects invalid mode", async () => {
-    await assert.rejects(runRalphTui({ mode: "bogus", contextMode: "fresh" }), /invalid mode/);
+test("runAutopilot: rejects invalid mode", async () => {
+    await assert.rejects(runAutopilot({ mode: "bogus", contextMode: "fresh" }), /invalid mode/);
 });
 
-test("runRalphTui: rejects missing prompt for prompt mode", async () => {
-    await assert.rejects(runRalphTui({ mode: "prompt", contextMode: "fresh" }), /requires a non-empty string/);
+test("runAutopilot: rejects missing prompt for prompt mode", async () => {
+    await assert.rejects(runAutopilot({ mode: "prompt", contextMode: "fresh" }), /requires a non-empty string/);
 });
 
-test("runRalphTui: rejects max out of range", async () => {
-    await assert.rejects(runRalphTui({ mode: "self-improve", contextMode: "fresh", max: 0 }), /max must be an integer/);
-    await assert.rejects(runRalphTui({ mode: "self-improve", contextMode: "fresh", max: MAX_ALLOWED_ITERATIONS + 1 }), /max must be an integer/);
+test("runAutopilot: rejects max out of range", async () => {
+    await assert.rejects(runAutopilot({ mode: "self-improve", contextMode: "fresh", max: 0 }), /max must be an integer/);
+    await assert.rejects(runAutopilot({ mode: "self-improve", contextMode: "fresh", max: MAX_ALLOWED_ITERATIONS + 1 }), /max must be an integer/);
 });
 
-test("runRalphTui: rejects bad contextMode", async () => {
-    await assert.rejects(runRalphTui({ mode: "self-improve", contextMode: "weird" }), /contextMode must be/);
+test("runAutopilot: rejects bad contextMode", async () => {
+    await assert.rejects(runAutopilot({ mode: "self-improve", contextMode: "weird" }), /contextMode must be/);
 });
 
-test("runRalphTui: rejects oversize focus", async () => {
+test("runAutopilot: rejects oversize focus", async () => {
     const focus = "x".repeat(MAX_FOCUS_CHARS + 1);
-    await assert.rejects(runRalphTui({ mode: "self-improve", contextMode: "fresh", focus }), /exceeds 2000 characters/);
+    await assert.rejects(runAutopilot({ mode: "self-improve", contextMode: "fresh", focus }), /exceeds 2000 characters/);
 });
 
 // ───────────── End-to-end with fake-copilot shim ─────────────
@@ -467,7 +467,7 @@ function makeShimEnv(scenario) {
     };
 }
 
-test("runRalphTui: --self-improve --continue iter 1 emits COMPLETE → reason=complete, sessionId captured", async () => {
+test("runAutopilot: --self-improve --continue iter 1 emits COMPLETE → reason=complete, sessionId captured", async () => {
     const { env } = makeShimEnv({
         iters: [
             {
@@ -479,7 +479,7 @@ test("runRalphTui: --self-improve --continue iter 1 emits COMPLETE → reason=co
             },
         ],
     });
-    const result = await runRalphTui({
+    const result = await runAutopilot({
         mode: "self-improve",
         contextMode: "continue",
         max: 5,
@@ -531,7 +531,7 @@ function makeMockSpawn(scripts) {
     };
 }
 
-test("runRalphTui: --continue resumes via --resume=<sessionId> on iter 2", async () => {
+test("runAutopilot: --continue resumes via --resume=<sessionId> on iter 2", async () => {
     const argLog = [];
     const spawn = function (bin, args, opts) {
         argLog.push([...args]);
@@ -559,7 +559,7 @@ test("runRalphTui: --continue resumes via --resume=<sessionId> on iter 2", async
         return child;
     };
 
-    const result = await runRalphTui({
+    const result = await runAutopilot({
         mode: "self-improve",
         contextMode: "continue",
         max: 5,
@@ -576,7 +576,7 @@ test("runRalphTui: --continue resumes via --resume=<sessionId> on iter 2", async
     assert.ok(!argLog[1].some((a) => a === "-n"), "iter 2 must not pass -n");
 });
 
-test("runRalphTui: --fresh never resumes and never reuses sessionId", async () => {
+test("runAutopilot: --fresh never resumes and never reuses sessionId", async () => {
     const argLog = [];
     const spawn = function (bin, args) {
         argLog.push([...args]);
@@ -599,7 +599,7 @@ test("runRalphTui: --fresh never resumes and never reuses sessionId", async () =
         return child;
     };
 
-    await runRalphTui({
+    await runAutopilot({
         mode: "grow-project",
         contextMode: "fresh",
         max: 5,
@@ -612,7 +612,7 @@ test("runRalphTui: --fresh never resumes and never reuses sessionId", async () =
     }
 });
 
-test("runRalphTui: ABORT_NO_IMPROVEMENTS triggers abort termination", async () => {
+test("runAutopilot: ABORT_NO_IMPROVEMENTS triggers abort termination", async () => {
     const spawn = makeMockSpawn([
         {
             stdout: [
@@ -622,7 +622,7 @@ test("runRalphTui: ABORT_NO_IMPROVEMENTS triggers abort termination", async () =
             exitCode: 0,
         },
     ]);
-    const result = await runRalphTui({
+    const result = await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 5,
@@ -633,7 +633,7 @@ test("runRalphTui: ABORT_NO_IMPROVEMENTS triggers abort termination", async () =
     assert.match(result.terminationNote, /ABORT_NO_IMPROVEMENTS/);
 });
 
-test("runRalphTui: ABORT_NO_BACKLOG default abort for grow-project", async () => {
+test("runAutopilot: ABORT_NO_BACKLOG default abort for grow-project", async () => {
     const spawn = makeMockSpawn([
         {
             stdout: [
@@ -643,7 +643,7 @@ test("runRalphTui: ABORT_NO_BACKLOG default abort for grow-project", async () =>
             exitCode: 0,
         },
     ]);
-    const result = await runRalphTui({
+    const result = await runAutopilot({
         mode: "grow-project",
         contextMode: "fresh",
         max: 5,
@@ -653,7 +653,7 @@ test("runRalphTui: ABORT_NO_BACKLOG default abort for grow-project", async () =>
     assert.equal(result.terminationReason, "abort");
 });
 
-test("runRalphTui: max-iter cap fires when no terminator is emitted", async () => {
+test("runAutopilot: max-iter cap fires when no terminator is emitted", async () => {
     let n = 0;
     const spawn = function () {
         n++;
@@ -674,7 +674,7 @@ test("runRalphTui: max-iter cap fires when no terminator is emitted", async () =
         });
         return child;
     };
-    const result = await runRalphTui({
+    const result = await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 3,
@@ -685,11 +685,11 @@ test("runRalphTui: max-iter cap fires when no terminator is emitted", async () =
     assert.equal(n, 3);
 });
 
-test("runRalphTui: subprocess exit code != 0 ends loop with subprocess_failed", async () => {
+test("runAutopilot: subprocess exit code != 0 ends loop with subprocess_failed", async () => {
     const spawn = makeMockSpawn([
         { stdout: "", stderr: "auth error\n", exitCode: 1 },
     ]);
-    const result = await runRalphTui({
+    const result = await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 5,
@@ -699,7 +699,7 @@ test("runRalphTui: subprocess exit code != 0 ends loop with subprocess_failed", 
     assert.equal(result.terminationReason, "subprocess_failed");
 });
 
-test("runRalphTui: stopRun mid-loop ends with terminationReason=stopped", async () => {
+test("runAutopilot: stopRun mid-loop ends with terminationReason=stopped", async () => {
     let runIdSeen = null;
     let envSeen = null;
     const spawn = function () {
@@ -726,7 +726,7 @@ test("runRalphTui: stopRun mid-loop ends with terminationReason=stopped", async 
     };
     const env = makeEnv();
     envSeen = env;
-    const result = await runRalphTui({
+    const result = await runAutopilot({
         mode: "prompt",
         prompt: "hi",
         contextMode: "fresh",
@@ -742,7 +742,7 @@ test("runRalphTui: stopRun mid-loop ends with terminationReason=stopped", async 
     assert.equal(s.terminationReason, "stopped");
 });
 
-test("runRalphTui: emits armed → iteration_start → iteration_end → terminal sequence", async () => {
+test("runAutopilot: emits armed → iteration_start → iteration_end → terminal sequence", async () => {
     const events = [];
     const eventEmitter = {
         runId: "test-run-fixed",
@@ -759,7 +759,7 @@ test("runRalphTui: emits armed → iteration_start → iteration_end → termina
             exitCode: 0,
         },
     ]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -775,7 +775,7 @@ test("runRalphTui: emits armed → iteration_start → iteration_end → termina
     // regress every time we tweak live-emission cadence.
     const skeleton = events.map((e) => e.type).filter((t) => t !== "usage_update");
     assert.deepEqual(skeleton, ["armed", "iteration_start", "iteration_end", "complete"]);
-    // armed event must carry contextMode + mode + maxIterations for ralph-tui list.
+    // armed event must carry contextMode + mode + maxIterations for autopilot list.
     assert.equal(events[0].contextMode, "fresh");
     assert.equal(events[0].mode, "self-improve");
     assert.equal(events[0].maxIterations, 1);
@@ -787,7 +787,7 @@ test("runRalphTui: emits armed → iteration_start → iteration_end → termina
 // `assistant.message` and on the terminal `result`, then includes
 // the same cumulative totals on `iteration_end` for replay
 // resilience. This test pins both halves of the contract.
-test("runRalphTui: emits usage_update mid-iter and cumulative tokens+premium on iteration_end", async () => {
+test("runAutopilot: emits usage_update mid-iter and cumulative tokens+premium on iteration_end", async () => {
     const events = [];
     const eventEmitter = {
         runId: "usage-test",
@@ -815,7 +815,7 @@ test("runRalphTui: emits usage_update mid-iter and cumulative tokens+premium on 
             exitCode: 0,
         },
     ]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 2,
@@ -855,7 +855,7 @@ test("runRalphTui: emits usage_update mid-iter and cumulative tokens+premium on 
     assert.equal(iterEnds[1].premiumRequests, 2 + 1);  // run total
 });
 
-test("runRalphTui: emits abort (NOT 'aborted') for early-terminate", async () => {
+test("runAutopilot: emits abort (NOT 'aborted') for early-terminate", async () => {
     const events = [];
     const eventEmitter = {
         runId: "x",
@@ -872,7 +872,7 @@ test("runRalphTui: emits abort (NOT 'aborted') for early-terminate", async () =>
             exitCode: 0,
         },
     ]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -959,7 +959,7 @@ test("extractStageMarkers: handles every grow_project stage, including SELECT an
     assert.deepEqual(got.map((m) => m.stage), SDLC_STAGES_GROW_PROJECT.map((_, i) => i + 1));
 });
 
-test("runRalphTui: parses [STAGE: NAME] markers from agent stdout and emits stage_start/stage_end pairs in order", async () => {
+test("runAutopilot: parses [STAGE: NAME] markers from agent stdout and emits stage_start/stage_end pairs in order", async () => {
     const events = [];
     const eventEmitter = {
         runId: "stage-test",
@@ -973,7 +973,7 @@ test("runRalphTui: parses [STAGE: NAME] markers from agent stdout and emits stag
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1002,7 +1002,7 @@ test("runRalphTui: parses [STAGE: NAME] markers from agent stdout and emits stag
     assert.ok(lastStageIdx < iterEndIdx, "stage events must come BEFORE iteration_end so the iter scope is right");
 });
 
-test("runRalphTui: hallucinated [STAGE: REVIEW] marker is silently dropped (no event emitted)", async () => {
+test("runAutopilot: hallucinated [STAGE: REVIEW] marker is silently dropped (no event emitted)", async () => {
     const events = [];
     const eventEmitter = {
         runId: "stage-bad",
@@ -1015,7 +1015,7 @@ test("runRalphTui: hallucinated [STAGE: REVIEW] marker is silently dropped (no e
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1030,7 +1030,7 @@ test("runRalphTui: hallucinated [STAGE: REVIEW] marker is silently dropped (no e
         ["stage_start:ORIENT", "stage_end:ORIENT"]);
 });
 
-test("runRalphTui: --prompt mode emits no stage events (no canonical stage list)", async () => {
+test("runAutopilot: --prompt mode emits no stage events (no canonical stage list)", async () => {
     const events = [];
     const eventEmitter = {
         runId: "stage-prompt",
@@ -1047,7 +1047,7 @@ test("runRalphTui: --prompt mode emits no stage events (no canonical stage list)
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "prompt",
         contextMode: "fresh",
         prompt: "drive the loop yourself",
@@ -1066,7 +1066,7 @@ import { extractAgentTimeline, summarizeToolArgs } from "../src/runner.mjs";
 
 // ─── Issue #48: live event streaming (regression for the
 // "(no active stage) / (no activity yet)" empty-pane bug
-// reported on `ralph-tui run --self-improve --fresh`).
+// reported on `autopilot run --self-improve --fresh`).
 //
 // Pre-fix, the runner buffered every child JSONL event in
 // memory and emitted the synthetic stage_start / substage
@@ -1084,7 +1084,7 @@ import { extractAgentTimeline, summarizeToolArgs } from "../src/runner.mjs";
 // BEFORE the close gate is released. The pre-fix runner
 // would not emit stage_start until close fired, so the
 // assertion `stageStartBeforeClose === true` would fail.
-test("runRalphTui: stage_start emits LIVE during the iter, not in a post-close batch (issue #48)", async () => {
+test("runAutopilot: stage_start emits LIVE during the iter, not in a post-close batch (issue #48)", async () => {
     const events = [];
     const eventEmitter = {
         runId: "stream-live",
@@ -1134,7 +1134,7 @@ test("runRalphTui: stage_start emits LIVE during the iter, not in a post-close b
         return child;
     };
 
-    const runPromise = runRalphTui({
+    const runPromise = runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1177,11 +1177,11 @@ test("runRalphTui: stage_start emits LIVE during the iter, not in a post-close b
 // post-fix runner would silently drop the last
 // tool.execution_complete (or final `[STAGE: ]` marker) and the
 // TUI's last-iter snapshot would be subtly wrong. The
-// streaming + suffix-replay design in `runRalphTui` defends
+// streaming + suffix-replay design in `runAutopilot` defends
 // against this in two ways (onLine-on-drain + suffix replay
 // against result.events), so even if only one path were
 // somehow broken, this assertion still holds.
-test("runRalphTui: final un-newline-terminated JSONL line is captured live (close-drain → onLine)", async () => {
+test("runAutopilot: final un-newline-terminated JSONL line is captured live (close-drain → onLine)", async () => {
     const events = [];
     const eventEmitter = {
         runId: "drain-live",
@@ -1217,7 +1217,7 @@ test("runRalphTui: final un-newline-terminated JSONL line is captured live (clos
         return child;
     };
 
-    const result = await runRalphTui({
+    const result = await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1353,7 +1353,7 @@ test("extractAgentTimeline: sub-agent (agentId set) assistant.message events are
     assert.equal(tl.length, 1, "only the root agent's marker counts");
 });
 
-test("runRalphTui: emits substage events with sub index, verb, argsSummary, outcome, durationMs", async () => {
+test("runAutopilot: emits substage events with sub index, verb, argsSummary, outcome, durationMs", async () => {
     const events = [];
     const eventEmitter = {
         runId: "substage-test",
@@ -1378,7 +1378,7 @@ test("runRalphTui: emits substage events with sub index, verb, argsSummary, outc
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1409,7 +1409,7 @@ test("runRalphTui: emits substage events with sub index, verb, argsSummary, outc
     assert.ok(types.includes("stage_end"), "stages must close so foldEvents bookkeeping is clean");
 });
 
-test("runRalphTui: substage sub-counter resets to 1 on each new stage_start", async () => {
+test("runAutopilot: substage sub-counter resets to 1 on each new stage_start", async () => {
     const events = [];
     const eventEmitter = {
         runId: "sub-reset-test",
@@ -1435,7 +1435,7 @@ test("runRalphTui: substage sub-counter resets to 1 on each new stage_start", as
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1677,7 +1677,7 @@ test("extractAgentTimeline: structured markers from sub-agents (agentId set) are
     assert.deepEqual(tl[0].payload.stages, ["B"]);
 });
 
-test("runRalphTui: STAGE_PLAN marker → emits stage_plan event followed by pinned-tail amendments", async () => {
+test("runAutopilot: STAGE_PLAN marker → emits stage_plan event followed by pinned-tail amendments", async () => {
     const events = [];
     const eventEmitter = {
         runId: "stage-plan-test",
@@ -1693,7 +1693,7 @@ test("runRalphTui: STAGE_PLAN marker → emits stage_plan event followed by pinn
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1715,7 +1715,7 @@ test("runRalphTui: STAGE_PLAN marker → emits stage_plan event followed by pinn
     assert.ok(planIdx >= 0 && planIdx < firstAmendIdx, "stage_plan precedes amends");
 });
 
-test("runRalphTui: bash 'git commit' substage → emits commit_observed with sha+subject+trailers", async () => {
+test("runAutopilot: bash 'git commit' substage → emits commit_observed with sha+subject+trailers", async () => {
     const events = [];
     const eventEmitter = {
         runId: "commit-observed-test",
@@ -1755,7 +1755,7 @@ test("runRalphTui: bash 'git commit' substage → emits commit_observed with sha
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1777,7 +1777,7 @@ test("runRalphTui: bash 'git commit' substage → emits commit_observed with sha
     assert.equal(cos[1].trailers.length, 1);
 });
 
-test("runRalphTui: failed git commit substage does NOT trigger commit_observed", async () => {
+test("runAutopilot: failed git commit substage does NOT trigger commit_observed", async () => {
     const events = [];
     const eventEmitter = {
         runId: "commit-fail-test",
@@ -1805,7 +1805,7 @@ test("runRalphTui: failed git commit substage does NOT trigger commit_observed",
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1821,7 +1821,7 @@ test("runRalphTui: failed git commit substage does NOT trigger commit_observed",
     assert.equal(gitExecCalls, 1, "gitExec called once at arm-time replay (rev-parse), short-circuits on null");
 });
 
-test("runRalphTui: non-bash tool with 'git commit' in argsSummary does NOT fire commit_observed", async () => {
+test("runAutopilot: non-bash tool with 'git commit' in argsSummary does NOT fire commit_observed", async () => {
     const events = [];
     const eventEmitter = {
         runId: "non-bash-test",
@@ -1841,7 +1841,7 @@ test("runRalphTui: non-bash tool with 'git commit' in argsSummary does NOT fire 
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1855,7 +1855,7 @@ test("runRalphTui: non-bash tool with 'git commit' in argsSummary does NOT fire 
 
 // ─── Issue #54 slice 2c: arm-time HEAD replay-on-mount ──────────────
 
-test("Issue #54 slice 2c: runRalphTui emits commit_observed at arm time when HEAD exists, even if iter makes no commits", async () => {
+test("Issue #54 slice 2c: runAutopilot emits commit_observed at arm time when HEAD exists, even if iter makes no commits", async () => {
     const events = [];
     const eventEmitter = {
         runId: "arm-replay-test",
@@ -1878,7 +1878,7 @@ test("Issue #54 slice 2c: runRalphTui emits commit_observed at arm time when HEA
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1911,7 +1911,7 @@ test("Issue #54 slice 2c: arm-time replay is silent when gitExec returns null (n
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1924,7 +1924,7 @@ test("Issue #54 slice 2c: arm-time replay is silent when gitExec returns null (n
         "no commit_observed emitted when gitExec returns null");
 });
 
-test("runRalphTui: WORKITEM_START + WORKITEM_END markers emit workitem events", async () => {
+test("runAutopilot: WORKITEM_START + WORKITEM_END markers emit workitem events", async () => {
     const events = [];
     const eventEmitter = {
         runId: "wi-test",
@@ -1942,7 +1942,7 @@ test("runRalphTui: WORKITEM_START + WORKITEM_END markers emit workitem events", 
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1960,7 +1960,7 @@ test("runRalphTui: WORKITEM_START + WORKITEM_END markers emit workitem events", 
     assert.equal(end.closesN, 1);
 });
 
-test("runRalphTui: TASK_LIST + TASK_START + TASK_END markers emit task events", async () => {
+test("runAutopilot: TASK_LIST + TASK_START + TASK_END markers emit task events", async () => {
     const events = [];
     const eventEmitter = {
         runId: "task-test",
@@ -1980,7 +1980,7 @@ test("runRalphTui: TASK_LIST + TASK_START + TASK_END markers emit task events", 
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -1999,7 +1999,7 @@ test("runRalphTui: TASK_LIST + TASK_START + TASK_END markers emit task events", 
     assert.equal(end.durationMs, 500);
 });
 
-test("runRalphTui: malformed marker payload (missing required field) is silently dropped", async () => {
+test("runAutopilot: malformed marker payload (missing required field) is silently dropped", async () => {
     const events = [];
     const eventEmitter = {
         runId: "bad-marker-test",
@@ -2022,7 +2022,7 @@ test("runRalphTui: malformed marker payload (missing required field) is silently
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -2170,7 +2170,7 @@ test("extractBacklogFromEvents: non-array input → null", () => {
     assert.equal(extractBacklogFromEvents("not events"), null);
 });
 
-test("runRalphTui: emits backlog_snapshot when the agent runs gh probes during ORIENT", async () => {
+test("runAutopilot: emits backlog_snapshot when the agent runs gh probes during ORIENT", async () => {
     const events = [];
     const eventEmitter = {
         runId: "backlog-test",
@@ -2203,7 +2203,7 @@ test("runRalphTui: emits backlog_snapshot when the agent runs gh probes during O
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
@@ -2224,7 +2224,7 @@ test("runRalphTui: emits backlog_snapshot when the agent runs gh probes during O
     assert.ok(snapIdx < iterEndIdx, "backlog_snapshot must precede iteration_end");
 });
 
-test("runRalphTui: no backlog_snapshot when the agent ran no gh probes (e.g. --prompt mode)", async () => {
+test("runAutopilot: no backlog_snapshot when the agent ran no gh probes (e.g. --prompt mode)", async () => {
     const events = [];
     const eventEmitter = {
         runId: "no-backlog-test",
@@ -2238,7 +2238,7 @@ test("runRalphTui: no backlog_snapshot when the agent ran no gh probes (e.g. --p
         JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
     ].join("\n") + "\n";
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
-    await runRalphTui({
+    await runAutopilot({
         mode: "prompt",
         contextMode: "fresh",
         prompt: "do something",
@@ -2253,7 +2253,7 @@ test("runRalphTui: no backlog_snapshot when the agent ran no gh probes (e.g. --p
 
 // ─── Issue #48 slice 9 commit 4: smoke test — full marker stream ────────
 //
-// Drives runRalphTui end-to-end with a single iter that emits the
+// Drives runAutopilot end-to-end with a single iter that emits the
 // complete marker hierarchy:
 //   workitem_start → stage_plan → task_list → task_start →
 //   tool_complete (git commit) → commit_observed (runner side) →
@@ -2265,7 +2265,7 @@ test("runRalphTui: no backlog_snapshot when the agent ran no gh probes (e.g. --p
 
 import { foldEvents } from "../src/events.mjs";
 
-test("runRalphTui smoke: full marker stream surfaces stage_plan + task_list + task_start/end + commit_observed + workitem_start/end", async () => {
+test("runAutopilot smoke: full marker stream surfaces stage_plan + task_list + task_start/end + commit_observed + workitem_start/end", async () => {
     const events = [];
     const eventEmitter = {
         runId: "smoke-r-48",
@@ -2331,7 +2331,7 @@ test("runRalphTui smoke: full marker stream surfaces stage_plan + task_list + ta
         }
         return null;
     };
-    const result = await runRalphTui({
+    const result = await runAutopilot({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,

--- a/packages/tui/test/runner.test.mjs
+++ b/packages/tui/test/runner.test.mjs
@@ -15,7 +15,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, chmodSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { tmpdir, homedir } from "node:os";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -25,6 +25,7 @@ import {
     reduceCopilotEvents,
     resolveStateRoot,
     resolveStatePath,
+    resolveCopilotBin,
     readState,
     updateState,
     pauseRun,
@@ -52,9 +53,43 @@ function tmp() {
 
 function makeEnv(extra = {}) {
     return {
-        RALPH_TUI_RUNS_DIR: extra.RALPH_TUI_RUNS_DIR ?? tmp(),
-        RALPH_EVENTS_DIR: extra.RALPH_EVENTS_DIR ?? tmp(),
+        AUTOPILOT_RUNS_DIR: extra.AUTOPILOT_RUNS_DIR ?? tmp(),
+        AUTOPILOT_EVENTS_DIR: extra.AUTOPILOT_EVENTS_DIR ?? tmp(),
         ...extra,
+    };
+}
+
+// Stage 3 (issue #49): resolveStateRoot / resolveCopilotBin now perform
+// sentinel-gated stderr deprecation notices when legacy
+// $RALPH_TUI_RUNS_DIR / $RALPH_TUI_COPILOT_BIN are used. Tests inject
+// a fake fs (no sentinel, accepts mkdir/append silently) and a fake
+// stderr (captures into messages[]). The sentinelPath points at a fake
+// location so deprecation writes never touch the real ~/.copilot.
+function makeFakeFs({ sentinel = "", existingPaths = new Set() } = {}) {
+    let written = "";
+    const fake = {
+        readFileSync: (p) => {
+            if (p === fake._sentinelPath) return sentinel + written;
+            const e = new Error("ENOENT");
+            e.code = "ENOENT";
+            throw e;
+        },
+        appendFileSync: (p, data) => {
+            if (p === fake._sentinelPath) written += data;
+        },
+        mkdirSync: () => {},
+        existsSync: (p) => existingPaths.has(p),
+    };
+    fake._sentinelPath = "/fake/sentinel";
+    fake.writtenSentinel = () => written;
+    return fake;
+}
+
+function makeFakeStderr() {
+    const messages = [];
+    return {
+        write: (m) => { messages.push(String(m)); },
+        messages,
     };
 }
 
@@ -192,17 +227,115 @@ test("reduceCopilotEvents: premiumRequests is null when result is missing or mal
 
 // ───────────── State root + path ─────────────
 
-test("resolveStateRoot: honors $RALPH_TUI_RUNS_DIR", () => {
-    assert.equal(resolveStateRoot({ RALPH_TUI_RUNS_DIR: "/tmp/whatever" }), "/tmp/whatever");
+test("resolveStateRoot: honors $AUTOPILOT_RUNS_DIR (primary)", () => {
+    assert.equal(resolveStateRoot({ env: { AUTOPILOT_RUNS_DIR: "/tmp/whatever" } }), "/tmp/whatever");
 });
 
-test("resolveStateRoot: defaults under ~/.copilot/ralph-tui/runs", () => {
-    const r = resolveStateRoot({});
-    assert.match(r, /\.copilot\/ralph-tui\/runs$/);
+test("resolveStateRoot: honors $RALPH_TUI_RUNS_DIR (legacy, with notice)", () => {
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/tmp/x" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        "/tmp/x",
+    );
+    assert.equal(stderr.messages.length, 1);
+    assert.match(stderr.messages[0], /RALPH_TUI_RUNS_DIR is deprecated/);
+});
+
+test("resolveStateRoot: defaults under ~/.copilot/autopilot/runs", () => {
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    const r = resolveStateRoot({ env: {}, fs, stderr, sentinelPath: "/fake/sentinel" });
+    assert.match(r, /\.copilot\/autopilot\/runs$/);
+    assert.equal(stderr.messages.length, 0);
+});
+
+test("resolveStateRoot: AUTOPILOT primary wins over RALPH_TUI legacy (no notice)", () => {
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveStateRoot({
+            env: { AUTOPILOT_RUNS_DIR: "/ap", RALPH_TUI_RUNS_DIR: "/legacy" },
+            fs, stderr, sentinelPath: "/fake/sentinel",
+        }),
+        "/ap",
+    );
+    assert.equal(stderr.messages.length, 0);
+});
+
+test("resolveStateRoot: legacy default path is honoured with deprecation notice", () => {
+    const legacyDefault = join(homedir(), ".copilot", "ralph-tui", "runs");
+    const fs = makeFakeFs({ existingPaths: new Set([legacyDefault]) });
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveStateRoot({ env: {}, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        legacyDefault,
+    );
+    assert.equal(stderr.messages.length, 1);
+    assert.match(stderr.messages[0], /reading from legacy/);
+});
+
+test("resolveStateRoot: when both default paths exist, primary wins (no notice)", () => {
+    const newDefault = join(homedir(), ".copilot", "autopilot", "runs");
+    const oldDefault = join(homedir(), ".copilot", "ralph-tui", "runs");
+    const fs = makeFakeFs({ existingPaths: new Set([newDefault, oldDefault]) });
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveStateRoot({ env: {}, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        newDefault,
+    );
+    assert.equal(stderr.messages.length, 0);
+});
+
+test("resolveStateRoot: deprecation notice is one-shot per process (sentinel-gated)", () => {
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    const sentinelPath = "/fake/sentinel";
+    resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/x" }, fs, stderr, sentinelPath });
+    resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/x" }, fs, stderr, sentinelPath });
+    resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/x" }, fs, stderr, sentinelPath });
+    assert.equal(stderr.messages.length, 1);
+    assert.match(fs.writtenSentinel(), /RALPH_TUI_RUNS_DIR/);
+});
+
+test("resolveStateRoot: pre-existing sentinel suppresses the notice", () => {
+    const fs = makeFakeFs({ sentinel: "env:RALPH_TUI_RUNS_DIR\n" });
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/tmp/x" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        "/tmp/x",
+    );
+    assert.equal(stderr.messages.length, 0);
+});
+
+// resolveCopilotBin (issue #49) — same DI shape as resolveStateRoot
+test("resolveCopilotBin: defaults to 'copilot'", () => {
+    assert.equal(resolveCopilotBin({ env: {} }), "copilot");
+});
+
+test("resolveCopilotBin: honours $AUTOPILOT_COPILOT_BIN (primary, no notice)", () => {
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveCopilotBin({ env: { AUTOPILOT_COPILOT_BIN: "/usr/local/bin/copilot" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        "/usr/local/bin/copilot",
+    );
+    assert.equal(stderr.messages.length, 0);
+});
+
+test("resolveCopilotBin: honours $RALPH_TUI_COPILOT_BIN (legacy, with notice)", () => {
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveCopilotBin({ env: { RALPH_TUI_COPILOT_BIN: "/usr/local/bin/copilot-old" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        "/usr/local/bin/copilot-old",
+    );
+    assert.equal(stderr.messages.length, 1);
+    assert.match(stderr.messages[0], /RALPH_TUI_COPILOT_BIN is deprecated/);
 });
 
 test("resolveStatePath: joins root + runId + state.json", () => {
-    const env = { RALPH_TUI_RUNS_DIR: "/tmp/r" };
+    const env = { AUTOPILOT_RUNS_DIR: "/tmp/r" };
     assert.equal(resolveStatePath("foo-1", env), "/tmp/r/foo-1/state.json");
 });
 
@@ -210,20 +343,20 @@ test("resolveStatePath: joins root + runId + state.json", () => {
 
 test("updateState: throws TypeError when state.json missing", () => {
     const dir = tmp();
-    const env = { RALPH_TUI_RUNS_DIR: dir };
+    const env = { AUTOPILOT_RUNS_DIR: dir };
     assert.throws(() => updateState("nonexistent", (s) => s, env), TypeError);
     rmSync(dir, { recursive: true, force: true });
 });
 
 test("readState: returns null when state.json missing", () => {
     const dir = tmp();
-    assert.equal(readState("nope", { RALPH_TUI_RUNS_DIR: dir }), null);
+    assert.equal(readState("nope", { AUTOPILOT_RUNS_DIR: dir }), null);
     rmSync(dir, { recursive: true, force: true });
 });
 
 test("pauseRun → resumeRun: idempotent + accumulates totalPausedMs", () => {
     const dir = tmp();
-    const env = { RALPH_TUI_RUNS_DIR: dir };
+    const env = { AUTOPILOT_RUNS_DIR: dir };
     // Seed a state file directly.
     const runId = "test-1";
     mkdirSync(join(dir, runId), { recursive: true });
@@ -259,7 +392,7 @@ test("pauseRun → resumeRun: idempotent + accumulates totalPausedMs", () => {
 
 test("stopRun: sets stopRequested + stopReason, idempotent on terminated runs", () => {
     const dir = tmp();
-    const env = { RALPH_TUI_RUNS_DIR: dir };
+    const env = { AUTOPILOT_RUNS_DIR: dir };
     const runId = "test-2";
     mkdirSync(join(dir, runId), { recursive: true });
     writeFileSync(join(dir, runId, "state.json"),
@@ -278,13 +411,13 @@ test("stopRun: sets stopRequested + stopReason, idempotent on terminated runs", 
 
 test("statusRun: throws TypeError on missing", () => {
     const dir = tmp();
-    assert.throws(() => statusRun("missing", { env: { RALPH_TUI_RUNS_DIR: dir } }), TypeError);
+    assert.throws(() => statusRun("missing", { env: { AUTOPILOT_RUNS_DIR: dir } }), TypeError);
     rmSync(dir, { recursive: true, force: true });
 });
 
 test("updateState: increments version monotonically under sequential writes", () => {
     const dir = tmp();
-    const env = { RALPH_TUI_RUNS_DIR: dir };
+    const env = { AUTOPILOT_RUNS_DIR: dir };
     const runId = "v";
     mkdirSync(join(dir, runId), { recursive: true });
     writeFileSync(join(dir, runId, "state.json"), JSON.stringify({ version: 1, runId, n: 0 }));

--- a/packages/tui/test/runner.test.mjs
+++ b/packages/tui/test/runner.test.mjs
@@ -634,8 +634,14 @@ test("runRalphTui: emits armed → iteration_start → iteration_end → termina
         spawn,
         eventEmitter,
     });
-    const types = events.map((e) => e.type);
-    assert.deepEqual(types, ["armed", "iteration_start", "iteration_end", "complete"]);
+    // The skeleton sequence is armed → iteration_start →
+    // (any number of usage_update for live tokens / excerpt
+    // streaming, issue #54 slice 2a) → iteration_end → complete.
+    // Drop usage_update before asserting the skeleton so this test
+    // stays focused on the iteration-lifecycle contract and doesn't
+    // regress every time we tweak live-emission cadence.
+    const skeleton = events.map((e) => e.type).filter((t) => t !== "usage_update");
+    assert.deepEqual(skeleton, ["armed", "iteration_start", "iteration_end", "complete"]);
     // armed event must carry contextMode + mode + maxIterations for ralph-tui list.
     assert.equal(events[0].contextMode, "fresh");
     assert.equal(events[0].mode, "self-improve");
@@ -1585,9 +1591,25 @@ test("runRalphTui: bash 'git commit' substage → emits commit_observed with sha
         close: () => {},
     };
     const NUL = "\u0000";
+    // Issue #54 slice 2c — runner now also probes HEAD at arm time
+    // (replay-on-mount) so the LastCommit pane is never empty when
+    // the run starts. Stateful gitExec returns the pre-loop HEAD on
+    // the first rev-parse+log pair (arm-time), then advances to the
+    // post-commit HEAD for subsequent calls (the iter-1 commit
+    // substage probe). This pins both legitimate emit sites.
+    let revParseCalls = 0;
+    let logCalls = 0;
     const gitExec = ({ args }) => {
-        if (args[0] === "rev-parse" && args[1] === "--short") return "abc1234\n";
-        if (args[0] === "log") return `feat(x): test commit${NUL}Co-authored-by: Copilot <copilot@users.noreply.github.com>`;
+        if (args[0] === "rev-parse" && args[1] === "--short") {
+            revParseCalls += 1;
+            return revParseCalls === 1 ? "0000000\n" : "abc1234\n";
+        }
+        if (args[0] === "log") {
+            logCalls += 1;
+            return logCalls === 1
+                ? `chore: pre-loop baseline${NUL}`
+                : `feat(x): test commit${NUL}Co-authored-by: Copilot <copilot@users.noreply.github.com>`;
+        }
         return null;
     };
     const stdout = [
@@ -1610,10 +1632,16 @@ test("runRalphTui: bash 'git commit' substage → emits commit_observed with sha
         gitExec,
     });
     const cos = events.filter((e) => e.type === "commit_observed");
-    assert.equal(cos.length, 1, "exactly one commit_observed for one git commit substage");
-    assert.equal(cos[0].sha, "abc1234");
-    assert.equal(cos[0].subject, "feat(x): test commit");
-    assert.equal(cos[0].trailers.length, 1);
+    // Two events: arm-time HEAD replay (iteration:0) +
+    // iter-1 git commit substage observation (iteration:1).
+    assert.equal(cos.length, 2, "arm-time replay + iter-1 commit substage");
+    assert.equal(cos[0].iteration, 0, "first event is arm-time replay");
+    assert.equal(cos[0].sha, "0000000");
+    assert.equal(cos[0].subject, "chore: pre-loop baseline");
+    assert.equal(cos[1].iteration, 1, "second event is iter-1 commit");
+    assert.equal(cos[1].sha, "abc1234");
+    assert.equal(cos[1].subject, "feat(x): test commit");
+    assert.equal(cos[1].trailers.length, 1);
 });
 
 test("runRalphTui: failed git commit substage does NOT trigger commit_observed", async () => {
@@ -1624,6 +1652,14 @@ test("runRalphTui: failed git commit substage does NOT trigger commit_observed",
         write: (ev) => events.push(ev),
         close: () => {},
     };
+    // Issue #54 slice 2c — runner now also probes HEAD at arm time
+    // for replay-on-mount. With a stub returning null (simulating
+    // "not a git repo"), the arm-time probe still calls gitExec
+    // (rev-parse) but gets null back, so no commit_observed event
+    // is emitted. The bash-substage path (which is what this test
+    // pins) is unrelated and would not emit either since success=
+    // false. Net: 0 commit_observed events, but gitExec IS called
+    // once at arm-time.
     let gitExecCalls = 0;
     const gitExec = () => { gitExecCalls += 1; return null; };
     const stdout = [
@@ -1646,7 +1682,10 @@ test("runRalphTui: failed git commit substage does NOT trigger commit_observed",
         gitExec,
     });
     assert.equal(events.filter((e) => e.type === "commit_observed").length, 0);
-    assert.equal(gitExecCalls, 0, "gitExec never called for a failed commit");
+    // Arm-time replay-on-mount calls gitExec once (rev-parse).
+    // Returns null → readHeadCommit short-circuits, no log call.
+    // Failed-commit substage path doesn't shell to git either.
+    assert.equal(gitExecCalls, 1, "gitExec called once at arm-time replay (rev-parse), short-circuits on null");
 });
 
 test("runRalphTui: non-bash tool with 'git commit' in argsSummary does NOT fire commit_observed", async () => {
@@ -1679,6 +1718,77 @@ test("runRalphTui: non-bash tool with 'git commit' in argsSummary does NOT fire 
         gitExec,
     });
     assert.equal(events.filter((e) => e.type === "commit_observed").length, 0);
+});
+
+// ─── Issue #54 slice 2c: arm-time HEAD replay-on-mount ──────────────
+
+test("Issue #54 slice 2c: runRalphTui emits commit_observed at arm time when HEAD exists, even if iter makes no commits", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "arm-replay-test",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    const NUL = "\u0000";
+    const gitExec = ({ args }) => {
+        if (args[0] === "rev-parse" && args[1] === "--short") return "deadbee\n";
+        if (args[0] === "log") return `chore: pre-loop baseline${NUL}Co-authored-by: Copilot <c@e>`;
+        return null;
+    };
+    // Iter that DOESN'T commit — just emits COMPLETE. The arm-time
+    // replay is what populates LastCommit so the user sees HEAD on
+    // mount instead of an empty pane.
+    const stdout = [
+        JSON.stringify({ type: "assistant.message", timestamp: "2026-01-01T00:00:00.000Z",
+            data: { content: "COMPLETE" } }),
+        JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+    ].join("\n") + "\n";
+    const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+        gitExec,
+    });
+    const cos = events.filter((e) => e.type === "commit_observed");
+    assert.equal(cos.length, 1, "exactly one commit_observed emitted at arm time");
+    assert.equal(cos[0].iteration, 0, "arm-time replay carries iteration: 0");
+    assert.equal(cos[0].sha, "deadbee");
+    assert.equal(cos[0].subject, "chore: pre-loop baseline");
+    assert.equal(cos[0].trailers.length, 1);
+});
+
+test("Issue #54 slice 2c: arm-time replay is silent when gitExec returns null (not a repo)", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "no-repo-test",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    // gitExec returns null for everything → not a repo / git missing.
+    const gitExec = () => null;
+    const stdout = [
+        JSON.stringify({ type: "assistant.message", timestamp: "2026-01-01T00:00:00.000Z",
+            data: { content: "COMPLETE" } }),
+        JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+    ].join("\n") + "\n";
+    const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+        gitExec,
+    });
+    assert.equal(events.filter((e) => e.type === "commit_observed").length, 0,
+        "no commit_observed emitted when gitExec returns null");
 });
 
 test("runRalphTui: WORKITEM_START + WORKITEM_END markers emit workitem events", async () => {
@@ -2064,15 +2174,27 @@ test("runRalphTui smoke: full marker stream surfaces stage_plan + task_list + ta
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
     // Stub gitExec so the smoke test doesn't depend on the test's cwd
     // being a real git repo. Returns canned data for the two
-    // composing calls readHeadCommit makes.
+    // composing calls readHeadCommit makes. Issue #54 slice 2c —
+    // arm-time replay-on-mount calls readHeadCommit once before
+    // iter-1 starts, then the iter-1 git commit substage calls it
+    // again. The stub uses distinct SHAs so the two emissions are
+    // distinguishable in the assertions below.
     let gitCalls = 0;
+    let revParseCalls = 0;
+    let logCalls = 0;
     const gitExec = ({ args }) => {
         gitCalls++;
         if (args[0] === "rev-parse" && args[1] === "--short") {
-            return "abc1234\n";
+            revParseCalls += 1;
+            // Arm-time HEAD before any iter has run.
+            // Iter-1 commit observation lands on the post-commit HEAD.
+            return revParseCalls === 1 ? "0000000\n" : "abc1234\n";
         }
         if (args[0] === "log") {
-            return "feat(tui): smoke\u0000Co-authored-by: Copilot <c@e>\nCo-authored-by: copilot-ralph <r@e>\n";
+            logCalls += 1;
+            return logCalls === 1
+                ? "chore: pre-loop baseline\u0000"
+                : "feat(tui): smoke\u0000Co-authored-by: Copilot <c@e>\nCo-authored-by: copilot-ralph <r@e>\n";
         }
         return null;
     };
@@ -2107,14 +2229,18 @@ test("runRalphTui smoke: full marker stream surfaces stage_plan + task_list + ta
     assert.equal(taskStart.sub, 1);
     const taskEnd = events.find((e) => e.type === "task_end");
     assert.equal(taskEnd.outcome, "ok");
-    const commitObs = events.find((e) => e.type === "commit_observed");
-    assert.equal(commitObs.sha, "abc1234");
-    assert.equal(commitObs.subject, "feat(tui): smoke");
-    assert.equal(commitObs.trailers.length, 2);
-
-    // commit_observed is exactly once (idempotent per toolCallId).
-    assert.equal(events.filter((e) => e.type === "commit_observed").length, 1,
-        "commit_observed must be idempotent per toolCallId");
+    // Two commit_observed events in order: arm-time replay then
+    // iter-1 commit substage. Pinning both proves slice 2c is wired
+    // and the iter-loop's per-toolCallId path is still idempotent.
+    const commitObsList = events.filter((e) => e.type === "commit_observed");
+    assert.equal(commitObsList.length, 2, "arm-time replay + iter-1 commit substage");
+    assert.equal(commitObsList[0].iteration, 0);
+    assert.equal(commitObsList[0].sha, "0000000");
+    assert.equal(commitObsList[0].subject, "chore: pre-loop baseline");
+    assert.equal(commitObsList[1].iteration, 1);
+    assert.equal(commitObsList[1].sha, "abc1234");
+    assert.equal(commitObsList[1].subject, "feat(tui): smoke");
+    assert.equal(commitObsList[1].trailers.length, 2);
 
     // foldEvents must build a snapshot the renderer can consume.
     const snap = foldEvents(events);
@@ -2126,10 +2252,12 @@ test("runRalphTui smoke: full marker stream surfaces stage_plan + task_list + ta
     );
     assert.deepEqual(snap.currentPlan?.stages, ["DIAG", "FIX", "TEST", "COMMIT", "PUSH", "END"]);
     assert.equal(snap.currentTaskList?.stage, "FIX");
+    // After both commit_observed emissions, snap.lastCommit reflects
+    // the most-recent (iter-1 commit), not the arm-time baseline.
     assert.equal(snap.lastCommit?.sha, "abc1234");
     assert.equal(snap.lastCommit?.subject, "feat(tui): smoke");
 
-    // The runner shelled out to git twice (rev-parse + log) for the
-    // single commit — proves the readHeadCommit path actually fired.
-    assert.equal(gitCalls, 2, "readHeadCommit composes two git commands");
+    // The runner shelled out to git four times: arm-time
+    // (rev-parse + log) + iter-1 commit (rev-parse + log).
+    assert.equal(gitCalls, 4, "arm-time + iter-1 each compose rev-parse + log");
 });

--- a/packages/tui/test/tail.test.mjs
+++ b/packages/tui/test/tail.test.mjs
@@ -8,7 +8,7 @@ import { readEventsFile, splitAndParse, tailEventsFile } from "../src/tail.mjs";
 import { serializeEvent } from "../src/events.mjs";
 
 function tmp() {
-    return mkdtempSync(join(tmpdir(), "ralph-tail-"));
+    return mkdtempSync(join(tmpdir(), "autopilot-tail-"));
 }
 
 function evLine(ev) {

--- a/packages/tui/test/writer.test.mjs
+++ b/packages/tui/test/writer.test.mjs
@@ -15,7 +15,7 @@ import {
 import { makeRunId } from "../src/events.mjs";
 
 function mkTmp() {
-    return fs.mkdtempSync(path.join(os.tmpdir(), "ralph-tui-writer-"));
+    return fs.mkdtempSync(path.join(os.tmpdir(), "autopilot-writer-"));
 }
 
 function readLines(filePath) {
@@ -146,8 +146,8 @@ test("resolveRunsRoot: pre-existing sentinel suppresses the notice", () => {
 });
 
 test("resolveRunEventsPath joins runId under the runs root", () => {
-    const p = resolveRunEventsPath("ralph_loop-1", { env: { AUTOPILOT_EVENTS_DIR: "/tmp/r" } });
-    assert.equal(p, "/tmp/r/ralph_loop-1/events.jsonl");
+    const p = resolveRunEventsPath("ap_loop-1", { env: { AUTOPILOT_EVENTS_DIR: "/tmp/r" } });
+    assert.equal(p, "/tmp/r/ap_loop-1/events.jsonl");
 });
 
 test("resolveRunEventsPath rejects empty runId", () => {
@@ -168,17 +168,17 @@ test("resolveRunEventsPath rejects path-traversal runIds", () => {
 test("resolveRunEventsPath accepts legitimately-shaped runIds", () => {
     const env = { AUTOPILOT_EVENTS_DIR: "/tmp/r" };
     // Emitter-produced shape: [A-Za-z0-9_-]+
-    for (const ok of ["ralph_loop-1", "self_improve-1700000000000", "grow_project-42", "a-b_c-1"]) {
+    for (const ok of ["ap_loop-1", "self_improve-1700000000000", "grow_project-42", "a-b_c-1"]) {
         assert.doesNotThrow(() => resolveRunEventsPath(ok, { env }));
     }
 });
 
 test("createEventWriter: emits a valid armed line and creates the run dir", () => {
     const root = mkTmp();
-    const runId = makeRunId("ralph_loop", 1700000000000);
+    const runId = makeRunId("ap_loop", 1700000000000);
     const w = createEventWriter({
         runId,
-        label: "ralph_loop",
+        label: "ap_loop",
         env: { AUTOPILOT_EVENTS_DIR: root },
         now: () => 1700000000000,
     });
@@ -187,7 +187,7 @@ test("createEventWriter: emits a valid armed line and creates the run dir", () =
     assert.equal(lines.length, 1);
     assert.equal(lines[0].type, "armed");
     assert.equal(lines[0].runId, runId);
-    assert.equal(lines[0].label, "ralph_loop");
+    assert.equal(lines[0].label, "ap_loop");
     assert.equal(lines[0].maxIterations, 20);
     assert.equal(lines[0].ts, 1700000000000);
 });
@@ -295,7 +295,7 @@ test("readRunIndex: empty when index.jsonl is missing", () => {
 
 test("readRunIndex: returns entries newest-first", () => {
     const root = mkTmp();
-    const w1 = createEventWriter({ runId: "r-1", label: "ralph_loop", env: { AUTOPILOT_EVENTS_DIR: root }, now: () => 100 });
+    const w1 = createEventWriter({ runId: "r-1", label: "ap_loop", env: { AUTOPILOT_EVENTS_DIR: root }, now: () => 100 });
     w1.emit({ type: "armed" });
     const w2 = createEventWriter({ runId: "r-2", label: "self_improve", env: { AUTOPILOT_EVENTS_DIR: root }, now: () => 200 });
     w2.emit({ type: "armed" });
@@ -312,10 +312,10 @@ test("readRunIndex: skips malformed lines, keeps good ones", () => {
     fs.mkdirSync(root, { recursive: true });
     fs.writeFileSync(indexPath, [
         "{not json}",
-        JSON.stringify({ type: "armed", ts: 1, runId: "ok-1", label: "ralph_loop" }),
+        JSON.stringify({ type: "armed", ts: 1, runId: "ok-1", label: "ap_loop" }),
         "",
         JSON.stringify({ type: "weird", ts: 2, runId: "skip" }),
-        JSON.stringify({ type: "armed", ts: 3, runId: "ok-2", label: "ralph_loop" }),
+        JSON.stringify({ type: "armed", ts: 3, runId: "ok-2", label: "ap_loop" }),
     ].join("\n") + "\n");
     const entries = readRunIndex({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.deepEqual(entries.map((e) => e.runId), ["ok-2", "ok-1"]);
@@ -342,14 +342,14 @@ test("aggregateRuns: empty index yields zero totals", () => {
 
 test("aggregateRuns: run with no terminal event counts toward total + byTool but not byReason", () => {
     const root = mkTmp();
-    writeRun(root, "ralph_loop-1", "ralph_loop", [
-        { type: "armed", ts: 1, runId: "ralph_loop-1", label: "ralph_loop" },
-        { type: "iteration_start", ts: 2, runId: "ralph_loop-1", iteration: 1 },
-        { type: "iteration_end", ts: 3, runId: "ralph_loop-1", iteration: 1 },
+    writeRun(root, "ap_loop-1", "ap_loop", [
+        { type: "armed", ts: 1, runId: "ap_loop-1", label: "ap_loop" },
+        { type: "iteration_start", ts: 2, runId: "ap_loop-1", iteration: 1 },
+        { type: "iteration_end", ts: 3, runId: "ap_loop-1", iteration: 1 },
     ]);
     const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.equal(r.total, 1);
-    assert.deepEqual(r.byTool, { ralph_loop: 1 });
+    assert.deepEqual(r.byTool, { ap_loop: 1 });
     assert.deepEqual(r.byReason, {});
     assert.equal(r.iters.max, 1);
     assert.equal(r.iters.mean, 1);
@@ -373,10 +373,10 @@ test("aggregateRuns: skips runs whose events.jsonl is missing", () => {
     const root = mkTmp();
     // Index claims a run exists, but no events.jsonl on disk.
     fs.writeFileSync(path.join(root, "index.jsonl"),
-        JSON.stringify({ type: "armed", ts: 1, runId: "ghost-1", label: "ralph_loop" }) + "\n");
+        JSON.stringify({ type: "armed", ts: 1, runId: "ghost-1", label: "ap_loop" }) + "\n");
     const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.equal(r.total, 1);
-    assert.deepEqual(r.byTool, { ralph_loop: 1 });
+    assert.deepEqual(r.byTool, { ap_loop: 1 });
     assert.deepEqual(r.byReason, {});
     assert.equal(r.iters.max, 0);
 });
@@ -385,14 +385,14 @@ test("aggregateRuns: malformed JSONL lines are skipped silently", () => {
     const root = mkTmp();
     fs.mkdirSync(path.join(root, "rl-1"), { recursive: true });
     fs.writeFileSync(path.join(root, "rl-1", "events.jsonl"), [
-        JSON.stringify({ type: "armed", ts: 1, runId: "rl-1", label: "ralph_loop" }),
+        JSON.stringify({ type: "armed", ts: 1, runId: "rl-1", label: "ap_loop" }),
         "{not-json",
         "",
         JSON.stringify({ type: "iteration_end", ts: 2, runId: "rl-1", iteration: 4 }),
         JSON.stringify({ type: "complete", ts: 3, runId: "rl-1", reason: "completion_promise", iteration: 4 }),
     ].join("\n") + "\n");
     fs.writeFileSync(path.join(root, "index.jsonl"),
-        JSON.stringify({ type: "armed", ts: 1, runId: "rl-1", label: "ralph_loop" }) + "\n");
+        JSON.stringify({ type: "armed", ts: 1, runId: "rl-1", label: "ap_loop" }) + "\n");
     const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.equal(r.total, 1);
     assert.deepEqual(r.byReason, { "complete:completion_promise": 1 });
@@ -401,8 +401,8 @@ test("aggregateRuns: malformed JSONL lines are skipped silently", () => {
 
 test("aggregateRuns: terminal event without reason buckets under bare type", () => {
     const root = mkTmp();
-    writeRun(root, "rl-2", "ralph_loop", [
-        { type: "armed", ts: 1, runId: "rl-2", label: "ralph_loop" },
+    writeRun(root, "rl-2", "ap_loop", [
+        { type: "armed", ts: 1, runId: "rl-2", label: "ap_loop" },
         { type: "abort", ts: 2, runId: "rl-2", iteration: 2 },
     ]);
     const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
@@ -411,12 +411,12 @@ test("aggregateRuns: terminal event without reason buckets under bare type", () 
 
 test("aggregateRuns: mean is arithmetic over runs with iterations", () => {
     const root = mkTmp();
-    writeRun(root, "a-1", "ralph_loop", [
-        { type: "armed", ts: 1, runId: "a-1", label: "ralph_loop" },
+    writeRun(root, "a-1", "ap_loop", [
+        { type: "armed", ts: 1, runId: "a-1", label: "ap_loop" },
         { type: "complete", ts: 2, runId: "a-1", reason: "completion_promise", iteration: 2 },
     ]);
-    writeRun(root, "a-2", "ralph_loop", [
-        { type: "armed", ts: 3, runId: "a-2", label: "ralph_loop" },
+    writeRun(root, "a-2", "ap_loop", [
+        { type: "armed", ts: 3, runId: "a-2", label: "ap_loop" },
         { type: "complete", ts: 4, runId: "a-2", reason: "completion_promise", iteration: 8 },
     ]);
     const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
@@ -431,11 +431,11 @@ test("aggregateRuns: handles >150k recorded runs without blowing the call stack"
     // call stack size exceeded" once iterCounts crosses Node's
     // argument-count limit (~150k on V8). A long-lived user with
     // daily self_improve runs would eventually hit that ceiling and
-    // `ralph-tui stats` would crash silently. We pump 200_001
+    // `autopilot stats` would crash silently. We pump 200_001
     // synthetic entries through aggregateRuns via an in-memory fs
     // stub and assert it returns the expected aggregates.
     const N = 200_001;
-    const armedLine = '{"type":"armed","runId":"r","label":"ralph_loop"}';
+    const armedLine = '{"type":"armed","runId":"r","label":"ap_loop"}';
     const completeLine = '{"type":"complete","runId":"r","reason":"completion_promise","iteration":42}';
     const indexContent = (armedLine + "\n").repeat(N);
     const eventsContent = completeLine + "\n";
@@ -452,7 +452,7 @@ test("aggregateRuns: handles >150k recorded runs without blowing the call stack"
     assert.equal(r.total, N);
     assert.equal(r.iters.max, 42);
     assert.equal(r.iters.mean, 42);
-    assert.equal(r.byTool.ralph_loop, N);
+    assert.equal(r.byTool.ap_loop, N);
 });
 
 test("pruneRuns: refuses to delete entries whose runId contains traversal segments", () => {
@@ -463,7 +463,7 @@ test("pruneRuns: refuses to delete entries whose runId contains traversal segmen
     // path.join. The hostile sibling directory is a sentinel we set
     // up OUTSIDE the runs root and assert is still present after the
     // prune.
-    const sentinel = fs.mkdtempSync(path.join(os.tmpdir(), "ralph-tui-sentinel-"));
+    const sentinel = fs.mkdtempSync(path.join(os.tmpdir(), "autopilot-sentinel-"));
     const sentinelMarker = path.join(sentinel, "do-not-delete.txt");
     fs.writeFileSync(sentinelMarker, "keep me\n");
     const goodId = "good-run-id";
@@ -571,7 +571,7 @@ test("createEventWriter: rejects path-traversal runIds (sandbox-escape guard)", 
         { runId: "a\\b", label: "embedded backslash" },
         { runId: ".", label: "current-dir literal" },
         { runId: "..", label: "parent-dir literal" },
-        { runId: "ralph_loop-1/../etc", label: "valid prefix + traversal" },
+        { runId: "ap_loop-1/../etc", label: "valid prefix + traversal" },
         { runId: "with\0null", label: "null byte" },
     ];
     for (const { runId, label } of cases) {
@@ -587,7 +587,7 @@ test("createEventWriter: rejects path-traversal runIds (sandbox-escape guard)", 
     const tmp = mkTmp();
     try {
         const w = createEventWriter({
-            runId: "ralph_loop-deadbeef",
+            runId: "ap_loop-deadbeef",
             env: { AUTOPILOT_EVENTS_DIR: tmp },
         });
         assert.equal(typeof w.emit, "function", "legitimate runIds must still construct successfully");
@@ -640,14 +640,14 @@ test("aggregateRuns: hand-edited iteration=Infinity (1e500) row is skipped, not 
     // but a hand-edited or corrupted events.jsonl row CAN reach
     // aggregateRuns through `readEventsFile`; the function is best-effort
     // and must not let a single malformed row poison the whole stats
-    // output for `ralph-tui stats`.
+    // output for `autopilot stats`.
     const root = mkTmp();
     fs.mkdirSync(path.join(root, "evil-1"), { recursive: true });
     // Hand-write the events.jsonl directly (writeRun would JSON.stringify
     // and lose the literal). The sane-row + crazy-row combination pins
     // that the OTHER row's iteration (a finite 4) wins.
     const lines = [
-        JSON.stringify({ type: "armed", ts: 1, runId: "evil-1", label: "ralph_loop" }),
+        JSON.stringify({ type: "armed", ts: 1, runId: "evil-1", label: "ap_loop" }),
         JSON.stringify({ type: "iteration_end", ts: 2, runId: "evil-1", iteration: 4 }),
         // Hand-injected literal — Number.MAX_VALUE * 2 → Infinity in JS.
         '{"type": "iteration_end", "ts": 3, "runId": "evil-1", "iteration": 1e500}',
@@ -655,7 +655,7 @@ test("aggregateRuns: hand-edited iteration=Infinity (1e500) row is skipped, not 
     ];
     fs.writeFileSync(path.join(root, "evil-1", "events.jsonl"), lines.join("\n") + "\n");
     fs.writeFileSync(path.join(root, "index.jsonl"),
-        JSON.stringify({ type: "armed", ts: 1, runId: "evil-1", label: "ralph_loop" }) + "\n");
+        JSON.stringify({ type: "armed", ts: 1, runId: "evil-1", label: "ap_loop" }) + "\n");
     const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.equal(Number.isFinite(r.iters.max), true,
         "iters.max must stay finite even with a hand-edited 1e500 iteration row");
@@ -677,7 +677,7 @@ test("pruneRuns: hand-edited empty-runId row does NOT delete the runs root (data
     // every legitimately-recorded run's events.jsonl. The writer never
     // emits an empty runId (`makeRunId` requires a non-empty label),
     // but a hand-edited or corrupted index.jsonl CAN. This is a true
-    // data-loss bug, not a theoretical one — `ralph-tui prune
+    // data-loss bug, not a theoretical one — `autopilot prune
     // --older-than 0d` against a corrupted index would silently
     // destroy a contributor's entire run history. The fix added an
     // `obj.runId.length > 0` clause to the centralised
@@ -691,11 +691,11 @@ test("pruneRuns: hand-edited empty-runId row does NOT delete the runs root (data
     const aliveTs = Date.now() + 60_000;
     fs.mkdirSync(path.join(root, "alive-1"), { recursive: true });
     fs.writeFileSync(path.join(root, "alive-1", "events.jsonl"),
-        JSON.stringify({ type: "armed", ts: aliveTs, runId: "alive-1", label: "ralph_loop" }) + "\n");
+        JSON.stringify({ type: "armed", ts: aliveTs, runId: "alive-1", label: "ap_loop" }) + "\n");
     // The DANGEROUS hand-edited row: empty runId, ts deep in the past.
     fs.writeFileSync(path.join(root, "index.jsonl"),
-        JSON.stringify({ type: "armed", ts: aliveTs, runId: "alive-1", label: "ralph_loop" }) + "\n"
-        + JSON.stringify({ type: "armed", ts: 1, runId: "", label: "ralph_loop" }) + "\n");
+        JSON.stringify({ type: "armed", ts: aliveTs, runId: "alive-1", label: "ap_loop" }) + "\n"
+        + JSON.stringify({ type: "armed", ts: 1, runId: "", label: "ap_loop" }) + "\n");
     // A canary file at the runs root: if pruneRuns wipes the root, the
     // canary disappears and the assertion below fires red.
     const canary = path.join(root, "canary.txt");
@@ -734,16 +734,16 @@ test("readRunIndex: empty-runId / missing-runId / non-string-runId rows are skip
     fs.mkdirSync(root, { recursive: true });
     fs.writeFileSync(indexPath, [
         // Empty-string runId: rejected by `obj.runId.length > 0`.
-        JSON.stringify({ type: "armed", ts: 1, runId: "", label: "ralph_loop" }),
+        JSON.stringify({ type: "armed", ts: 1, runId: "", label: "ap_loop" }),
         // Missing runId entirely: rejected by `typeof obj.runId === "string"`.
-        JSON.stringify({ type: "armed", ts: 2, label: "ralph_loop" }),
+        JSON.stringify({ type: "armed", ts: 2, label: "ap_loop" }),
         // Non-string runId (number): rejected by typeof check.
-        JSON.stringify({ type: "armed", ts: 3, runId: 42, label: "ralph_loop" }),
+        JSON.stringify({ type: "armed", ts: 3, runId: 42, label: "ap_loop" }),
         // Null runId: rejected by typeof check (typeof null === "object").
-        JSON.stringify({ type: "armed", ts: 4, runId: null, label: "ralph_loop" }),
+        JSON.stringify({ type: "armed", ts: 4, runId: null, label: "ap_loop" }),
         // The one legitimate row — must survive to prove the filter
         // isn't accidentally rejecting valid input.
-        JSON.stringify({ type: "armed", ts: 5, runId: "real-1", label: "ralph_loop" }),
+        JSON.stringify({ type: "armed", ts: 5, runId: "real-1", label: "ap_loop" }),
     ].join("\n") + "\n");
     const entries = readRunIndex({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.equal(entries.length, 1, "only the legitimate row should survive (4 invalid shapes rejected)");
@@ -764,14 +764,14 @@ test("pruneRuns: hand-edited ts=-Infinity row does NOT prematurely delete the ru
     // class of bug on the index.jsonl side.
     const root = mkTmp();
     const indexPath = path.join(root, "index.jsonl");
-    const liveRunId = "ralph_loop-1700000000000";
+    const liveRunId = "ap_loop-1700000000000";
     const liveRunDir = path.join(root, liveRunId);
     fs.mkdirSync(liveRunDir, { recursive: true });
     fs.writeFileSync(path.join(liveRunDir, "events.jsonl"), "{}\n", "utf8");
     // Forge a row whose ts JSON.parses to -Infinity. We cannot just
     // use the literal `-1e500` — JSON.stringify would emit "null".
     // Construct the line by hand to mimic a corrupted writer dump.
-    const corruptedRow = '{"type":"armed","runId":"' + liveRunId + '","label":"ralph_loop","startedAt":1700000000000,"ts":-1e500}\n';
+    const corruptedRow = '{"type":"armed","runId":"' + liveRunId + '","label":"ap_loop","startedAt":1700000000000,"ts":-1e500}\n';
     fs.writeFileSync(indexPath, corruptedRow, "utf8");
     // Sanity check: parsing this row indeed yields -Infinity (so the
     // bug it pins is the actually-reachable one, not theoretical).

--- a/packages/tui/test/writer.test.mjs
+++ b/packages/tui/test/writer.test.mjs
@@ -26,17 +26,127 @@ function readLines(filePath) {
         .map((l) => JSON.parse(l));
 }
 
-test("resolveRunsRoot honours $RALPH_EVENTS_DIR", () => {
-    assert.equal(resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/tmp/x" } }), "/tmp/x");
+// Stage 3 (issue #49): writer.mjs's resolveRunsRoot now performs
+// sentinel-gated stderr deprecation notices when legacy
+// $AUTOPILOT_EVENTS_DIR or the legacy ~/.copilot/ralph/runs default
+// path is used. Tests inject a fake fs (which has no sentinel and
+// accepts mkdir/append silently) and a fake stderr (capturing
+// writes into an array). The sentinelPath points at a fake
+// location so deprecation writes never touch the real ~/.copilot.
+function makeFakeFs({ sentinel = "", existingPaths = new Set() } = {}) {
+    let written = "";
+    const fake = {
+        readFileSync: (p) => {
+            if (p === fake._sentinelPath) return sentinel + written;
+            const e = new Error("ENOENT");
+            e.code = "ENOENT";
+            throw e;
+        },
+        appendFileSync: (p, data) => {
+            if (p === fake._sentinelPath) written += data;
+        },
+        mkdirSync: () => {},
+        existsSync: (p) => existingPaths.has(p),
+    };
+    fake._sentinelPath = "/fake/sentinel";
+    fake.writtenSentinel = () => written;
+    return fake;
+}
+
+function makeFakeStderr() {
+    const messages = [];
+    return {
+        write: (m) => { messages.push(String(m)); },
+        messages,
+    };
+}
+
+test("resolveRunsRoot honours $AUTOPILOT_EVENTS_DIR (primary)", () => {
+    assert.equal(resolveRunsRoot({ env: { AUTOPILOT_EVENTS_DIR: "/tmp/x" } }), "/tmp/x");
 });
 
-test("resolveRunsRoot defaults to $HOME/.copilot/ralph/runs", () => {
+test("resolveRunsRoot honours $RALPH_EVENTS_DIR (legacy, with notice)", () => {
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/tmp/x" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        "/tmp/x",
+    );
+    assert.equal(stderr.messages.length, 1);
+    assert.match(stderr.messages[0], /RALPH_EVENTS_DIR is deprecated/);
+});
+
+test("resolveRunsRoot defaults to $HOME/.copilot/autopilot/events", () => {
     const fakeOs = { homedir: () => "/h" };
-    assert.equal(resolveRunsRoot({ env: {}, os: fakeOs }), "/h/.copilot/ralph/runs");
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveRunsRoot({ env: {}, os: fakeOs, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        "/h/.copilot/autopilot/events",
+    );
+    assert.equal(stderr.messages.length, 0);
+});
+
+test("resolveRunsRoot: AUTOPILOT primary wins over RALPH legacy (no notice)", () => {
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveRunsRoot({
+            env: { AUTOPILOT_EVENTS_DIR: "/ap", RALPH_EVENTS_DIR: "/legacy" },
+            fs, stderr, sentinelPath: "/fake/sentinel",
+        }),
+        "/ap",
+    );
+    assert.equal(stderr.messages.length, 0);
+});
+
+test("resolveRunsRoot: legacy default path is honoured with deprecation notice", () => {
+    const fakeOs = { homedir: () => "/h" };
+    const legacyDefault = "/h/.copilot/ralph/runs";
+    const fs = makeFakeFs({ existingPaths: new Set([legacyDefault]) });
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveRunsRoot({ env: {}, os: fakeOs, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        legacyDefault,
+    );
+    assert.equal(stderr.messages.length, 1);
+    assert.match(stderr.messages[0], /reading from legacy/);
+});
+
+test("resolveRunsRoot: when both default paths exist, primary wins (no notice)", () => {
+    const fakeOs = { homedir: () => "/h" };
+    const fs = makeFakeFs({ existingPaths: new Set(["/h/.copilot/autopilot/events", "/h/.copilot/ralph/runs"]) });
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveRunsRoot({ env: {}, os: fakeOs, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        "/h/.copilot/autopilot/events",
+    );
+    assert.equal(stderr.messages.length, 0);
+});
+
+test("resolveRunsRoot: deprecation notice is one-shot per process (sentinel-gated)", () => {
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    const sentinelPath = "/fake/sentinel";
+    resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/x" }, fs, stderr, sentinelPath });
+    resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/x" }, fs, stderr, sentinelPath });
+    resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/x" }, fs, stderr, sentinelPath });
+    assert.equal(stderr.messages.length, 1);
+    assert.match(fs.writtenSentinel(), /RALPH_EVENTS_DIR/);
+});
+
+test("resolveRunsRoot: pre-existing sentinel suppresses the notice", () => {
+    const fs = makeFakeFs({ sentinel: "env:RALPH_EVENTS_DIR\n" });
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/tmp/x" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        "/tmp/x",
+    );
+    assert.equal(stderr.messages.length, 0);
 });
 
 test("resolveRunEventsPath joins runId under the runs root", () => {
-    const p = resolveRunEventsPath("ralph_loop-1", { env: { RALPH_EVENTS_DIR: "/tmp/r" } });
+    const p = resolveRunEventsPath("ralph_loop-1", { env: { AUTOPILOT_EVENTS_DIR: "/tmp/r" } });
     assert.equal(p, "/tmp/r/ralph_loop-1/events.jsonl");
 });
 
@@ -45,7 +155,7 @@ test("resolveRunEventsPath rejects empty runId", () => {
 });
 
 test("resolveRunEventsPath rejects path-traversal runIds", () => {
-    const env = { RALPH_EVENTS_DIR: "/tmp/r" };
+    const env = { AUTOPILOT_EVENTS_DIR: "/tmp/r" };
     for (const bad of ["..", ".", "../etc", "foo/../bar", "foo/bar", "foo\\bar", "..\\etc", "foo\0bar"]) {
         assert.throws(
             () => resolveRunEventsPath(bad, { env }),
@@ -56,7 +166,7 @@ test("resolveRunEventsPath rejects path-traversal runIds", () => {
 });
 
 test("resolveRunEventsPath accepts legitimately-shaped runIds", () => {
-    const env = { RALPH_EVENTS_DIR: "/tmp/r" };
+    const env = { AUTOPILOT_EVENTS_DIR: "/tmp/r" };
     // Emitter-produced shape: [A-Za-z0-9_-]+
     for (const ok of ["ralph_loop-1", "self_improve-1700000000000", "grow_project-42", "a-b_c-1"]) {
         assert.doesNotThrow(() => resolveRunEventsPath(ok, { env }));
@@ -69,7 +179,7 @@ test("createEventWriter: emits a valid armed line and creates the run dir", () =
     const w = createEventWriter({
         runId,
         label: "ralph_loop",
-        env: { RALPH_EVENTS_DIR: root },
+        env: { AUTOPILOT_EVENTS_DIR: root },
         now: () => 1700000000000,
     });
     w.emit({ type: "armed", maxIterations: 20, minIterations: 5 });
@@ -87,7 +197,7 @@ test("createEventWriter: index.jsonl gains a row only on armed events", () => {
     const w = createEventWriter({
         runId: "self_improve-2",
         label: "self_improve",
-        env: { RALPH_EVENTS_DIR: root },
+        env: { AUTOPILOT_EVENTS_DIR: root },
         now: () => 2,
     });
     w.emit({ type: "armed" });
@@ -104,7 +214,7 @@ test("createEventWriter: ts is auto-filled from injected clock when caller omits
     const ticks = [10, 20, 30];
     const w = createEventWriter({
         runId: "r-ts",
-        env: { RALPH_EVENTS_DIR: root },
+        env: { AUTOPILOT_EVENTS_DIR: root },
         now: () => ticks.shift(),
     });
     w.emit({ type: "armed" });
@@ -118,7 +228,7 @@ test("createEventWriter: caller-provided ts is preserved", () => {
     const root = mkTmp();
     const w = createEventWriter({
         runId: "r-ts2",
-        env: { RALPH_EVENTS_DIR: root },
+        env: { AUTOPILOT_EVENTS_DIR: root },
         now: () => 999,
     });
     w.emit({ type: "armed", ts: 1234 });
@@ -131,7 +241,7 @@ test("createEventWriter: serializer failures route through onError, not throw", 
     const errs = [];
     const w = createEventWriter({
         runId: "r-bad",
-        env: { RALPH_EVENTS_DIR: root },
+        env: { AUTOPILOT_EVENTS_DIR: root },
         now: () => 1,
         onError: (e) => errs.push(e),
     });
@@ -146,7 +256,7 @@ test("createEventWriter: close() makes subsequent emits no-ops", () => {
     const root = mkTmp();
     const w = createEventWriter({
         runId: "r-close",
-        env: { RALPH_EVENTS_DIR: root },
+        env: { AUTOPILOT_EVENTS_DIR: root },
         now: () => 1,
     });
     w.emit({ type: "armed" });
@@ -162,7 +272,7 @@ test("createEventWriter: rejects non-object events through onError (no throw)", 
     const errs = [];
     const w = createEventWriter({
         runId: "r-nono",
-        env: { RALPH_EVENTS_DIR: root },
+        env: { AUTOPILOT_EVENTS_DIR: root },
         onError: (e) => errs.push(e),
     });
     w.emit("oops");
@@ -172,7 +282,7 @@ test("createEventWriter: rejects non-object events through onError (no throw)", 
 
 test("createEventWriter: armed getter flips after first armed emit", () => {
     const root = mkTmp();
-    const w = createEventWriter({ runId: "r-armed", env: { RALPH_EVENTS_DIR: root } });
+    const w = createEventWriter({ runId: "r-armed", env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.equal(w.armed, false);
     w.emit({ type: "armed" });
     assert.equal(w.armed, true);
@@ -180,18 +290,18 @@ test("createEventWriter: armed getter flips after first armed emit", () => {
 
 test("readRunIndex: empty when index.jsonl is missing", () => {
     const root = mkTmp();
-    assert.deepEqual(readRunIndex({ env: { RALPH_EVENTS_DIR: root } }), []);
+    assert.deepEqual(readRunIndex({ env: { AUTOPILOT_EVENTS_DIR: root } }), []);
 });
 
 test("readRunIndex: returns entries newest-first", () => {
     const root = mkTmp();
-    const w1 = createEventWriter({ runId: "r-1", label: "ralph_loop", env: { RALPH_EVENTS_DIR: root }, now: () => 100 });
+    const w1 = createEventWriter({ runId: "r-1", label: "ralph_loop", env: { AUTOPILOT_EVENTS_DIR: root }, now: () => 100 });
     w1.emit({ type: "armed" });
-    const w2 = createEventWriter({ runId: "r-2", label: "self_improve", env: { RALPH_EVENTS_DIR: root }, now: () => 200 });
+    const w2 = createEventWriter({ runId: "r-2", label: "self_improve", env: { AUTOPILOT_EVENTS_DIR: root }, now: () => 200 });
     w2.emit({ type: "armed" });
-    const w3 = createEventWriter({ runId: "r-3", label: "grow_project", env: { RALPH_EVENTS_DIR: root }, now: () => 300 });
+    const w3 = createEventWriter({ runId: "r-3", label: "grow_project", env: { AUTOPILOT_EVENTS_DIR: root }, now: () => 300 });
     w3.emit({ type: "armed" });
-    const entries = readRunIndex({ env: { RALPH_EVENTS_DIR: root } });
+    const entries = readRunIndex({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.deepEqual(entries.map((e) => e.runId), ["r-3", "r-2", "r-1"]);
     assert.equal(entries[0].label, "grow_project");
 });
@@ -207,7 +317,7 @@ test("readRunIndex: skips malformed lines, keeps good ones", () => {
         JSON.stringify({ type: "weird", ts: 2, runId: "skip" }),
         JSON.stringify({ type: "armed", ts: 3, runId: "ok-2", label: "ralph_loop" }),
     ].join("\n") + "\n");
-    const entries = readRunIndex({ env: { RALPH_EVENTS_DIR: root } });
+    const entries = readRunIndex({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.deepEqual(entries.map((e) => e.runId), ["ok-2", "ok-1"]);
 });
 
@@ -222,7 +332,7 @@ function writeRun(root, runId, label, lines) {
 
 test("aggregateRuns: empty index yields zero totals", () => {
     const root = mkTmp();
-    const r = aggregateRuns({ env: { RALPH_EVENTS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.equal(r.total, 0);
     assert.deepEqual(r.byTool, {});
     assert.deepEqual(r.byReason, {});
@@ -237,7 +347,7 @@ test("aggregateRuns: run with no terminal event counts toward total + byTool but
         { type: "iteration_start", ts: 2, runId: "ralph_loop-1", iteration: 1 },
         { type: "iteration_end", ts: 3, runId: "ralph_loop-1", iteration: 1 },
     ]);
-    const r = aggregateRuns({ env: { RALPH_EVENTS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.equal(r.total, 1);
     assert.deepEqual(r.byTool, { ralph_loop: 1 });
     assert.deepEqual(r.byReason, {});
@@ -254,7 +364,7 @@ test("aggregateRuns: last terminal event wins when multiple are present", () => 
         { type: "abort", ts: 2, runId: "self_improve-1", reason: "stagnation", iteration: 3 },
         { type: "complete", ts: 3, runId: "self_improve-1", reason: "completion_promise", iteration: 5 },
     ]);
-    const r = aggregateRuns({ env: { RALPH_EVENTS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.deepEqual(r.byReason, { "complete:completion_promise": 1 });
     assert.equal(r.iters.max, 5);
 });
@@ -264,7 +374,7 @@ test("aggregateRuns: skips runs whose events.jsonl is missing", () => {
     // Index claims a run exists, but no events.jsonl on disk.
     fs.writeFileSync(path.join(root, "index.jsonl"),
         JSON.stringify({ type: "armed", ts: 1, runId: "ghost-1", label: "ralph_loop" }) + "\n");
-    const r = aggregateRuns({ env: { RALPH_EVENTS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.equal(r.total, 1);
     assert.deepEqual(r.byTool, { ralph_loop: 1 });
     assert.deepEqual(r.byReason, {});
@@ -283,7 +393,7 @@ test("aggregateRuns: malformed JSONL lines are skipped silently", () => {
     ].join("\n") + "\n");
     fs.writeFileSync(path.join(root, "index.jsonl"),
         JSON.stringify({ type: "armed", ts: 1, runId: "rl-1", label: "ralph_loop" }) + "\n");
-    const r = aggregateRuns({ env: { RALPH_EVENTS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.equal(r.total, 1);
     assert.deepEqual(r.byReason, { "complete:completion_promise": 1 });
     assert.equal(r.iters.max, 4);
@@ -295,7 +405,7 @@ test("aggregateRuns: terminal event without reason buckets under bare type", () 
         { type: "armed", ts: 1, runId: "rl-2", label: "ralph_loop" },
         { type: "abort", ts: 2, runId: "rl-2", iteration: 2 },
     ]);
-    const r = aggregateRuns({ env: { RALPH_EVENTS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.deepEqual(r.byReason, { abort: 1 });
 });
 
@@ -309,7 +419,7 @@ test("aggregateRuns: mean is arithmetic over runs with iterations", () => {
         { type: "armed", ts: 3, runId: "a-2", label: "ralph_loop" },
         { type: "complete", ts: 4, runId: "a-2", reason: "completion_promise", iteration: 8 },
     ]);
-    const r = aggregateRuns({ env: { RALPH_EVENTS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.equal(r.total, 2);
     assert.equal(r.iters.max, 8);
     assert.equal(r.iters.mean, 5);
@@ -337,7 +447,7 @@ test("aggregateRuns: handles >150k recorded runs without blowing the call stack"
     };
     const r = aggregateRuns({
         fs: fakeFs,
-        env: { RALPH_EVENTS_DIR: "/fake" },
+        env: { AUTOPILOT_EVENTS_DIR: "/fake" },
     });
     assert.equal(r.total, N);
     assert.equal(r.iters.max, 42);
@@ -368,7 +478,7 @@ test("pruneRuns: refuses to delete entries whose runId contains traversal segmen
     const result = pruneRuns({
         olderThanMs: 10,
         now: () => 10_000,
-        env: { RALPH_EVENTS_DIR: root },
+        env: { AUTOPILOT_EVENTS_DIR: root },
     });
     // Only the legitimate run was removed.
     assert.deepEqual(result.removed.map((r) => r.runId), [goodId]);
@@ -400,7 +510,7 @@ test("pruneRuns: deletes only the per-run dir, leaves index for fresh runs", () 
     const result = pruneRuns({
         olderThanMs: 1_000,
         now: () => 10_000,
-        env: { RALPH_EVENTS_DIR: root },
+        env: { AUTOPILOT_EVENTS_DIR: root },
     });
     assert.equal(result.removed.length, 1);
     assert.equal(result.removed[0].runId, oldId);
@@ -423,7 +533,7 @@ test("pruneRuns: dryRun never touches the filesystem", () => {
         olderThanMs: 1,
         dryRun: true,
         now: () => 10_000,
-        env: { RALPH_EVENTS_DIR: root },
+        env: { AUTOPILOT_EVENTS_DIR: root },
     });
     assert.equal(result.removed.length, 1);
     assert.ok(fs.existsSync(path.join(root, oldId)), "dryRun must not delete");
@@ -440,7 +550,7 @@ test("pruneRuns: missing index.jsonl returns empty result", () => {
     const root = mkTmp();
     const result = pruneRuns({
         olderThanMs: 1,
-        env: { RALPH_EVENTS_DIR: root },
+        env: { AUTOPILOT_EVENTS_DIR: root },
     });
     assert.deepEqual(result, { removed: [], kept: 0 });
 });
@@ -466,7 +576,7 @@ test("createEventWriter: rejects path-traversal runIds (sandbox-escape guard)", 
     ];
     for (const { runId, label } of cases) {
         assert.throws(
-            () => createEventWriter({ runId, env: { RALPH_EVENTS_DIR: "/tmp/ralph-test-traversal" } }),
+            () => createEventWriter({ runId, env: { AUTOPILOT_EVENTS_DIR: "/tmp/ralph-test-traversal" } }),
             (err) => err instanceof TypeError && /path separators or traversal segments/.test(err.message),
             `runId ${JSON.stringify(runId)} (${label}) must throw a TypeError before any fs work`,
         );
@@ -478,7 +588,7 @@ test("createEventWriter: rejects path-traversal runIds (sandbox-escape guard)", 
     try {
         const w = createEventWriter({
             runId: "ralph_loop-deadbeef",
-            env: { RALPH_EVENTS_DIR: tmp },
+            env: { AUTOPILOT_EVENTS_DIR: tmp },
         });
         assert.equal(typeof w.emit, "function", "legitimate runIds must still construct successfully");
         w.close();
@@ -506,7 +616,7 @@ test("traversal-guard error message prefixes the calling function name (assertSa
         "resolveRunEventsPath must prefix its own name in the traversal-guard TypeError",
     );
     assert.throws(
-        () => createEventWriter({ runId: "../etc", env: { RALPH_EVENTS_DIR: "/tmp/ralph-test-traversal-prefix" } }),
+        () => createEventWriter({ runId: "../etc", env: { AUTOPILOT_EVENTS_DIR: "/tmp/ralph-test-traversal-prefix" } }),
         (err) => err instanceof TypeError
             && err.message.startsWith("createEventWriter:")
             && /path separators or traversal segments/.test(err.message),
@@ -546,7 +656,7 @@ test("aggregateRuns: hand-edited iteration=Infinity (1e500) row is skipped, not 
     fs.writeFileSync(path.join(root, "evil-1", "events.jsonl"), lines.join("\n") + "\n");
     fs.writeFileSync(path.join(root, "index.jsonl"),
         JSON.stringify({ type: "armed", ts: 1, runId: "evil-1", label: "ralph_loop" }) + "\n");
-    const r = aggregateRuns({ env: { RALPH_EVENTS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.equal(Number.isFinite(r.iters.max), true,
         "iters.max must stay finite even with a hand-edited 1e500 iteration row");
     assert.equal(Number.isFinite(r.iters.mean), true,
@@ -591,7 +701,7 @@ test("pruneRuns: hand-edited empty-runId row does NOT delete the runs root (data
     const canary = path.join(root, "canary.txt");
     fs.writeFileSync(canary, "do-not-delete");
 
-    pruneRuns({ olderThanMs: 0, env: { RALPH_EVENTS_DIR: root } });
+    pruneRuns({ olderThanMs: 0, env: { AUTOPILOT_EVENTS_DIR: root } });
 
     assert.equal(fs.existsSync(root), true, "runs root must NOT be deleted by an empty-runId row");
     assert.equal(fs.existsSync(canary), true, "sibling files at runs root must NOT be deleted by an empty-runId row");
@@ -635,7 +745,7 @@ test("readRunIndex: empty-runId / missing-runId / non-string-runId rows are skip
         // isn't accidentally rejecting valid input.
         JSON.stringify({ type: "armed", ts: 5, runId: "real-1", label: "ralph_loop" }),
     ].join("\n") + "\n");
-    const entries = readRunIndex({ env: { RALPH_EVENTS_DIR: root } });
+    const entries = readRunIndex({ env: { AUTOPILOT_EVENTS_DIR: root } });
     assert.equal(entries.length, 1, "only the legitimate row should survive (4 invalid shapes rejected)");
     assert.equal(entries[0].runId, "real-1", "the surviving row must be the one with the non-empty string runId");
 });
@@ -668,7 +778,7 @@ test("pruneRuns: hand-edited ts=-Infinity row does NOT prematurely delete the ru
     const parsed = JSON.parse(corruptedRow);
     assert.equal(parsed.ts, -Infinity, "JSON.parse of the literal -1e500 must materialise as -Infinity");
 
-    const result = pruneRuns({ olderThanMs: 1, now: () => Date.now(), env: { RALPH_EVENTS_DIR: root } });
+    const result = pruneRuns({ olderThanMs: 1, now: () => Date.now(), env: { AUTOPILOT_EVENTS_DIR: root } });
 
     assert.equal(result.removed.length, 0, "ts=-Infinity row must NOT be marked for removal — finite-ts guard");
     assert.equal(fs.existsSync(liveRunDir), true, "the legitimate run dir must survive a corrupted-ts row in the index");

--- a/scripts/autopilot-fresh.sh
+++ b/scripts/autopilot-fresh.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# scripts/autopilot-fresh.sh — wrapper for `node packages/tui/bin/tui.mjs`
+# that runs `git pull --quiet --ff-only` from the repo root immediately
+# before an `autopilot run` invocation, so each long-haul out-of-session
+# loop starts on the latest source.
+#
+# Why this is safe:
+#   * `autopilot run` runs OUT-OF-SESSION — each iter is a fresh
+#     `copilot -p ...` subprocess. The TUI binary itself is loaded
+#     into memory once at Node startup, so a `git pull` immediately
+#     before `exec node …/tui.mjs` lands the new source on disk
+#     before Node imports the module graph. No self-overwrite race.
+#   * Mid-loop version skew is impossible: Node imports the module
+#     graph at process start, so a `git pull` running concurrently
+#     with the loop CANNOT change the running iter's behaviour.
+#
+# Why only `run` upgrades:
+#   The other subcommands (`list`, `replay`, `watch`, `doctor`,
+#   `prune`, `stats`, `where`) are millisecond-fast read ops on
+#   local files. Adding a `git pull` to those would make `list`
+#   feel laggy for no behavioural benefit.
+#
+# Why failures are silent:
+#   No network, dirty working tree, non-fast-forward, or detached
+#   HEAD all silently fall through to the existing checked-out
+#   code (`|| true`). The wrapper never blocks a run on git issues.
+#   `--ff-only` deliberately refuses to clobber local work-in-progress.
+#
+# Usage:
+#   alias autopilot="$PWD/scripts/autopilot-fresh.sh"   # in ~/.zshrc
+#   autopilot run --self-improve --continue
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Subshell isolates `cd`: the parent shell stays in the user's cwd so
+# `exec node` below preserves it (the TUI's `run` subcommand spawns
+# `copilot -p` subprocesses that inherit cwd from the user, NOT this
+# wrapper's repo root).
+if [[ "${1:-}" == "run" ]]; then
+    ( cd "$ROOT" && git pull --quiet --ff-only ) 2>/dev/null || true
+fi
+
+exec node "$ROOT/packages/tui/bin/tui.mjs" "$@"

--- a/scripts/ralph-tui-fresh.sh
+++ b/scripts/ralph-tui-fresh.sh
@@ -1,45 +1,5 @@
 #!/usr/bin/env bash
-# scripts/ralph-tui-fresh.sh — wrapper for `node packages/tui/bin/tui.mjs`
-# that runs `git pull --quiet --ff-only` from the repo root immediately
-# before a `ralph-tui run` invocation, so each long-haul out-of-session
-# loop starts on the latest source.
-#
-# Why this is safe:
-#   * `ralph-tui run` runs OUT-OF-SESSION — each iter is a fresh
-#     `copilot -p ...` subprocess. The TUI binary itself is loaded
-#     into memory once at Node startup, so a `git pull` immediately
-#     before `exec node …/tui.mjs` lands the new source on disk
-#     before Node imports the module graph. No self-overwrite race.
-#   * Mid-loop version skew is impossible: Node imports the module
-#     graph at process start, so a `git pull` running concurrently
-#     with the loop CANNOT change the running iter's behaviour.
-#
-# Why only `run` upgrades:
-#   The other subcommands (`list`, `replay`, `watch`, `doctor`,
-#   `prune`, `stats`, `where`) are millisecond-fast read ops on
-#   local files. Adding a `git pull` to those would make `list`
-#   feel laggy for no behavioural benefit.
-#
-# Why failures are silent:
-#   No network, dirty working tree, non-fast-forward, or detached
-#   HEAD all silently fall through to the existing checked-out
-#   code (`|| true`). The wrapper never blocks a run on git issues.
-#   `--ff-only` deliberately refuses to clobber local work-in-progress.
-#
-# Usage:
-#   alias ralph-tui="$PWD/scripts/ralph-tui-fresh.sh"   # in ~/.zshrc
-#   ralph-tui run --self-improve --continue
-#
-set -euo pipefail
-
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-
-# Subshell isolates `cd`: the parent shell stays in the user's cwd so
-# `exec node` below preserves it (the TUI's `run` subcommand spawns
-# `copilot -p` subprocesses that inherit cwd from the user, NOT this
-# wrapper's repo root).
-if [[ "${1:-}" == "run" ]]; then
-    ( cd "$ROOT" && git pull --quiet --ff-only ) 2>/dev/null || true
-fi
-
-exec node "$ROOT/packages/tui/bin/tui.mjs" "$@"
+# scripts/ralph-tui-fresh.sh — deprecating wrapper for scripts/autopilot-fresh.sh.
+# Will be removed in a future release. See issue #49.
+echo "ralph-tui-fresh.sh is deprecated; use scripts/autopilot-fresh.sh instead." >&2
+exec "$(dirname "$0")/autopilot-fresh.sh" "$@"

--- a/test/events-emit.test.mjs
+++ b/test/events-emit.test.mjs
@@ -36,7 +36,7 @@ test("resolveRunsRoot: tolerates missing env arg", () => {
 });
 
 test("makeRunId: composes ${label}-${startedAt}", () => {
-    assert.equal(makeRunId("ralph_loop", 1700000000000), "ralph_loop-1700000000000");
+    assert.equal(makeRunId("ap_loop", 1700000000000), "ap_loop-1700000000000");
 });
 
 test("makeRunId: sanitises label by replacing every non-[A-Za-z0-9_-] with _", () => {
@@ -44,10 +44,10 @@ test("makeRunId: sanitises label by replacing every non-[A-Za-z0-9_-] with _", (
     assert.equal(makeRunId("a b c", 1), "a_b_c-1");
 });
 
-test("makeRunId: falls back to 'ralph_loop' when label is empty / null / undefined", () => {
-    assert.equal(makeRunId("", 1), "ralph_loop-1");
-    assert.equal(makeRunId(null, 1), "ralph_loop-1");
-    assert.equal(makeRunId(undefined, 1), "ralph_loop-1");
+test("makeRunId: falls back to 'ap_loop' when label is empty / null / undefined", () => {
+    assert.equal(makeRunId("", 1), "ap_loop-1");
+    assert.equal(makeRunId(null, 1), "ap_loop-1");
+    assert.equal(makeRunId(undefined, 1), "ap_loop-1");
 });
 
 test("makeRunId: substitutes Date.now() when startedAt is non-finite", () => {
@@ -59,15 +59,15 @@ test("makeRunId: substitutes Date.now() when startedAt is non-finite", () => {
     // under degraded input.
     const before = Date.now();
     for (const bad of [undefined, null, NaN, Infinity, -Infinity, "1700000000000", {}]) {
-        const id = makeRunId("ralph_loop", bad);
-        const m = /^ralph_loop-(\d+)$/.exec(id);
+        const id = makeRunId("ap_loop", bad);
+        const m = /^ap_loop-(\d+)$/.exec(id);
         assert.ok(m, `expected fallback runId, got ${id} (input: ${String(bad)})`);
         const ts = Number(m[1]);
         assert.ok(ts >= before, `fallback ts must be >= now() snapshot (got ${ts}, before ${before})`);
     }
     // Finite numeric startedAt is preserved verbatim.
-    assert.equal(makeRunId("ralph_loop", 0), "ralph_loop-0");
-    assert.equal(makeRunId("ralph_loop", 1700000000000), "ralph_loop-1700000000000");
+    assert.equal(makeRunId("ap_loop", 0), "ap_loop-0");
+    assert.equal(makeRunId("ap_loop", 1700000000000), "ap_loop-1700000000000");
 });
 
 test("createEventEmitter: write appends one JSONL line per call", () => {
@@ -77,14 +77,14 @@ test("createEventEmitter: write appends one JSONL line per call", () => {
         appendFileSync: (path, line) => lines.push({ path, line }),
     };
     const e = createEventEmitter({
-        label: "ralph_loop",
+        label: "ap_loop",
         startedAt: 1234,
         env: { RALPH_EVENTS_DIR: "/tmp/r" },
         fs: fakeFs,
     });
     e.write({ type: "iteration_start", runId: e.runId, ts: 1, iteration: 1 });
     assert.equal(lines.length, 1);
-    assert.equal(lines[0].path, "/tmp/r/ralph_loop-1234/events.jsonl");
+    assert.equal(lines[0].path, "/tmp/r/ap_loop-1234/events.jsonl");
     assert.equal(JSON.parse(lines[0].line.trimEnd()).type, "iteration_start");
 });
 
@@ -134,15 +134,15 @@ test("createEventEmitter: index entry round-trips through TUI's readRunIndex", a
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "ralph-emit-rt-"));
     try {
         const e = createEventEmitter({
-            label: "ralph_loop",
+            label: "ap_loop",
             startedAt: 12345,
             env: { RALPH_EVENTS_DIR: root },
         });
         e.write({ type: "armed", runId: e.runId, ts: 0, maxIterations: 7, minIterations: 1 });
         const entries = readRunIndex({ env: { RALPH_EVENTS_DIR: root } });
         assert.equal(entries.length, 1, "TUI's readRunIndex must surface the extension-emitted run");
-        assert.equal(entries[0].runId, "ralph_loop-12345");
-        assert.equal(entries[0].label, "ralph_loop");
+        assert.equal(entries[0].runId, "ap_loop-12345");
+        assert.equal(entries[0].label, "ap_loop");
         assert.equal(entries[0].type, "armed");
     } finally {
         fs.rmSync(root, { recursive: true, force: true });
@@ -156,7 +156,7 @@ test("createEventEmitter: non-armed events do NOT touch the index", () => {
         appendFileSync: (path, line) => lines.push({ path, line }),
     };
     const e = createEventEmitter({
-        label: "ralph_loop",
+        label: "ap_loop",
         startedAt: 1,
         env: { RALPH_EVENTS_DIR: "/tmp/r" },
         fs: fakeFs,
@@ -169,7 +169,7 @@ test("createEventEmitter: non-armed events do NOT touch the index", () => {
 test("createEventEmitter: ignores non-object / falsy events instead of writing junk", () => {
     const lines = [];
     const e = createEventEmitter({
-        label: "ralph_loop",
+        label: "ap_loop",
         startedAt: 1,
         env: { RALPH_EVENTS_DIR: "/tmp/r" },
         fs: { mkdirSync: () => {}, appendFileSync: (p, l) => lines.push({ p, l }) },
@@ -184,7 +184,7 @@ test("createEventEmitter: ignores non-object / falsy events instead of writing j
 test("createEventEmitter: long excerpt is clipped to <= 500 chars + trailing ellipsis", () => {
     const captured = [];
     const e = createEventEmitter({
-        label: "ralph_loop",
+        label: "ap_loop",
         startedAt: 1,
         env: { RALPH_EVENTS_DIR: "/tmp/r" },
         fs: {
@@ -202,7 +202,7 @@ test("createEventEmitter: long excerpt is clipped to <= 500 chars + trailing ell
 
 test("createEventEmitter: write swallows mkdir + append errors so the loop never crashes", () => {
     const e = createEventEmitter({
-        label: "ralph_loop",
+        label: "ap_loop",
         startedAt: 1,
         env: { RALPH_EVENTS_DIR: "/tmp/r" },
         fs: {
@@ -218,7 +218,7 @@ test("createEventEmitter: write swallows mkdir + append errors so the loop never
 test("createEventEmitter: mkdir is called once across many writes (memoised)", () => {
     let mkdirCalls = 0;
     const e = createEventEmitter({
-        label: "ralph_loop",
+        label: "ap_loop",
         startedAt: 1,
         env: { RALPH_EVENTS_DIR: "/tmp/r" },
         fs: {
@@ -234,7 +234,7 @@ test("createEventEmitter: mkdir is called once across many writes (memoised)", (
 
 test("createEventEmitter: close() is a no-op safe to call repeatedly", () => {
     const e = createEventEmitter({
-        label: "ralph_loop",
+        label: "ap_loop",
         startedAt: 1,
         env: { RALPH_EVENTS_DIR: "/tmp/r" },
         fs: { mkdirSync: () => {}, appendFileSync: () => {} },
@@ -245,7 +245,7 @@ test("createEventEmitter: close() is a no-op safe to call repeatedly", () => {
 test("createEventEmitter: oversize event line is dropped after stripping excerpt+note (best-effort)", () => {
     const captured = [];
     const e = createEventEmitter({
-        label: "ralph_loop",
+        label: "ap_loop",
         startedAt: 1,
         env: { RALPH_EVENTS_DIR: "/tmp/r" },
         fs: {
@@ -270,7 +270,7 @@ test("createEventEmitter: BigInt / circular ref events are dropped, not thrown",
     // drop the bad event silently and leave the disk untouched.
     const captured = [];
     const e = createEventEmitter({
-        label: "ralph_loop",
+        label: "ap_loop",
         startedAt: 1,
         env: { RALPH_EVENTS_DIR: "/tmp/r" },
         fs: {
@@ -324,7 +324,7 @@ test("resolveRunsRoot: trims surrounding whitespace from RALPH_EVENTS_DIR overri
 test("createEventEmitter: clipExcerpt does not produce lone high surrogates at the truncation boundary", () => {
     const captured = [];
     const e = createEventEmitter({
-        label: "ralph_loop",
+        label: "ap_loop",
         startedAt: 1,
         env: { RALPH_EVENTS_DIR: "/tmp/r" },
         fs: {
@@ -452,7 +452,7 @@ test("createEventEmitter: serialize salvages an oversize event by stripping exce
     // (after stripping excerpt+note) is ~15.7KB (under).
     const captured = [];
     const e = createEventEmitter({
-        label: "ralph_loop",
+        label: "ap_loop",
         startedAt: 1,
         env: { RALPH_EVENTS_DIR: "/tmp/r" },
         fs: {

--- a/test/events-emit.test.mjs
+++ b/test/events-emit.test.mjs
@@ -16,23 +16,162 @@ import {
     createEventEmitter,
 } from "../extension/events-emit.mjs";
 
-test("resolveRunsRoot: defaults to $HOME/.copilot/ralph/runs", () => {
-    assert.equal(resolveRunsRoot({}), join(homedir(), ".copilot", "ralph", "runs"));
+// Stage 3 (issue #49): resolveRunsRoot now performs sentinel-gated
+// stderr deprecation notices when legacy $RALPH_EVENTS_DIR or the
+// legacy ~/.copilot/ralph/runs default path is used. Tests that don't
+// care about the notice path inject a fake fs (which has no sentinel
+// and accepts mkdir/append silently) and a fake stderr (capturing
+// writes into an array we can inspect). The sentinelPath is pointed
+// at a fake location too so a deprecation write never touches the
+// real ~/.copilot dir.
+function makeFakeFs({ sentinel = "", existingPaths = new Set() } = {}) {
+    let written = "";
+    const fs = {
+        readFileSync: (p) => {
+            if (p === fs._sentinelPath) return sentinel + written;
+            const e = new Error("ENOENT");
+            e.code = "ENOENT";
+            throw e;
+        },
+        appendFileSync: (p, data) => {
+            if (p === fs._sentinelPath) written += data;
+        },
+        mkdirSync: () => {},
+        existsSync: (p) => existingPaths.has(p),
+    };
+    fs._sentinelPath = "/fake/sentinel";
+    fs.writtenSentinel = () => written;
+    return fs;
+}
+
+function makeFakeStderr() {
+    const messages = [];
+    return {
+        write: (m) => { messages.push(String(m)); },
+        messages,
+    };
+}
+
+test("resolveRunsRoot: defaults to $HOME/.copilot/autopilot/events", () => {
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveRunsRoot({ env: {}, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        join(homedir(), ".copilot", "autopilot", "events"),
+    );
+    assert.equal(stderr.messages.length, 0, "no notice when env is empty + neither default exists");
 });
 
-test("resolveRunsRoot: honours RALPH_EVENTS_DIR override", () => {
-    assert.equal(resolveRunsRoot({ RALPH_EVENTS_DIR: "/tmp/ralph" }), "/tmp/ralph");
+test("resolveRunsRoot: honours RALPH_EVENTS_DIR override (legacy, with notice)", () => {
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/tmp/ralph" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        "/tmp/ralph",
+    );
+    assert.equal(stderr.messages.length, 1, "legacy env override emits one notice");
+    assert.match(stderr.messages[0], /RALPH_EVENTS_DIR is deprecated/);
 });
 
 test("resolveRunsRoot: ignores empty / whitespace override and falls back to default", () => {
-    const def = join(homedir(), ".copilot", "ralph", "runs");
-    assert.equal(resolveRunsRoot({ RALPH_EVENTS_DIR: "" }), def);
-    assert.equal(resolveRunsRoot({ RALPH_EVENTS_DIR: "   " }), def);
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    const def = join(homedir(), ".copilot", "autopilot", "events");
+    assert.equal(
+        resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        def,
+    );
+    assert.equal(
+        resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "   " }, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        def,
+    );
 });
 
-test("resolveRunsRoot: tolerates missing env arg", () => {
-    // Should not throw even when env is undefined; falls back to homedir-based default.
-    assert.match(resolveRunsRoot(undefined), /\.copilot[/\\]ralph[/\\]runs$/);
+test("resolveRunsRoot: tolerates missing arg bag (env defaults to process.env)", () => {
+    // Should not throw even when called with no args; falls back to
+    // homedir-based default. Real fs/stderr are used; we only assert
+    // the path shape since real env state is not under our control.
+    assert.match(resolveRunsRoot(), /\.copilot[/\\](autopilot[/\\]events|ralph[/\\]runs)$/);
+});
+
+test("resolveRunsRoot: AUTOPILOT_EVENTS_DIR is preferred over RALPH_EVENTS_DIR", () => {
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveRunsRoot({
+            env: { AUTOPILOT_EVENTS_DIR: "/tmp/ap", RALPH_EVENTS_DIR: "/tmp/legacy" },
+            fs, stderr, sentinelPath: "/fake/sentinel",
+        }),
+        "/tmp/ap",
+    );
+    assert.equal(stderr.messages.length, 0, "primary env wins, no notice");
+});
+
+test("resolveRunsRoot: AUTOPILOT_EVENTS_DIR alone emits no notice", () => {
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveRunsRoot({
+            env: { AUTOPILOT_EVENTS_DIR: "/tmp/ap" },
+            fs, stderr, sentinelPath: "/fake/sentinel",
+        }),
+        "/tmp/ap",
+    );
+    assert.equal(stderr.messages.length, 0);
+});
+
+test("resolveRunsRoot: legacy default path is honoured with deprecation notice", () => {
+    // When AUTOPILOT_EVENTS_DIR is unset and the legacy default
+    // ~/.copilot/ralph/runs already exists on disk, fall back to it
+    // (preserves user data) while emitting a one-shot deprecation
+    // notice.
+    const legacyDefault = join(homedir(), ".copilot", "ralph", "runs");
+    const fs = makeFakeFs({ existingPaths: new Set([legacyDefault]) });
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveRunsRoot({ env: {}, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        legacyDefault,
+    );
+    assert.equal(stderr.messages.length, 1);
+    assert.match(stderr.messages[0], /reading from legacy ~\/\.copilot\/ralph\/runs/);
+});
+
+test("resolveRunsRoot: when both default paths exist, primary wins (no notice)", () => {
+    const apDefault = join(homedir(), ".copilot", "autopilot", "events");
+    const legacyDefault = join(homedir(), ".copilot", "ralph", "runs");
+    const fs = makeFakeFs({ existingPaths: new Set([apDefault, legacyDefault]) });
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveRunsRoot({ env: {}, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        apDefault,
+    );
+    assert.equal(stderr.messages.length, 0);
+});
+
+test("resolveRunsRoot: deprecation notice is one-shot per process (sentinel-gated)", () => {
+    // After the first notice, the sentinel file records which key was
+    // emitted; subsequent calls with the same trigger stay quiet.
+    const fs = makeFakeFs();
+    const stderr = makeFakeStderr();
+    const sentinelPath = "/fake/sentinel";
+    resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/x" }, fs, stderr, sentinelPath });
+    resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/x" }, fs, stderr, sentinelPath });
+    resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/x" }, fs, stderr, sentinelPath });
+    assert.equal(stderr.messages.length, 1, "only the first call writes a notice");
+    assert.match(fs.writtenSentinel(), /RALPH_EVENTS_DIR/);
+});
+
+test("resolveRunsRoot: pre-existing sentinel suppresses the notice", () => {
+    const fs = makeFakeFs({ sentinel: "env:RALPH_EVENTS_DIR\n" });
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveRunsRoot({
+            env: { RALPH_EVENTS_DIR: "/tmp/x" },
+            fs, stderr, sentinelPath: "/fake/sentinel",
+        }),
+        "/tmp/x",
+    );
+    assert.equal(stderr.messages.length, 0, "sentinel already records this key");
 });
 
 test("makeRunId: composes ${label}-${startedAt}", () => {
@@ -302,12 +441,18 @@ test("createEventEmitter: BigInt / circular ref events are dropped, not thrown",
 // resolve time so a future regression cannot reintroduce that
 // papercut.
 test("resolveRunsRoot: trims surrounding whitespace from RALPH_EVENTS_DIR override", () => {
-    assert.equal(resolveRunsRoot({ RALPH_EVENTS_DIR: "  /tmp/ralph-runs  " }), "/tmp/ralph-runs");
-    assert.equal(resolveRunsRoot({ RALPH_EVENTS_DIR: "/tmp/ralph-runs\n" }), "/tmp/ralph-runs");
-    assert.equal(resolveRunsRoot({ RALPH_EVENTS_DIR: "\t/tmp/ralph-runs" }), "/tmp/ralph-runs");
+    const sentinelPath = "/fake/sentinel";
+    const mk = () => ({ fs: makeFakeFs(), stderr: makeFakeStderr() });
+    let { fs, stderr } = mk();
+    assert.equal(resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "  /tmp/ralph-runs  " }, fs, stderr, sentinelPath }), "/tmp/ralph-runs");
+    ({ fs, stderr } = mk());
+    assert.equal(resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/tmp/ralph-runs\n" }, fs, stderr, sentinelPath }), "/tmp/ralph-runs");
+    ({ fs, stderr } = mk());
+    assert.equal(resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "\t/tmp/ralph-runs" }, fs, stderr, sentinelPath }), "/tmp/ralph-runs");
     // Internal whitespace (paths with literal spaces, like macOS volumes)
     // is preserved — only the SURROUNDING whitespace is stripped.
-    assert.equal(resolveRunsRoot({ RALPH_EVENTS_DIR: "  /Volumes/My Drive/runs  " }), "/Volumes/My Drive/runs");
+    ({ fs, stderr } = mk());
+    assert.equal(resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "  /Volumes/My Drive/runs  " }, fs, stderr, sentinelPath }), "/Volumes/My Drive/runs");
 });
 
 // Iter 115 — clipExcerpt's slice boundary must not split a UTF-16

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -7,7 +7,7 @@ import { dirname, resolve, join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { createRalphController, validateArgs, __test__ } from "../extension/handler.mjs";
-const { MAX_PROMISE_CHARS, MAX_PROMPT_CHARS, MAX_ALLOWED_ITERATIONS, PREVIEW_CHARS, PROMPT_SELF_IMPROVE, PROMPT_GROW_PROJECT, BAKED_ABORT_TOKEN, BAKED_BACKLOG_ABORT_TOKEN, BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER, BAKED_ATTRIBUTION_OPT_OUT, BAKED_RALPH_LOOP_RIDER, composeRalphLoopPrompt, SELF_IMPROVE_DEFAULTS, GROW_PROJECT_DEFAULTS, MAX_FOCUS_CHARS, previewOf, evaluateAdaptiveSignals, ADAPTIVE_WINDOW, reprefixRalphLoopError, gitAheadBehind, gitUncommittedLines, parseUserReason, coerceNumberField } = __test__;
+const { MAX_PROMISE_CHARS, MAX_PROMPT_CHARS, MAX_ALLOWED_ITERATIONS, PREVIEW_CHARS, PROMPT_SELF_IMPROVE, PROMPT_GROW_PROJECT, BAKED_ABORT_TOKEN, BAKED_BACKLOG_ABORT_TOKEN, BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER, BAKED_ATTRIBUTION_OPT_OUT, BAKED_ATTRIBUTION_OPT_OUT_LEGACY, BAKED_RALPH_LOOP_RIDER, composeRalphLoopPrompt, SELF_IMPROVE_DEFAULTS, GROW_PROJECT_DEFAULTS, MAX_FOCUS_CHARS, previewOf, evaluateAdaptiveSignals, ADAPTIVE_WINDOW, reprefixRalphLoopError, gitAheadBehind, gitUncommittedLines, parseUserReason, coerceNumberField } = __test__;
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -1370,20 +1370,22 @@ test("both baked prompts retain the cwd guardrail and the trigger-phrase footgun
     }
 });
 
-test("PROMPT_SELF_IMPROVE bakes the dual Co-authored-by trailer + RALPH_NO_ATTRIBUTION opt-out (issue #1)", () => {
+test("PROMPT_SELF_IMPROVE bakes the dual Co-authored-by trailer + AUTOPILOT_NO_ATTRIBUTION opt-out (issue #1)", () => {
     // Issue #1: every loop-driven commit ships TWO Co-authored-by
     // trailers — the existing Copilot trailer for agent attribution,
     // plus a copilot-ralph bot-account trailer for passive usage
-    // analytics across public GitHub. RALPH_NO_ATTRIBUTION=1 in env
-    // suppresses ONLY the second trailer; the Copilot trailer always
-    // ships. Pin both literals so a future edit can't silently drop
-    // the bot-account trailer or invert the opt-out polarity.
+    // analytics across public GitHub. AUTOPILOT_NO_ATTRIBUTION=1
+    // (or legacy RALPH_NO_ATTRIBUTION=1) in env suppresses ONLY the
+    // second trailer; the Copilot trailer always ships. Pin both
+    // literals so a future edit can't silently drop the bot-account
+    // trailer or invert the opt-out polarity.
     const p = PROMPT_SELF_IMPROVE;
     assert.match(p, /Co-authored-by: Copilot <223556219\+Copilot@users\.noreply\.github\.com>/, "must keep the canonical Copilot trailer");
     assert.match(p, /Co-authored-by: copilot-ralph <copilot-ralph@users\.noreply\.github\.com>/, "must bake the copilot-ralph bot-account trailer (issue #1)");
-    assert.match(p, /RALPH_NO_ATTRIBUTION=1/, "must document the RALPH_NO_ATTRIBUTION=1 opt-out env var");
+    assert.match(p, /AUTOPILOT_NO_ATTRIBUTION=1/, "must document the AUTOPILOT_NO_ATTRIBUTION=1 primary opt-out env var");
+    assert.match(p, /RALPH_NO_ATTRIBUTION=1/, "must document the legacy RALPH_NO_ATTRIBUTION=1 opt-out env var (still honored)");
     // Opt-out polarity: setting the var SUPPRESSES, not enables.
-    assert.match(p, /RALPH_NO_ATTRIBUTION=1[\s\S]{0,200}\bomit\b/i, "RALPH_NO_ATTRIBUTION=1 must instruct the agent to OMIT the second trailer");
+    assert.match(p, /AUTOPILOT_NO_ATTRIBUTION=1[\s\S]{0,200}\bomit\b/i, "AUTOPILOT_NO_ATTRIBUTION=1 must instruct the agent to OMIT the second trailer");
     // Stricter polarity: must say "omit ONLY" (or equivalent) so a future
     // edit can't degrade to "omit BOTH" trailers — the Copilot trailer
     // must always ship for agent-attribution audit.
@@ -1391,22 +1393,23 @@ test("PROMPT_SELF_IMPROVE bakes the dual Co-authored-by trailer + RALPH_NO_ATTRI
     assert.match(p, /\balways\s+ship/i, "must promise the Copilot trailer always ships");
 });
 
-test("PROMPT_GROW_PROJECT bakes the dual Co-authored-by trailer + RALPH_NO_ATTRIBUTION opt-out (issue #1)", () => {
+test("PROMPT_GROW_PROJECT bakes the dual Co-authored-by trailer + AUTOPILOT_NO_ATTRIBUTION opt-out (issue #1)", () => {
     // Mirror of the PROMPT_SELF_IMPROVE pin. grow_project also commits
     // per iter and must carry the same dual-trailer + opt-out contract
     // so the two loop tools stay symmetric on the attribution surface.
     const p = PROMPT_GROW_PROJECT;
     assert.match(p, /Co-authored-by: Copilot <223556219\+Copilot@users\.noreply\.github\.com>/, "must keep the canonical Copilot trailer");
     assert.match(p, /Co-authored-by: copilot-ralph <copilot-ralph@users\.noreply\.github\.com>/, "must bake the copilot-ralph bot-account trailer (issue #1)");
-    assert.match(p, /RALPH_NO_ATTRIBUTION=1/, "must document the RALPH_NO_ATTRIBUTION=1 opt-out env var");
-    assert.match(p, /RALPH_NO_ATTRIBUTION=1[\s\S]{0,200}\bomit\b/i, "RALPH_NO_ATTRIBUTION=1 must instruct the agent to OMIT the copilot-ralph trailer");
+    assert.match(p, /AUTOPILOT_NO_ATTRIBUTION=1/, "must document the AUTOPILOT_NO_ATTRIBUTION=1 primary opt-out env var");
+    assert.match(p, /RALPH_NO_ATTRIBUTION=1/, "must document the legacy RALPH_NO_ATTRIBUTION=1 opt-out env var (still honored)");
+    assert.match(p, /AUTOPILOT_NO_ATTRIBUTION=1[\s\S]{0,200}\bomit\b/i, "AUTOPILOT_NO_ATTRIBUTION=1 must instruct the agent to OMIT the copilot-ralph trailer");
     // Stricter polarity (mirror of self_improve pin): must say "omit ONLY"
     // so a future edit can't degrade to "omit BOTH" trailers.
     assert.match(p, /\bomit\b[\s\S]{0,80}\bonly\b/i, "must instruct OMIT ONLY the copilot-ralph trailer (Copilot trailer + Closes #N always ship)");
     assert.match(p, /\balways\s+ship/i, "must promise the Copilot trailer (and Closes #N) always ship");
 });
 
-test("BAKED_RALPH_LOOP_RIDER bakes the dual Co-authored-by trailer + RALPH_NO_ATTRIBUTION opt-out (issue #1, ap_loop parity)", () => {
+test("BAKED_RALPH_LOOP_RIDER bakes the dual Co-authored-by trailer + AUTOPILOT_NO_ATTRIBUTION opt-out (issue #1, ap_loop parity)", () => {
     // ap_loop parity with self_improve / grow_project: every
     // loop-driven commit must carry the dual trailer. Because
     // ap_loop's prompt is user-supplied, the rider is appended
@@ -1416,8 +1419,9 @@ test("BAKED_RALPH_LOOP_RIDER bakes the dual Co-authored-by trailer + RALPH_NO_AT
     const r = BAKED_RALPH_LOOP_RIDER;
     assert.match(r, /Co-authored-by: Copilot <223556219\+Copilot@users\.noreply\.github\.com>/, "must keep the canonical Copilot trailer");
     assert.match(r, /Co-authored-by: copilot-ralph <copilot-ralph@users\.noreply\.github\.com>/, "must bake the copilot-ralph bot-account trailer");
-    assert.match(r, /RALPH_NO_ATTRIBUTION=1/, "must document the RALPH_NO_ATTRIBUTION=1 opt-out env var");
-    assert.match(r, /RALPH_NO_ATTRIBUTION=1[\s\S]{0,200}\bomit\b/i, "RALPH_NO_ATTRIBUTION=1 must instruct the agent to OMIT the copilot-ralph trailer");
+    assert.match(r, /AUTOPILOT_NO_ATTRIBUTION=1/, "must document the AUTOPILOT_NO_ATTRIBUTION=1 primary opt-out env var");
+    assert.match(r, /RALPH_NO_ATTRIBUTION=1/, "must document the legacy RALPH_NO_ATTRIBUTION=1 opt-out env var (still honored)");
+    assert.match(r, /AUTOPILOT_NO_ATTRIBUTION=1[\s\S]{0,200}\bomit\b/i, "AUTOPILOT_NO_ATTRIBUTION=1 must instruct the agent to OMIT the copilot-ralph trailer");
     assert.match(r, /\bomit\b[\s\S]{0,80}\bonly\b/i, "must instruct OMIT ONLY the copilot-ralph trailer");
     assert.match(r, /\balways\s+ship/i, "must promise the Copilot trailer always ships");
     // Order pin: Copilot must precede copilot-ralph (GitHub UI
@@ -1538,11 +1542,17 @@ test("BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER, BAKED_ATTRIBUTION_OPT_OUT pin 
     // CHANGELOG.
     assert.equal(BAKED_COPILOT_TRAILER, "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>");
     assert.equal(BAKED_RALPH_TRAILER, "Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>");
-    assert.equal(BAKED_ATTRIBUTION_OPT_OUT, "RALPH_NO_ATTRIBUTION=1");
+    // Project-rename stage 4: AUTOPILOT_NO_ATTRIBUTION is the
+    // primary opt-out env var; the legacy RALPH_NO_ATTRIBUTION
+    // spelling still works (and remains baked into prompt prose
+    // so existing user scripts don't drift).
+    assert.equal(BAKED_ATTRIBUTION_OPT_OUT, "AUTOPILOT_NO_ATTRIBUTION=1");
+    assert.equal(BAKED_ATTRIBUTION_OPT_OUT_LEGACY, "RALPH_NO_ATTRIBUTION=1");
     // Trailers must be distinct lines; opt-out polarity is "=1"
     // (truthy enables the suppression), not a bare flag.
     assert.notEqual(BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER);
     assert.match(BAKED_ATTRIBUTION_OPT_OUT, /=1$/, "opt-out env var must use the =1 polarity convention");
+    assert.match(BAKED_ATTRIBUTION_OPT_OUT_LEGACY, /=1$/, "legacy opt-out env var must use the =1 polarity convention");
     // Both trailers must use the canonical GitHub noreply domain.
     // A typo like "users.noreply.gihub.com" would silently produce
     // commits whose Co-authored-by line does not link to any GitHub
@@ -1627,7 +1637,8 @@ test("the prompt actually fired through armLoop carries both Co-authored-by trai
     // the agent's actual instructions while leaving the exported
     // PROMPT_* constants untouched. Pin the SENT prompt — the
     // string the executing agent actually sees — to contain both
-    // trailer literals and the RALPH_NO_ATTRIBUTION env var
+    // trailer literals AND both opt-out env var spellings
+    // (AUTOPILOT_NO_ATTRIBUTION primary + legacy RALPH_NO_ATTRIBUTION)
     // verbatim, for both self_improve and grow_project.
     for (const name of ["self_improve", "grow_project"]) {
         const session = makeFakeSession();
@@ -1642,6 +1653,7 @@ test("the prompt actually fired through armLoop carries both Co-authored-by trai
         assert.ok(sent.includes(BAKED_COPILOT_TRAILER), `${name} sent prompt must carry the Copilot trailer`);
         assert.ok(sent.includes(BAKED_RALPH_TRAILER), `${name} sent prompt must carry the copilot-ralph trailer`);
         assert.ok(sent.includes(BAKED_ATTRIBUTION_OPT_OUT), `${name} sent prompt must mention ${BAKED_ATTRIBUTION_OPT_OUT}`);
+        assert.ok(sent.includes(BAKED_ATTRIBUTION_OPT_OUT_LEGACY), `${name} sent prompt must mention legacy ${BAKED_ATTRIBUTION_OPT_OUT_LEGACY}`);
     }
 });
 
@@ -4798,14 +4810,16 @@ test("dual Co-authored-by trailers are baked in canonical order: Copilot first, 
     }
 });
 
-test("README documents both Co-authored-by trailers and RALPH_NO_ATTRIBUTION opt-out (issue #1)", () => {
+test("README documents both Co-authored-by trailers and the opt-out env var (issue #1)", () => {
     // The user-facing README "Commit attribution" section is the
     // canonical disclosure surface for issue #1. Pin its presence
     // so a future README rewrite can't quietly drop:
     //   - the "Commit attribution" section heading
     //   - either of the two canonical Co-authored-by trailer lines
     //     (Copilot agent + copilot-ralph bot account)
-    //   - the RALPH_NO_ATTRIBUTION=1 opt-out env var
+    //   - the opt-out env var (primary AUTOPILOT_NO_ATTRIBUTION=1
+    //     OR legacy RALPH_NO_ATTRIBUTION=1; either disclosure
+    //     satisfies the contract while the rename rolls out)
     //   - the public-only-searchability caveat
     //
     // Also pin that the trailer literals in the README match the
@@ -4816,7 +4830,10 @@ test("README documents both Co-authored-by trailers and RALPH_NO_ATTRIBUTION opt
     assert.match(readme, /^## Commit attribution\b/m, "README must have a '## Commit attribution' section");
     assert.ok(readme.includes(BAKED_COPILOT_TRAILER), "README must spell out the canonical Copilot Co-authored-by trailer");
     assert.ok(readme.includes(BAKED_RALPH_TRAILER), "README must spell out the canonical copilot-ralph Co-authored-by trailer");
-    assert.ok(readme.includes(BAKED_ATTRIBUTION_OPT_OUT), `README must document the ${BAKED_ATTRIBUTION_OPT_OUT} opt-out env var`);
+    assert.ok(
+        readme.includes(BAKED_ATTRIBUTION_OPT_OUT) || readme.includes(BAKED_ATTRIBUTION_OPT_OUT_LEGACY),
+        `README must document either the ${BAKED_ATTRIBUTION_OPT_OUT} or legacy ${BAKED_ATTRIBUTION_OPT_OUT_LEGACY} opt-out env var`,
+    );
     // The public-only caveat is a required disclosure per the issue.
     assert.match(readme, /\bpublic[-\s]?repo[-\s]?(commits|only)\b/i, "README must disclose the public-repo-only searchability caveat");
     // Trailer order matters: GitHub's commit UI surfaces the first
@@ -5674,34 +5691,40 @@ function makeCaffeinateSpy({ failSpawn = false, failError = null } = {}) {
     return { calls, children, spawnFn };
 }
 
-async function armWithCaffeinate({ env = {}, platform = "darwin", spawnSpy } = {}) {
+async function armWithCaffeinate({ env = {}, platform = "darwin", spawnSpy, stderr } = {}) {
     const session = makeFakeSession();
+    // Reset per-process legacy-env notice flags so each arm starts
+    // from a clean slate (otherwise the second test that reads the
+    // legacy env var sees a stale "already warned" sentinel).
+    __test__._resetLegacyEnvNotices();
+    const stderrStub = stderr ?? { write() { /* swallow */ } };
     const controller = createRalphController({
         caffeinate: {
             env,
             platform,
             pid: 12345,
             spawnFn: spawnSpy.spawnFn,
+            stderr: stderrStub,
         },
     });
     controller.attach(session);
     const ralph = controller.tools.find((t) => t.name === "ap_loop");
     const armResult = await ralph.handler({ prompt: "go", max_iterations: 3 });
-    return { session, controller, armResult, ralph };
+    return { session, controller, armResult, ralph, stderr: stderrStub };
 }
 
 test("caffeinate: disabled by default — no spawn, no log line", async () => {
     const spy = makeCaffeinateSpy();
     const { session, armResult } = await armWithCaffeinate({ env: {}, spawnSpy: spy });
     assert.equal(armResult.armed, true);
-    assert.equal(spy.calls.length, 0, "must NOT spawn caffeinate when RALPH_CAFFEINATE is unset");
+    assert.equal(spy.calls.length, 0, "must NOT spawn caffeinate when AUTOPILOT_CAFFEINATE is unset");
     assert.equal(session.logs.some((l) => l.includes("caffeinate")), false, "no caffeinate log line when disabled");
 });
 
-test("caffeinate: enabled via RALPH_CAFFEINATE=1 spawns 'caffeinate -i -w <pid>' on darwin", async () => {
+test("caffeinate: enabled via AUTOPILOT_CAFFEINATE=1 spawns 'caffeinate -i -w <pid>' on darwin", async () => {
     const spy = makeCaffeinateSpy();
     const { session } = await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1" },
+        env: { AUTOPILOT_CAFFEINATE: "1" },
         platform: "darwin",
         spawnSpy: spy,
     });
@@ -5713,10 +5736,75 @@ test("caffeinate: enabled via RALPH_CAFFEINATE=1 spawns 'caffeinate -i -w <pid>'
     assert.ok(session.logs.some((l) => /keeping system awake via caffeinate/.test(l)), "must log activation line");
 });
 
+test("caffeinate: enabled via legacy RALPH_CAFFEINATE=1 still works (with deprecation)", async () => {
+    // Legacy env var: still honored as a fallback so existing user
+    // scripts don't break, but a one-line stderr deprecation fires
+    // the first time per process.
+    const spy = makeCaffeinateSpy();
+    const writes = [];
+    const stderr = { write(s) { writes.push(s); } };
+    const { session } = await armWithCaffeinate({
+        env: { RALPH_CAFFEINATE: "1" },
+        platform: "darwin",
+        spawnSpy: spy,
+        stderr,
+    });
+    assert.equal(spy.calls.length, 1, "legacy RALPH_CAFFEINATE=1 must still enable caffeinate");
+    assert.deepEqual(spy.calls[0].args, ["-i", "-w", "12345"]);
+    assert.ok(session.logs.some((l) => /keeping system awake via caffeinate/.test(l)));
+    assert.equal(writes.length, 1, "exactly one stderr deprecation must fire");
+    assert.match(writes[0], /\$RALPH_CAFFEINATE.*deprecated/i);
+    assert.match(writes[0], /\$AUTOPILOT_CAFFEINATE/);
+});
+
+test("caffeinate: AUTOPILOT_CAFFEINATE wins when BOTH primary and legacy are set; no deprecation fires", async () => {
+    // Decision B precedence: when a user has both spellings set
+    // (mid-migration scripts), the primary takes precedence and
+    // the legacy var is ignored — no deprecation noise either.
+    const spy = makeCaffeinateSpy();
+    const writes = [];
+    const stderr = { write(s) { writes.push(s); } };
+    await armWithCaffeinate({
+        env: { AUTOPILOT_CAFFEINATE: "1", RALPH_CAFFEINATE: "0" },
+        platform: "darwin",
+        spawnSpy: spy,
+        stderr,
+    });
+    assert.equal(spy.calls.length, 1, "primary AUTOPILOT_CAFFEINATE=1 must win over legacy RALPH_CAFFEINATE=0");
+    assert.deepEqual(writes, [], "no deprecation should fire when primary is set");
+});
+
+test("caffeinate: legacy-env deprecation fires at most ONCE per process", async () => {
+    // Read the legacy var multiple times in a row; only the first
+    // call should produce the stderr notice.
+    const { isCaffeinateEnabled, _resetLegacyEnvNotices } = __test__;
+    _resetLegacyEnvNotices();
+    const writes = [];
+    const stderr = { write(s) { writes.push(s); } };
+    for (let i = 0; i < 5; i++) {
+        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: "1" }, stderr), true);
+    }
+    assert.equal(writes.length, 1, "deprecation must fire exactly once across repeated reads");
+    assert.match(writes[0], /\$RALPH_CAFFEINATE/);
+});
+
+test("caffeinate: legacy-env deprecation fires at most once for SCOPE too", async () => {
+    const { resolveCaffeinateScope, _resetLegacyEnvNotices } = __test__;
+    _resetLegacyEnvNotices();
+    const writes = [];
+    const stderr = { write(s) { writes.push(s); } };
+    for (let i = 0; i < 5; i++) {
+        assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "idle+display" }, stderr), "idle+display");
+    }
+    assert.equal(writes.length, 1, "deprecation must fire exactly once across repeated reads");
+    assert.match(writes[0], /\$RALPH_CAFFEINATE_SCOPE/);
+    assert.match(writes[0], /\$AUTOPILOT_CAFFEINATE_SCOPE/);
+});
+
 test("caffeinate: scope=idle+display adds -d flag", async () => {
     const spy = makeCaffeinateSpy();
     await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1", RALPH_CAFFEINATE_SCOPE: "idle+display" },
+        env: { AUTOPILOT_CAFFEINATE: "1", AUTOPILOT_CAFFEINATE_SCOPE: "idle+display" },
         platform: "darwin",
         spawnSpy: spy,
     });
@@ -5726,7 +5814,7 @@ test("caffeinate: scope=idle+display adds -d flag", async () => {
 test("caffeinate: invalid scope falls back to idle", async () => {
     const spy = makeCaffeinateSpy();
     await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1", RALPH_CAFFEINATE_SCOPE: "bogus" },
+        env: { AUTOPILOT_CAFFEINATE: "1", AUTOPILOT_CAFFEINATE_SCOPE: "bogus" },
         platform: "darwin",
         spawnSpy: spy,
     });
@@ -5736,7 +5824,7 @@ test("caffeinate: invalid scope falls back to idle", async () => {
 test("caffeinate: child is killed on loop completion", async () => {
     const spy = makeCaffeinateSpy();
     const { session, controller } = await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1" },
+        env: { AUTOPILOT_CAFFEINATE: "1" },
         platform: "darwin",
         spawnSpy: spy,
     });
@@ -5751,7 +5839,7 @@ test("caffeinate: child is killed on loop completion", async () => {
 test("caffeinate: child is killed on ap_stop", async () => {
     const spy = makeCaffeinateSpy();
     const { controller } = await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1" },
+        env: { AUTOPILOT_CAFFEINATE: "1" },
         platform: "darwin",
         spawnSpy: spy,
     });
@@ -5763,7 +5851,7 @@ test("caffeinate: child is killed on ap_stop", async () => {
 test("caffeinate: non-darwin platform is a silent no-op (logged skip, no spawn)", async () => {
     const spy = makeCaffeinateSpy();
     const { session } = await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1" },
+        env: { AUTOPILOT_CAFFEINATE: "1" },
         platform: "linux",
         spawnSpy: spy,
     });
@@ -5774,7 +5862,7 @@ test("caffeinate: non-darwin platform is a silent no-op (logged skip, no spawn)"
 test("caffeinate: spawn throw does not abort the loop", async () => {
     const spy = makeCaffeinateSpy({ failSpawn: true });
     const { session, armResult, controller } = await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1" },
+        env: { AUTOPILOT_CAFFEINATE: "1" },
         platform: "darwin",
         spawnSpy: spy,
     });
@@ -5787,7 +5875,7 @@ test("caffeinate: truthy variants ('true', 'YES', 'on') all enable", async () =>
     for (const val of ["true", "YES", "on", "1"]) {
         const spy = makeCaffeinateSpy();
         await armWithCaffeinate({
-            env: { RALPH_CAFFEINATE: val },
+            env: { AUTOPILOT_CAFFEINATE: val },
             platform: "darwin",
             spawnSpy: spy,
         });
@@ -5799,7 +5887,7 @@ test("caffeinate: falsy values keep it off", async () => {
     for (const val of ["0", "false", "", "no", "off"]) {
         const spy = makeCaffeinateSpy();
         await armWithCaffeinate({
-            env: { RALPH_CAFFEINATE: val },
+            env: { AUTOPILOT_CAFFEINATE: val },
             platform: "darwin",
             spawnSpy: spy,
         });
@@ -10253,73 +10341,88 @@ test("VERB_BY_REASON: max_tokens has explicit entry; neutral exits fall through 
 });
 
 test("isCaffeinateEnabled: case + whitespace tolerant truthy parse (issue #8)", () => {
-    // The helper at extension/handler.mjs:536 lower-cases + trims env
-    // input before checking against the truthy set. Pin the contract
-    // directly so a future refactor swapping in a shared env-parser
-    // can't silently tighten or loosen what counts as "enabled" — the
-    // existing caffeinate end-to-end tests only exercise "1" and would
-    // pass even if the case/whitespace tolerance were dropped.
-    const { isCaffeinateEnabled } = __test__;
+    // The helper lower-cases + trims env input before checking
+    // against the truthy set. Pin the contract directly so a future
+    // refactor swapping in a shared env-parser can't silently
+    // tighten or loosen what counts as "enabled" — the existing
+    // caffeinate end-to-end tests only exercise "1" and would pass
+    // even if the case/whitespace tolerance were dropped.
+    const { isCaffeinateEnabled, _resetLegacyEnvNotices } = __test__;
+    _resetLegacyEnvNotices();
+    // Stub stderr so legacy-env deprecations during this test
+    // don't pollute the tap stream.
+    const stderrStub = { write() { /* swallow */ } };
 
     // Truthy variants — every documented form + capitalisation.
     for (const v of ["1", "true", "yes", "on", "TRUE", "YES", "ON",
         "True", "Yes", "On", "  1  ", "\t1\n", "  true  "]) {
-        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: v }), true,
-            `RALPH_CAFFEINATE=${JSON.stringify(v)} must enable caffeinate`);
+        assert.equal(isCaffeinateEnabled({ AUTOPILOT_CAFFEINATE: v }, stderrStub), true,
+            `AUTOPILOT_CAFFEINATE=${JSON.stringify(v)} must enable caffeinate`);
+        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: v }, stderrStub), true,
+            `legacy RALPH_CAFFEINATE=${JSON.stringify(v)} must still enable caffeinate`);
     }
 
     // Falsy / disabled — anything not in the truthy set, including
     // unset, empty string, and bogus tokens.
     for (const v of [undefined, "", "0", "false", "no", "off", "FALSE",
         "enable", "y", "  ", "1\n2"]) {
-        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: v }), false,
+        assert.equal(isCaffeinateEnabled({ AUTOPILOT_CAFFEINATE: v }, stderrStub), false,
+            `AUTOPILOT_CAFFEINATE=${JSON.stringify(v)} must NOT enable caffeinate`);
+        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: v }, stderrStub), false,
             `RALPH_CAFFEINATE=${JSON.stringify(v)} must NOT enable caffeinate`);
     }
 
     // Defensive: env arg itself absent / non-object → false (no throw).
-    assert.equal(isCaffeinateEnabled(undefined), false, "undefined env must not throw");
-    assert.equal(isCaffeinateEnabled(null), false, "null env must not throw");
-    assert.equal(isCaffeinateEnabled({}), false, "empty env must default to disabled");
+    assert.equal(isCaffeinateEnabled(undefined, stderrStub), false, "undefined env must not throw");
+    assert.equal(isCaffeinateEnabled(null, stderrStub), false, "null env must not throw");
+    assert.equal(isCaffeinateEnabled({}, stderrStub), false, "empty env must default to disabled");
 
     // Non-string values must NOT enable — protects against e.g.
-    // RALPH_CAFFEINATE=true (boolean) sneaking in via a wrapper.
+    // AUTOPILOT_CAFFEINATE=true (boolean) sneaking in via a wrapper.
     for (const v of [true, 1, {}, []]) {
-        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: v }), false,
+        assert.equal(isCaffeinateEnabled({ AUTOPILOT_CAFFEINATE: v }, stderrStub), false,
+            `AUTOPILOT_CAFFEINATE=${typeof v} (non-string) must NOT enable caffeinate`);
+        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: v }, stderrStub), false,
             `RALPH_CAFFEINATE=${typeof v} (non-string) must NOT enable caffeinate`);
     }
 });
 
 test("resolveCaffeinateScope: case + whitespace tolerant; bogus → idle (issue #8)", () => {
-    const { resolveCaffeinateScope } = __test__;
+    const { resolveCaffeinateScope, _resetLegacyEnvNotices } = __test__;
+    _resetLegacyEnvNotices();
+    const stderrStub = { write() { /* swallow */ } };
 
     // Default (env unset / absent) → "idle".
-    assert.equal(resolveCaffeinateScope({}), "idle");
-    assert.equal(resolveCaffeinateScope(undefined), "idle");
-    assert.equal(resolveCaffeinateScope(null), "idle");
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: undefined }), "idle");
+    assert.equal(resolveCaffeinateScope({}, stderrStub), "idle");
+    assert.equal(resolveCaffeinateScope(undefined, stderrStub), "idle");
+    assert.equal(resolveCaffeinateScope(null, stderrStub), "idle");
+    assert.equal(resolveCaffeinateScope({ AUTOPILOT_CAFFEINATE_SCOPE: undefined }, stderrStub), "idle");
+    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: undefined }, stderrStub), "idle");
 
-    // Explicit "idle" passes through.
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "idle" }), "idle");
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "IDLE" }), "idle");
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "  idle  " }), "idle");
+    // Explicit "idle" passes through (both env-var spellings).
+    for (const k of ["AUTOPILOT_CAFFEINATE_SCOPE", "RALPH_CAFFEINATE_SCOPE"]) {
+        assert.equal(resolveCaffeinateScope({ [k]: "idle" }, stderrStub), "idle");
+        assert.equal(resolveCaffeinateScope({ [k]: "IDLE" }, stderrStub), "idle");
+        assert.equal(resolveCaffeinateScope({ [k]: "  idle  " }, stderrStub), "idle");
 
-    // "idle+display" — the only other documented scope.
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "idle+display" }), "idle+display");
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "IDLE+DISPLAY" }), "idle+display");
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "  Idle+Display  " }), "idle+display");
+        // "idle+display" — the only other documented scope.
+        assert.equal(resolveCaffeinateScope({ [k]: "idle+display" }, stderrStub), "idle+display");
+        assert.equal(resolveCaffeinateScope({ [k]: "IDLE+DISPLAY" }, stderrStub), "idle+display");
+        assert.equal(resolveCaffeinateScope({ [k]: "  Idle+Display  " }, stderrStub), "idle+display");
 
-    // Bogus values fall back to "idle" (safe default — keep the loop
-    // on rather than failing arm-time over a typo).
-    for (const v of ["display", "always", "idle+", "+display", "true",
-        "1", "", "  ", "\n"]) {
-        assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: v }), "idle",
-            `bogus scope ${JSON.stringify(v)} must collapse to "idle"`);
-    }
+        // Bogus values fall back to "idle" (safe default — keep the loop
+        // on rather than failing arm-time over a typo).
+        for (const v of ["display", "always", "idle+", "+display", "true",
+            "1", "", "  ", "\n"]) {
+            assert.equal(resolveCaffeinateScope({ [k]: v }, stderrStub), "idle",
+                `${k}=${JSON.stringify(v)} must collapse to "idle"`);
+        }
 
-    // Non-string → "idle".
-    for (const v of [true, 1, {}, []]) {
-        assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: v }), "idle",
-            `non-string scope ${typeof v} must collapse to "idle"`);
+        // Non-string → "idle".
+        for (const v of [true, 1, {}, []]) {
+            assert.equal(resolveCaffeinateScope({ [k]: v }, stderrStub), "idle",
+                `${k}=${typeof v} (non-string) must collapse to "idle"`);
+        }
     }
 });
 

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -5287,7 +5287,7 @@ test("install.sh: rejects duplicate flags and unknown arguments", () => {
     assert.match(unknown.stderr, /unknown argument/);
 });
 
-test("scripts/ralph-tui-fresh.sh: shape, shebang, and only-when-run gate", () => {
+test("scripts/autopilot-fresh.sh: shape, shebang, and only-when-run gate", () => {
     // Drift guard for the auto-upgrade wrapper. Each assertion below
     // pins a specific safety property documented in the script's
     // header comment + the `Auto-upgrade for each run` subsection
@@ -5296,9 +5296,9 @@ test("scripts/ralph-tui-fresh.sh: shape, shebang, and only-when-run gate", () =>
     // dropping `set -euo pipefail`, removing the `|| true` failure
     // swallow, or relocating the entry point Node script) trips the
     // matching assertion before merge.
-    const wrapperPath = resolve(REPO_ROOT, "scripts/ralph-tui-fresh.sh");
+    const wrapperPath = resolve(REPO_ROOT, "scripts/autopilot-fresh.sh");
     const src = readFileSync(wrapperPath, "utf8");
-    // Shebang — invocation via `./scripts/ralph-tui-fresh.sh` requires
+    // Shebang — invocation via `./scripts/autopilot-fresh.sh` requires
     // the kernel to find `bash` via env.
     assert.match(src, /^#!\/usr\/bin\/env bash\n/,
         "wrapper must start with `#!/usr/bin/env bash` shebang");
@@ -5309,7 +5309,7 @@ test("scripts/ralph-tui-fresh.sh: shape, shebang, and only-when-run gate", () =>
         "wrapper must `set -euo pipefail` so typos surface loudly");
     // Only-when-`run` gate. Pin the literal "$1" branch shape so a
     // refactor that fires the upgrade on every invocation (which
-    // would make `ralph-tui list` feel laggy) trips this test.
+    // would make `autopilot list` feel laggy) trips this test.
     assert.match(src, /\[\[ "\$\{1:-\}" == "run" \]\]/,
         'wrapper must guard the upgrade behind `[[ "${1:-}" == "run" ]]`');
     // Silent failure mode — pin the `git pull --quiet --ff-only`
@@ -5331,21 +5331,21 @@ test("scripts/ralph-tui-fresh.sh: shape, shebang, and only-when-run gate", () =>
         'wrapper must end with `exec node "$ROOT/packages/tui/bin/tui.mjs" "$@"` so signals + exit code propagate from Node, not from bash');
 });
 
-test("scripts/ralph-tui-fresh.sh: file mode includes execute bit", () => {
-    // Without the +x bit, `./scripts/ralph-tui-fresh.sh` from a fresh
+test("scripts/autopilot-fresh.sh: file mode includes execute bit", () => {
+    // Without the +x bit, `./scripts/autopilot-fresh.sh` from a fresh
     // clone fails with EACCES even though the shebang line is correct.
     // chmod is set at file-creation time; this test pins it so a
     // future commit that recreates the file (e.g. via a string-edit
     // tool that drops mode bits) doesn't silently regress to 644.
-    const wrapperPath = resolve(REPO_ROOT, "scripts/ralph-tui-fresh.sh");
+    const wrapperPath = resolve(REPO_ROOT, "scripts/autopilot-fresh.sh");
     const st = statSync(wrapperPath);
     // Owner execute bit (0o100). Group/other bits are not pinned —
     // umask differs per contributor, but +x for owner is mandatory.
     assert.ok((st.mode & 0o100) !== 0,
-        `scripts/ralph-tui-fresh.sh must be executable (got mode 0${(st.mode & 0o777).toString(8)})`);
+        `scripts/autopilot-fresh.sh must be executable (got mode 0${(st.mode & 0o777).toString(8)})`);
 });
 
-test("scripts/ralph-tui-fresh.sh: non-`run` subcommand skips upgrade and passes through to bin/tui.mjs", () => {
+test("scripts/autopilot-fresh.sh: non-`run` subcommand skips upgrade and passes through to bin/tui.mjs", () => {
     // End-to-end smoke: invoke the wrapper with `--help` (which is
     // NOT `run`) and assert that bin/tui.mjs's USAGE is printed and
     // the exit code is 0. Two failure modes this catches:
@@ -5357,12 +5357,54 @@ test("scripts/ralph-tui-fresh.sh: non-`run` subcommand skips upgrade and passes 
     // Running with `--help` keeps the test sub-second and offline.
     const r = spawnSync(
         "bash",
-        [resolve(REPO_ROOT, "scripts/ralph-tui-fresh.sh"), "--help"],
+        [resolve(REPO_ROOT, "scripts/autopilot-fresh.sh"), "--help"],
         { encoding: "utf8", timeout: 10_000 },
     );
     assert.equal(r.status, 0, `--help exited ${r.status}; stderr=${r.stderr}`);
     assert.match(r.stdout, /autopilot — terminal visualizer/,
         "wrapper must passthrough `--help` to bin/tui.mjs's USAGE block");
+});
+
+test("scripts/ralph-tui-fresh.sh: deprecating wrapper that execs autopilot-fresh.sh", () => {
+    // Decision C (issue #49): the legacy script becomes a thin
+    // deprecating wrapper that prints a one-line stderr notice and
+    // execs the canonical `scripts/autopilot-fresh.sh`. Pin the
+    // shape so a future "simplify" pass that drops the notice
+    // (silent rename) or replaces `exec` with a plain call (signals
+    // / exit code regress) trips this test.
+    const wrapperPath = resolve(REPO_ROOT, "scripts/ralph-tui-fresh.sh");
+    const src = readFileSync(wrapperPath, "utf8");
+    assert.match(src, /^#!\/usr\/bin\/env bash\n/,
+        "deprecating wrapper must start with `#!/usr/bin/env bash` shebang");
+    assert.match(src, /deprecated/i,
+        "deprecating wrapper must mention deprecation in its body so users see a notice");
+    assert.match(src, /autopilot-fresh\.sh/,
+        "deprecating wrapper must point users at scripts/autopilot-fresh.sh");
+    assert.match(src, /^exec ".*autopilot-fresh\.sh" "\$@"$/m,
+        "deprecating wrapper must `exec` the canonical script with `$@` so signals + exit code propagate");
+    // File mode — the wrapper is invoked directly via alias on
+    // legacy installs, so the +x bit must survive the rewrite.
+    const st = statSync(wrapperPath);
+    assert.ok((st.mode & 0o100) !== 0,
+        `scripts/ralph-tui-fresh.sh must be executable (got mode 0${(st.mode & 0o777).toString(8)})`);
+});
+
+test("scripts/ralph-tui-fresh.sh: emits deprecation notice on stderr and forwards to autopilot-fresh.sh", () => {
+    // End-to-end smoke for Decision C: invoke the legacy wrapper
+    // with `--help` (NOT `run`, so no network round-trip) and
+    // assert (a) the deprecation notice landed on stderr, (b) the
+    // canonical script's stdout (bin/tui.mjs USAGE) was forwarded,
+    // and (c) the exit code is 0 (Node's, not bash's).
+    const r = spawnSync(
+        "bash",
+        [resolve(REPO_ROOT, "scripts/ralph-tui-fresh.sh"), "--help"],
+        { encoding: "utf8", timeout: 10_000 },
+    );
+    assert.equal(r.status, 0, `--help exited ${r.status}; stderr=${r.stderr}`);
+    assert.match(r.stderr, /deprecated/i,
+        "legacy wrapper must print a deprecation notice on stderr");
+    assert.match(r.stdout, /ralph-tui — terminal visualizer/,
+        "legacy wrapper must passthrough `--help` to bin/tui.mjs's USAGE block via autopilot-fresh.sh");
 });
 
 test("packages/tui/README.md: documents the ralph-tui-fresh.sh wrapper", () => {

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -6853,7 +6853,7 @@ test("docs/faq.md is no longer the stub and answers core operational questions",
     // Headline questions that MUST be present (regression guard against
     // future "simplify" PRs that drop sections wholesale).
     const requiredHeadings = [
-        /Why doesn't `\/extensions` list `ralph` after install\?/,
+        /Why doesn't `\/extensions` list `autopilot` after install\?/,
         /Why does arming fail with .*already armed/,
         /Why did my loop stop after exactly one iteration\?/,
         /Why does my loop never finish\?/,
@@ -6878,8 +6878,8 @@ test("docs/faq.md is no longer the stub and answers core operational questions",
     assert.match(faq, /pause[\s\S]{0,80}idempotent/i);
     assert.match(faq, /resume[\s\S]{0,40}\*\*not\*\* idempotent/i);
     // (c) The default runs root path — used by the events emitter.
-    assert.match(faq, /~\/\.copilot\/ralph\/runs/);
-    assert.match(faq, /RALPH_EVENTS_DIR/);
+    assert.match(faq, /~\/\.copilot\/autopilot\/runs/);
+    assert.match(faq, /AUTOPILOT_EVENTS_DIR/);
 });
 
 // -----------------------------------------------------------------------------

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -5225,9 +5225,9 @@ test("install.sh: --help prints the leading comment block", () => {
 test("install.sh: --dry-run reports target dir + sizes without writing", () => {
     // End-to-end behaviour test for the install path. Runs install.sh
     // under a sandboxed $HOME (so we never touch the developer's real
-    // ~/.copilot/extensions/ralph) and asserts:
+    // ~/.copilot/extensions/autopilot) and asserts:
     //   - exit 0
-    //   - target dir resolved to $HOME/.copilot/extensions/ralph
+    //   - target dir resolved to $HOME/.copilot/extensions/autopilot
     //   - every FILES entry shows up in the dry-run listing with a
     //     non-zero byte size
     //   - the sandbox dir is NOT created (dry-run truly writes nothing).
@@ -5241,7 +5241,7 @@ test("install.sh: --dry-run reports target dir + sizes without writing", () => {
         assert.equal(r.status, 0, `--dry-run exited ${r.status}; stderr=${r.stderr}`);
         assert.match(r.stdout, /DRY RUN/);
         assert.ok(
-            r.stdout.includes(`${sandboxHome}/.copilot/extensions/ralph/`),
+            r.stdout.includes(`${sandboxHome}/.copilot/extensions/autopilot/`),
             `expected sandbox target in stdout, got: ${r.stdout}`,
         );
         const onDisk = readdirSync(resolve(REPO_ROOT, "extension")).filter((f) =>
@@ -5256,7 +5256,7 @@ test("install.sh: --dry-run reports target dir + sizes without writing", () => {
         }
         // Dry-run must NOT have created the target dir.
         assert.equal(
-            existsSync(`${sandboxHome}/.copilot/extensions/ralph`),
+            existsSync(`${sandboxHome}/.copilot/extensions/autopilot`),
             false,
             "dry-run must not create the target directory",
         );
@@ -5420,7 +5420,7 @@ test("scripts/ralph-tui-fresh.sh: emits deprecation notice on stderr and forward
     assert.equal(r.status, 0, `--help exited ${r.status}; stderr=${r.stderr}`);
     assert.match(r.stderr, /deprecated/i,
         "legacy wrapper must print a deprecation notice on stderr");
-    assert.match(r.stdout, /ralph-tui — terminal visualizer/,
+    assert.match(r.stdout, /autopilot — terminal visualizer/,
         "legacy wrapper must passthrough `--help` to bin/tui.mjs's USAGE block via autopilot-fresh.sh");
 });
 
@@ -6906,7 +6906,7 @@ test("activeLoopGuard: paused beats pendingFire when both flags are set", async 
 
 // -----------------------------------------------------------------------------
 // install.sh --project flag handling. The --project arm computes the install
-// target as $(git rev-parse --show-toplevel)/.github/extensions/ralph; if no
+// target as $(git rev-parse --show-toplevel)/.github/extensions/autopilot; if no
 // git repo is in scope, the script must refuse instead of silently writing
 // somewhere unexpected (e.g. a stale TARGET_DIR from a previous run, or worse,
 // failing partway through after mkdir clobbered something). Pin both the
@@ -6940,10 +6940,10 @@ test("install.sh: --project outside a git repo refuses with a friendly error", (
     }
 });
 
-test("install.sh: --project --dry-run reports $GIT_ROOT/.github/extensions/ralph as target", () => {
+test("install.sh: --project --dry-run reports $GIT_ROOT/.github/extensions/autopilot as target", () => {
     // Happy path: when run from the repo root (the natural working dir for
     // a contributor running ./install.sh --project), the target must land
-    // under .github/extensions/ralph rooted at the git toplevel — NOT
+    // under .github/extensions/autopilot rooted at the git toplevel — NOT
     // under $HOME, and NOT under $PWD. cmp these against the actual
     // git rev-parse output so the test still passes when REPO_ROOT is a
     // symlinked path.
@@ -6959,7 +6959,7 @@ test("install.sh: --project --dry-run reports $GIT_ROOT/.github/extensions/ralph
     assert.equal(r.status, 0, `install.sh --project --dry-run must succeed; stderr=${r.stderr}`);
     assert.match(r.stdout, /DRY RUN — no files will be written\./);
     assert.ok(
-        r.stdout.includes(`Target:    ${root}/.github/extensions/ralph/`),
+        r.stdout.includes(`Target:    ${root}/.github/extensions/autopilot/`),
         `dry-run output must report git-root-relative target dir; got:\n${r.stdout}`,
     );
     // Sanity: must NOT be the user-scoped path.
@@ -8295,7 +8295,7 @@ test("coerceNumberField: error message echoes the requested fieldName", () => {
 test("VERSION matches package.json#version (sync guard)", async () => {
     // The VERSION constant in extension/handler.mjs is hand-baked
     // because `install.sh` does not ship `package.json` to the
-    // installed copy at `~/.copilot/extensions/ralph/`. A
+    // installed copy at `~/.copilot/extensions/autopilot/`. A
     // `require("../package.json")` at module-load time would crash
     // on installed copies, so we keep the literal in source and
     // verify here that release PRs bumping `package.json#version`
@@ -9126,7 +9126,7 @@ test("install.sh: --dry-run annotates each file with [unchanged] when target equ
     const fs = await import("node:fs");
     const sandboxHome = mkdtempSync(join(tmpdir(), "ralph-install-status-unchanged-"));
     try {
-        const targetDir = `${sandboxHome}/.copilot/extensions/ralph`;
+        const targetDir = `${sandboxHome}/.copilot/extensions/autopilot`;
         fs.mkdirSync(targetDir, { recursive: true });
         const onDisk = readdirSync(resolve(REPO_ROOT, "extension"))
             .filter((f) => f.endsWith(".mjs"));
@@ -9261,7 +9261,7 @@ test("install.sh: --dry-run annotates each file with [overwrite] when target dif
     const fs = await import("node:fs");
     const sandboxHome = mkdtempSync(join(tmpdir(), "ralph-install-status-overwrite-"));
     try {
-        const targetDir = `${sandboxHome}/.copilot/extensions/ralph`;
+        const targetDir = `${sandboxHome}/.copilot/extensions/autopilot`;
         fs.mkdirSync(targetDir, { recursive: true });
         const onDisk = readdirSync(resolve(REPO_ROOT, "extension"))
             .filter((f) => f.endsWith(".mjs"));
@@ -9352,10 +9352,10 @@ test("install.sh: a successful (non-dry-run) install exits 0 (cleanup trap must 
         );
         assert.equal(r.status, 0,
             `install.sh exited ${r.status} after a clean run; cleanup() trap must return 0 when no real failure occurred. stdout=${r.stdout}; stderr=${r.stderr}`);
-        assert.match(r.stdout, /Installed ralph extension/,
+        assert.match(r.stdout, /Installed autopilot/,
             "stdout must include the success line; install.sh should run end-to-end");
         // Sanity: every file landed.
-        const installedDir = `${sandboxHome}/.copilot/extensions/ralph`;
+        const installedDir = `${sandboxHome}/.copilot/extensions/autopilot`;
         for (const f of ["extension.mjs", "handler.mjs", "events-emit.mjs"]) {
             assert.ok(existsSync(`${installedDir}/${f}`),
                 `${f} must be present in the installed dir after a clean install`);
@@ -9381,7 +9381,7 @@ test("install.sh: cleanup() returns 0 explicitly so the EXIT trap cannot leak a 
 // Iter 109 — install.sh extracts the extension's version from
 // handler.mjs's `export const VERSION = "X.Y.Z"` declaration and
 // prints it on both the dry-run header (`Version:   vX.Y.Z`) and
-// the post-install success line (`Installed ralph extension vX.Y.Z
+// the post-install success line (`Installed autopilot vX.Y.Z
 // to …`). Single source of truth: handler.mjs's VERSION constant
 // is what the running extension reports via `ap_status`, so the
 // install output cannot drift away from what's actually loaded.
@@ -9397,7 +9397,7 @@ test("install.sh: --dry-run header prints `Version: vX.Y.Z` matching extension/h
         `dry-run header must include "Version:   v${version}" so a contributor verifying an upgrade can confirm at a glance which version would be installed`);
 });
 
-test("install.sh: success line prints `Installed ralph extension vX.Y.Z` matching VERSION", () => {
+test("install.sh: success line prints `Installed autopilot vX.Y.Z` matching VERSION", () => {
     const handler = readFileSync(resolve(REPO_ROOT, "extension/handler.mjs"), "utf8");
     const version = handler.match(/^export const VERSION = "([^"]+)";/m)[1];
     const sandboxHome = mkdtempSync(join(tmpdir(), "ralph-install-success-version-"));
@@ -9408,9 +9408,9 @@ test("install.sh: success line prints `Installed ralph extension vX.Y.Z` matchin
             { encoding: "utf8", env: { ...process.env, HOME: sandboxHome } },
         );
         assert.equal(r.status, 0, `install.sh exited ${r.status}; stderr=${r.stderr}`);
-        const re = new RegExp(`✅ Installed ralph extension v${version.replace(/\./g, "\\.")} to `);
+        const re = new RegExp(`✅ Installed autopilot v${version.replace(/\./g, "\\.")} to `);
         assert.match(r.stdout, re,
-            `success line must echo "Installed ralph extension v${version} to …" so the post-install confirmation matches what ap_status reports at runtime`);
+            `success line must echo "Installed autopilot v${version} to …" so the post-install confirmation matches what ap_status reports at runtime`);
     } finally {
         rmSync(sandboxHome, { recursive: true, force: true });
     }
@@ -9420,7 +9420,7 @@ test("install.sh: VERSION extraction fails loudly if handler.mjs declaration sha
     // Drift guard: a future refactor that renames the constant or
     // changes the declaration shape MUST surface as a hard install
     // failure (non-zero exit + clear stderr) rather than silently
-    // printing "Installed ralph extension v to …". Set up an
+    // printing "Installed autopilot v to …". Set up an
     // isolated sandbox that mirrors the repo, mutate handler.mjs to
     // strip the VERSION line, and assert install.sh refuses to run.
     const fs = await import("node:fs");
@@ -9555,7 +9555,7 @@ test("ap_status: paused-without-reason summary preserves docs format even after 
 // recovery hint.
 test("install.sh: friendly diagnostic when mkdir -p fails (parent is a regular file)", async () => {
     // Force mkdir failure by pointing $HOME at a regular file —
-    // mkdir of `$HOME/.copilot/extensions/ralph` then tries to
+    // mkdir of `$HOME/.copilot/extensions/autopilot` then tries to
     // create `.copilot` inside a non-directory, which fails with
     // ENOTDIR on every platform.
     const fs = await import("node:fs");
@@ -9772,7 +9772,7 @@ test("README curl install loops use leaf-first order matching install.sh's FILES
 // would `./install.sh` install?" gets the canonical answer without
 // having to parse `--dry-run` output (which writes more verbose lines)
 // or grep handler.mjs themselves.
-test("install.sh: --version prints `copilot-ralph-extension vX.Y.Z` and exits 0", () => {
+test("install.sh: --version prints `autopilot vX.Y.Z` and exits 0", () => {
     const r = spawnSync("bash", [resolve(REPO_ROOT, "install.sh"), "--version"], {
         encoding: "utf8",
     });
@@ -9781,8 +9781,8 @@ test("install.sh: --version prints `copilot-ralph-extension vX.Y.Z` and exits 0"
     // and is allowed to change between releases.
     assert.match(
         r.stdout,
-        /^copilot-ralph-extension v\d+\.\d+\.\d+/,
-        "--version output must start with `copilot-ralph-extension vX.Y.Z`",
+        /^autopilot v\d+\.\d+\.\d+/,
+        "--version output must start with `autopilot vX.Y.Z`",
     );
     // Cross-check: the printed version must equal the constant in handler.mjs.
     const handler = readFileSync(resolve(REPO_ROOT, "extension/handler.mjs"), "utf8");
@@ -9798,7 +9798,7 @@ test("install.sh: -V short flag is an alias for --version", () => {
         encoding: "utf8",
     });
     assert.equal(r.status, 0, `-V exited ${r.status}; stderr=${r.stderr}`);
-    assert.match(r.stdout, /^copilot-ralph-extension v\d+\.\d+\.\d+/);
+    assert.match(r.stdout, /^autopilot v\d+\.\d+\.\d+/);
 });
 
 test("install.sh: --help advertises --version", () => {
@@ -9924,7 +9924,7 @@ test("install.sh --dry-run: surfaces currently-installed version when target dir
         // Branch 1: pre-seed handler.mjs with a fake older VERSION at
         // the user-scoped target path, run --dry-run again. The
         // extractor must report the seeded version verbatim.
-        const targetDir = `${sandboxHome}/.copilot/extensions/ralph`;
+        const targetDir = `${sandboxHome}/.copilot/extensions/autopilot`;
         const fs = await import("node:fs");
         fs.mkdirSync(targetDir, { recursive: true });
         fs.writeFileSync(
@@ -10087,7 +10087,7 @@ test("install.sh --dry-run: distinguishes (none) from (unknown) when target hand
     // distinct, actionable signal.
     const sandboxHome = mkdtempSync(join(tmpdir(), "ralph-install-malformed-"));
     try {
-        const targetDir = `${sandboxHome}/.copilot/extensions/ralph`;
+        const targetDir = `${sandboxHome}/.copilot/extensions/autopilot`;
         const fs = await import("node:fs");
         fs.mkdirSync(targetDir, { recursive: true });
         // Seed a handler.mjs that EXISTS but has no parseable
@@ -10234,7 +10234,7 @@ test("install.sh --dry-run prints Direction line covering fresh / no-op / upgrad
     const { mkdirSync, writeFileSync } = await import("node:fs");
     const sandboxHome = mkdtempSync(join(tmpdir(), "ralph-install-direction-"));
     try {
-        const targetDir = join(sandboxHome, ".copilot/extensions/ralph");
+        const targetDir = join(sandboxHome, ".copilot/extensions/autopilot");
         const installScript = resolve(REPO_ROOT, "install.sh");
         // Read the project's actual VERSION so we can craft synthetic
         // installed handler.mjs files relative to it (sourceVersion).
@@ -10517,7 +10517,7 @@ test("ci.yml: post-test step pins working-tree cleanliness so the iter 149 artif
     // Iter 150 — drift guard for the new "Tests must leave the
     // working tree clean" step in `.github/workflows/ci.yml`. Iter
     // 149's first commit (1f4f509) accidentally swept three
-    // install-dogfood artifacts under `.github/extensions/ralph/`
+    // install-dogfood artifacts under `.github/extensions/autopilot/`
     // into the repo via `git add -A`, inflating the diff from ~50
     // lines to 2804 insertions. The CI step catches this class of
     // regression on PR before it lands on main; this test pins the
@@ -10531,7 +10531,7 @@ test("ci.yml: post-test step pins working-tree cleanliness so the iter 149 artif
     assert.match(ci, /git diff --exit-code/,
         "ci.yml's working-tree-clean step must run `git diff --exit-code` (tracked-file modification check)");
     assert.match(ci, /git status --porcelain/,
-        "ci.yml's working-tree-clean step must also run `git status --porcelain` (untracked-file check) — `git diff` alone would have missed iter 149's untracked .github/extensions/ralph/ artifacts");
+        "ci.yml's working-tree-clean step must also run `git status --porcelain` (untracked-file check) — `git diff` alone would have missed iter 149's untracked .github/extensions/autopilot/ artifacts");
 });
 
 test("package.json author matches LICENSE copyright holder", () => {

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -5361,7 +5361,7 @@ test("scripts/ralph-tui-fresh.sh: non-`run` subcommand skips upgrade and passes 
         { encoding: "utf8", timeout: 10_000 },
     );
     assert.equal(r.status, 0, `--help exited ${r.status}; stderr=${r.stderr}`);
-    assert.match(r.stdout, /ralph-tui — terminal visualizer/,
+    assert.match(r.stdout, /autopilot — terminal visualizer/,
         "wrapper must passthrough `--help` to bin/tui.mjs's USAGE block");
 });
 

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -922,8 +922,8 @@ test("PROMPT_SELF_IMPROVE does not leak internal tool names (ap_loop/ap_stop/sel
     // their absence so a future "let's reference the tool by name"
     // edit fails loudly.
     const p = PROMPT_SELF_IMPROVE;
-    assert.equal(/\bralph_loop\b/.test(p), false, "PROMPT_SELF_IMPROVE must not mention ap_loop");
-    assert.equal(/\bralph_stop\b/.test(p), false, "PROMPT_SELF_IMPROVE must not mention ap_stop");
+    assert.equal(/\bap_loop\b/.test(p), false, "PROMPT_SELF_IMPROVE must not mention ap_loop");
+    assert.equal(/\bap_stop\b/.test(p), false, "PROMPT_SELF_IMPROVE must not mention ap_stop");
     assert.equal(/\bself_improve\b/.test(p), false, "PROMPT_SELF_IMPROVE must not mention self_improve (it IS self_improve)");
 });
 
@@ -1129,8 +1129,8 @@ test("PROMPT_GROW_PROJECT does not leak internal tool names (ap_loop/ap_stop/sel
     // and couples the prompt body to extension internals. Mirror the
     // PROMPT_SELF_IMPROVE leak guard.
     const p = PROMPT_GROW_PROJECT;
-    assert.equal(/\bralph_loop\b/.test(p), false, "PROMPT_GROW_PROJECT must not mention ap_loop");
-    assert.equal(/\bralph_stop\b/.test(p), false, "PROMPT_GROW_PROJECT must not mention ap_stop");
+    assert.equal(/\bap_loop\b/.test(p), false, "PROMPT_GROW_PROJECT must not mention ap_loop");
+    assert.equal(/\bap_stop\b/.test(p), false, "PROMPT_GROW_PROJECT must not mention ap_stop");
     assert.equal(/\bself_improve\b/.test(p), false, "PROMPT_GROW_PROJECT must not mention self_improve");
     assert.equal(/\bgrow_project\b/.test(p), false, "PROMPT_GROW_PROJECT must not mention grow_project (it IS grow_project)");
 });

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -7683,32 +7683,79 @@ test("docs/concepts.md documents the token-tracking model (issues #7 + iters 67/
 // PR cannot silently regress the loop's resilience.
 import { makeRunId, resolveRunsRoot } from "../extension/events-emit.mjs";
 
-test("events-emit resolveRunsRoot: respects $RALPH_EVENTS_DIR override", () => {
-    const r = resolveRunsRoot({ RALPH_EVENTS_DIR: "/tmp/ralph-test-runs" });
+// Stage 3 (issue #49): resolveRunsRoot now performs sentinel-gated
+// stderr deprecation notices when legacy $RALPH_EVENTS_DIR or the
+// legacy ~/.copilot/ralph/runs default path is used. These tests
+// inject a fake fs (no sentinel, accepts mkdir/append silently) and
+// a fake stderr (capturing into messages[]). The sentinelPath
+// points at a fake location so deprecation writes never touch the
+// real ~/.copilot.
+function makeFakeFsForEmit({ sentinel = "", existingPaths = new Set() } = {}) {
+    let written = "";
+    const fake = {
+        readFileSync: (p) => {
+            if (p === fake._sentinelPath) return sentinel + written;
+            const e = new Error("ENOENT");
+            e.code = "ENOENT";
+            throw e;
+        },
+        appendFileSync: (p, data) => {
+            if (p === fake._sentinelPath) written += data;
+        },
+        mkdirSync: () => {},
+        existsSync: (p) => existingPaths.has(p),
+    };
+    fake._sentinelPath = "/fake/sentinel";
+    return fake;
+}
+
+function makeFakeStderrForEmit() {
+    const messages = [];
+    return { write: (m) => { messages.push(String(m)); }, messages };
+}
+
+test("events-emit resolveRunsRoot: respects $AUTOPILOT_EVENTS_DIR override", () => {
+    const r = resolveRunsRoot({ env: { AUTOPILOT_EVENTS_DIR: "/tmp/ap-events" } });
+    assert.equal(r, "/tmp/ap-events");
+});
+
+test("events-emit resolveRunsRoot: respects $RALPH_EVENTS_DIR (legacy, with notice)", () => {
+    const fs = makeFakeFsForEmit();
+    const stderr = makeFakeStderrForEmit();
+    const r = resolveRunsRoot({
+        env: { RALPH_EVENTS_DIR: "/tmp/ralph-test-runs" },
+        fs, stderr, sentinelPath: "/fake/sentinel",
+    });
     assert.equal(r, "/tmp/ralph-test-runs");
+    assert.equal(stderr.messages.length, 1);
+    assert.match(stderr.messages[0], /RALPH_EVENTS_DIR is deprecated/);
 });
 
 test("events-emit resolveRunsRoot: falls back when env override is empty / whitespace / missing", () => {
-    // Default: ~/.copilot/ralph/runs — assert the segment shape so the
+    // Default: ~/.copilot/autopilot/events — assert the segment shape so the
     // test stays platform-portable across CI runners + dev machines.
-    const fallbackPattern = /\.copilot[\\/]ralph[\\/]runs$/;
-    assert.match(resolveRunsRoot({}), fallbackPattern,
+    const fallbackPattern = /\.copilot[\\/]autopilot[\\/]events$/;
+    const mk = () => ({ fs: makeFakeFsForEmit(), stderr: makeFakeStderrForEmit(), sentinelPath: "/fake/sentinel" });
+    assert.match(resolveRunsRoot({ env: {}, ...mk() }), fallbackPattern,
         "missing override → default fallback");
-    assert.match(resolveRunsRoot({ RALPH_EVENTS_DIR: "" }), fallbackPattern,
+    assert.match(resolveRunsRoot({ env: { AUTOPILOT_EVENTS_DIR: "" }, ...mk() }), fallbackPattern,
         "empty-string override → default fallback (not literal empty path)");
-    assert.match(resolveRunsRoot({ RALPH_EVENTS_DIR: "   " }), fallbackPattern,
+    assert.match(resolveRunsRoot({ env: { AUTOPILOT_EVENTS_DIR: "   " }, ...mk() }), fallbackPattern,
         "whitespace-only override → default fallback (trim() rejects it)");
-    assert.match(resolveRunsRoot(undefined), fallbackPattern,
+    // No env-bag at all → defaults to process.env. Real fs/stderr are
+    // used here; we only assert the path shape (autopilot or legacy).
+    assert.match(resolveRunsRoot(undefined), /\.copilot[\\/](autopilot[\\/]events|ralph[\\/]runs)$/,
         "undefined env arg → default fallback (env arg defaults to process.env)");
 });
 
 test("events-emit resolveRunsRoot: ignores non-string env override types", () => {
     // Defensive: a programmer error that injects non-string into
-    // RALPH_EVENTS_DIR should not crash makeRunId / createEventEmitter.
-    const fallbackPattern = /\.copilot[\\/]ralph[\\/]runs$/;
-    assert.match(resolveRunsRoot({ RALPH_EVENTS_DIR: 12345 }), fallbackPattern,
+    // AUTOPILOT_EVENTS_DIR should not crash makeRunId / createEventEmitter.
+    const fallbackPattern = /\.copilot[\\/]autopilot[\\/]events$/;
+    const mk = () => ({ fs: makeFakeFsForEmit(), stderr: makeFakeStderrForEmit(), sentinelPath: "/fake/sentinel" });
+    assert.match(resolveRunsRoot({ env: { AUTOPILOT_EVENTS_DIR: 12345 }, ...mk() }), fallbackPattern,
         "numeric override rejected → default fallback");
-    assert.match(resolveRunsRoot({ RALPH_EVENTS_DIR: null }), fallbackPattern,
+    assert.match(resolveRunsRoot({ env: { AUTOPILOT_EVENTS_DIR: null }, ...mk() }), fallbackPattern,
         "null override rejected → default fallback");
 });
 

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -48,8 +48,8 @@ async function arm(args = {}) {
     const session = makeFakeSession();
     const controller = createRalphController();
     controller.attach(session);
-    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
-    const stop = controller.tools.find((t) => t.name === "ralph_stop");
+    const ralph = controller.tools.find((t) => t.name === "ap_loop");
+    const stop = controller.tools.find((t) => t.name === "ap_stop");
     const armResult = await ralph.handler({ prompt: "go", max_iterations: 5, ...args });
     return { session, controller, ralph, stop, armResult };
 }
@@ -243,7 +243,7 @@ test("validateArgs: trims surrounding whitespace from completion_promise / abort
     assert.match(r2.error, /completion_promise exceeds/, r2.error);
 });
 
-test("ralph_loop: re-fires the trimmed prompt to session.send (not the raw padded input)", async () => {
+test("ap_loop: re-fires the trimmed prompt to session.send (not the raw padded input)", async () => {
     // validateArgs trims args.prompt before storing it on state.active. The
     // value re-fired each iteration should therefore be the trimmed string,
     // not the user's raw input. Without this pin, a future change that
@@ -253,7 +253,7 @@ test("ralph_loop: re-fires the trimmed prompt to session.send (not the raw padde
     const session = makeFakeSession();
     const controller = createRalphController();
     controller.attach(session);
-    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
+    const ralph = controller.tools.find((t) => t.name === "ap_loop");
     await ralph.handler({ prompt: "  go\n  ", max_iterations: 3 });
     const expected = composeRalphLoopPrompt("go").value;
     assert.equal(controller.state.active.prompt, expected);
@@ -373,8 +373,8 @@ test("validateArgs: rejects unknown keys (typo guard)", () => {
 
 test("all tool schemas declare additionalProperties:false (mirrors runtime validation)", () => {
     const c = createRalphController();
-    const ralph = c.tools.find((t) => t.name === "ralph_loop");
-    const stop = c.tools.find((t) => t.name === "ralph_stop");
+    const ralph = c.tools.find((t) => t.name === "ap_loop");
+    const stop = c.tools.find((t) => t.name === "ap_stop");
     const si = c.tools.find((t) => t.name === "self_improve");
     assert.equal(ralph.parameters.additionalProperties, false);
     assert.equal(stop.parameters.additionalProperties, false);
@@ -387,8 +387,8 @@ test("all tool schemas declare type:'object' at the root", () => {
     // type goes missing). Pin it for all three tools alongside the
     // additionalProperties:false invariant above.
     const c = createRalphController();
-    const ralph = c.tools.find((t) => t.name === "ralph_loop");
-    const stop = c.tools.find((t) => t.name === "ralph_stop");
+    const ralph = c.tools.find((t) => t.name === "ap_loop");
+    const stop = c.tools.find((t) => t.name === "ap_stop");
     const si = c.tools.find((t) => t.name === "self_improve");
     assert.equal(ralph.parameters.type, "object");
     assert.equal(stop.parameters.type, "object");
@@ -397,17 +397,17 @@ test("all tool schemas declare type:'object' at the root", () => {
 
 // ── tool spec ─────────────────────────────────────────────────────────────
 
-test("ralph_loop arm result has the documented shape (textResultForLlm + extras)", async () => {
+test("ap_loop arm result has the documented shape (textResultForLlm + extras)", async () => {
     // Pin the user-facing arm message so the README's "Result shape"
     // example doesn't drift from reality. This caught one such drift
-    // (the trailing "Use ralph_stop to cancel." sentence had been
+    // (the trailing "Use ap_stop to cancel." sentence had been
     // added to the handler but the README example wasn't updated).
     //
     // We don't use the arm() helper here because we need the raw arming
     // return value, not the {session, controller} envelope arm() returns.
     const c = createRalphController();
     c.attach(makeFakeSession());
-    const r = await c.tools.find((t) => t.name === "ralph_loop").handler({
+    const r = await c.tools.find((t) => t.name === "ap_loop").handler({
         prompt: "go", max_iterations: 20,
     });
     assert.equal(r.resultType, "success");
@@ -416,22 +416,22 @@ test("ralph_loop arm result has the documented shape (textResultForLlm + extras)
     assert.equal(r.min, 1);
     assert.equal(
         r.textResultForLlm,
-        "ralph_loop armed (max=20). Iterations will run as conversation turns. Use ralph_stop to cancel.",
+        "ap_loop armed (max=20). Iterations will run as conversation turns. Use ap_stop to cancel.",
     );
     // min > 1 path: the text adds ", min=N" inside the parens.
     const c2 = createRalphController();
     c2.attach(makeFakeSession());
-    const r2 = await c2.tools.find((t) => t.name === "ralph_loop").handler({
+    const r2 = await c2.tools.find((t) => t.name === "ap_loop").handler({
         prompt: "go", max_iterations: 5, min_iterations: 3,
     });
     assert.equal(
         r2.textResultForLlm,
-        "ralph_loop armed (max=5, min=3). Iterations will run as conversation turns. Use ralph_stop to cancel.",
+        "ap_loop armed (max=5, min=3). Iterations will run as conversation turns. Use ap_stop to cancel.",
     );
     assert.equal(r2.min, 3);
 });
 
-test("ralph_loop arm result has exactly { textResultForLlm, resultType, armed, max, min } — no stray keys", () => {
+test("ap_loop arm result has exactly { textResultForLlm, resultType, armed, max, min } — no stray keys", () => {
     // The arm-success object is constructed via `success(message, {armed, max, min})`,
     // and `success()`'s contract is `{...extra, textResultForLlm, resultType}` with
     // extra unable to override the latter two. Pin the EXACT key set so a future
@@ -440,7 +440,7 @@ test("ralph_loop arm result has exactly { textResultForLlm, resultType, armed, m
     // bloat the response and risk exposing private state.
     const c = createRalphController();
     c.attach(makeFakeSession());
-    return c.tools.find((t) => t.name === "ralph_loop").handler({
+    return c.tools.find((t) => t.name === "ap_loop").handler({
         prompt: "go", max_iterations: 7, min_iterations: 1,
     }).then((r) => {
         assert.deepEqual(
@@ -450,8 +450,8 @@ test("ralph_loop arm result has exactly { textResultForLlm, resultType, armed, m
     });
 });
 
-test("self_improve arm result has the same shape as ralph_loop's — no stray keys", async () => {
-    // Mirror of the ralph_loop arm-result shape pin. self_improve flows
+test("self_improve arm result has the same shape as ap_loop's — no stray keys", async () => {
+    // Mirror of the ap_loop arm-result shape pin. self_improve flows
     // through the same armLoop() helper and the same success(...) call,
     // so the LLM-facing shape MUST match: any divergence (e.g. an extra
     // "label" or "focus" key leaking through) is a code smell that would
@@ -554,7 +554,7 @@ test("state.active: arming sets exactly the documented 32-field ActiveLoopState 
     assert.equal(a.pendingFire, true);
     assert.equal(a.fireInFlight, false);
     assert.equal(a.observedMessageThisFire, false);
-    assert.equal(a.label, "ralph_loop");
+    assert.equal(a.label, "ap_loop");
     assert.equal(typeof a.startedAt, "number");
     assert.ok(a.startedAt > 0);
     assert.equal(a.maxTokens, null);
@@ -593,9 +593,9 @@ test("controller instances are independent (state is closure-private, not module
 });
 
 
-test("controller exposes ralph_loop, ralph_stop, ralph_pause, ralph_resume, ralph_status, self_improve, and grow_project tools and hooks", () => {
+test("controller exposes ap_loop, ap_stop, ap_pause, ap_resume, ap_status, self_improve, and grow_project tools and hooks", () => {
     const c = createRalphController();
-    assert.deepEqual(c.tools.map((t) => t.name).sort(), ["grow_project", "ralph_loop", "ralph_pause", "ralph_resume", "ralph_status", "ralph_stop", "self_improve"]);
+    assert.deepEqual(c.tools.map((t) => t.name).sort(), ["ap_loop", "ap_pause", "ap_resume", "ap_status", "ap_stop", "grow_project", "self_improve"]);
     assert.equal(typeof c.hooks.onUserPromptSubmitted, "function");
     assert.equal(typeof c.attach, "function");
     // Pin the EXACT hook surface — if a future change leaks an internal
@@ -604,16 +604,16 @@ test("controller exposes ralph_loop, ralph_stop, ralph_pause, ralph_resume, ralp
     // shipping contract is exactly one hook: onUserPromptSubmitted.
     assert.deepEqual(Object.keys(c.hooks), ["onUserPromptSubmitted"]);
     // Pin the tools-array ORDER: dozens of integration tests in this file
-    // index `c.tools[0]` for the ralph_loop handler. A future refactor
-    // that reorders the array (e.g. puts ralph_stop first) would break
+    // index `c.tools[0]` for the ap_loop handler. A future refactor
+    // that reorders the array (e.g. puts ap_stop first) would break
     // every one of those tests with confusing "wrong tool name" or
     // "missing prompt" failures. Surface the regression with one focused
     // assertion instead of a cascade of cryptic ones.
-    assert.equal(c.tools[0].name, "ralph_loop", "tools[0] must be ralph_loop");
-    assert.equal(c.tools[1].name, "ralph_stop", "tools[1] must be ralph_stop");
-    assert.equal(c.tools[2].name, "ralph_status", "tools[2] must be ralph_status");
-    assert.equal(c.tools[3].name, "ralph_pause", "tools[3] must be ralph_pause");
-    assert.equal(c.tools[4].name, "ralph_resume", "tools[4] must be ralph_resume");
+    assert.equal(c.tools[0].name, "ap_loop", "tools[0] must be ap_loop");
+    assert.equal(c.tools[1].name, "ap_stop", "tools[1] must be ap_stop");
+    assert.equal(c.tools[2].name, "ap_status", "tools[2] must be ap_status");
+    assert.equal(c.tools[3].name, "ap_pause", "tools[3] must be ap_pause");
+    assert.equal(c.tools[4].name, "ap_resume", "tools[4] must be ap_resume");
     assert.equal(c.tools[5].name, "self_improve", "tools[5] must be self_improve");
     assert.equal(c.tools[6].name, "grow_project", "tools[6] must be grow_project");
     assert.equal(c.tools.length, 7, "tools array must have exactly seven entries");
@@ -627,21 +627,21 @@ test("self_improve tool is exposed (stub)", () => {
     assert.ok(t.parameters && t.parameters.type === "object");
 });
 
-test("self_improve description tells the LLM about ralph_stop and single-loop guard", () => {
+test("self_improve description tells the LLM about ap_stop and single-loop guard", () => {
     const c = createRalphController();
     const t = c.tools.find((x) => x.name === "self_improve");
-    assert.match(t.description, /ralph_stop/, "must point users at ralph_stop for cancellation");
+    assert.match(t.description, /ap_stop/, "must point users at ap_stop for cancellation");
     assert.match(t.description, /one loop|single loop/i, "must mention single-loop-per-session");
     assert.match(t.description, /SDLC/i);
 });
 
-test("ralph_stop description names self_improve too (not just ralph_loop)", () => {
-    // ralph_stop cancels both flavors of armed loop; the tool description
+test("ap_stop description names self_improve too (not just ap_loop)", () => {
+    // ap_stop cancels both flavors of armed loop; the tool description
     // surfaced to the LLM must name both so the agent knows it can call
-    // ralph_stop on either, not assume self_improve has a separate stop.
+    // ap_stop on either, not assume self_improve has a separate stop.
     const c = createRalphController();
-    const t = c.tools.find((x) => x.name === "ralph_stop");
-    assert.match(t.description, /ralph_loop/);
+    const t = c.tools.find((x) => x.name === "ap_stop");
+    assert.match(t.description, /ap_loop/);
     assert.match(t.description, /self_improve/);
 });
 
@@ -658,23 +658,23 @@ test("self_improve arms with max=100 min=5 defaults", async () => {
     assert.match(r.textResultForLlm, /^self_improve armed/);
 });
 
-test("self_improve refuses when ralph_loop is already active", async () => {
+test("self_improve refuses when ap_loop is already active", async () => {
     const session = makeFakeSession();
     const c = createRalphController();
     c.attach(session);
-    const ralph = c.tools.find((x) => x.name === "ralph_loop");
+    const ralph = c.tools.find((x) => x.name === "ap_loop");
     const si = c.tools.find((x) => x.name === "self_improve");
     await ralph.handler({ prompt: "go", max_iterations: 5 });
     const r = await si.handler({});
     assert.equal(r.resultType, "failure");
-    assert.match(r.textResultForLlm, /ralph_loop is already/);
+    assert.match(r.textResultForLlm, /ap_loop is already/);
 });
 
-test("ralph_loop refuses when self_improve is already active", async () => {
+test("ap_loop refuses when self_improve is already active", async () => {
     const session = makeFakeSession();
     const c = createRalphController();
     c.attach(session);
-    const ralph = c.tools.find((x) => x.name === "ralph_loop");
+    const ralph = c.tools.find((x) => x.name === "ap_loop");
     const si = c.tools.find((x) => x.name === "self_improve");
     const armed = await si.handler({ max_iterations: 5 });
     assert.equal(armed.resultType, "success");
@@ -683,20 +683,20 @@ test("ralph_loop refuses when self_improve is already active", async () => {
     assert.match(r.textResultForLlm, /already/i);
     // Label-aware wording: the active loop was armed by self_improve, so
     // the error should say "self_improve is already …" — not the previous
-    // hardcoded "ralph_loop is already …" which lied about who armed it.
+    // hardcoded "ap_loop is already …" which lied about who armed it.
     assert.match(r.textResultForLlm, /^self_improve is already/);
 });
 
-test("grow_project refuses when ralph_loop is already active", async () => {
+test("grow_project refuses when ap_loop is already active", async () => {
     const session = makeFakeSession();
     const c = createRalphController();
     c.attach(session);
-    const ralph = c.tools.find((x) => x.name === "ralph_loop");
+    const ralph = c.tools.find((x) => x.name === "ap_loop");
     const gp = c.tools.find((x) => x.name === "grow_project");
     await ralph.handler({ prompt: "go", max_iterations: 5 });
     const r = await gp.handler({});
     assert.equal(r.resultType, "failure");
-    assert.match(r.textResultForLlm, /^ralph_loop is already/);
+    assert.match(r.textResultForLlm, /^ap_loop is already/);
 });
 
 test("grow_project refuses when self_improve is already active", async () => {
@@ -711,11 +711,11 @@ test("grow_project refuses when self_improve is already active", async () => {
     assert.match(r.textResultForLlm, /^self_improve is already/);
 });
 
-test("ralph_loop refuses when grow_project is already active", async () => {
+test("ap_loop refuses when grow_project is already active", async () => {
     const session = makeFakeSession();
     const c = createRalphController();
     c.attach(session);
-    const ralph = c.tools.find((x) => x.name === "ralph_loop");
+    const ralph = c.tools.find((x) => x.name === "ap_loop");
     const gp = c.tools.find((x) => x.name === "grow_project");
     const armed = await gp.handler({});
     assert.equal(armed.resultType, "success");
@@ -756,9 +756,9 @@ test("grow_project refuses when grow_project is already active", async () => {
 
 test("self_improve refuses when self_improve is already active", async () => {
     // Symmetry pin parallel to the grow_project self-block test above
-    // and the existing ralph_loop "arming twice" test. self_improve's
+    // and the existing ap_loop "arming twice" test. self_improve's
     // handler must use the SAME activeLoopGuard plumbing — re-arming
-    // it without an intervening ralph_stop must fail with the
+    // it without an intervening ap_stop must fail with the
     // label-aware "self_improve is already …" wording (proves armLoop's
     // label propagation, mirroring the cross-tool tests above).
     const session = makeFakeSession();
@@ -772,12 +772,12 @@ test("self_improve refuses when self_improve is already active", async () => {
     assert.match(second.textResultForLlm, /^self_improve is already/);
 });
 
-test("ralph_stop tears down a self_improve-armed loop", async () => {
+test("ap_stop tears down a self_improve-armed loop", async () => {
     const session = makeFakeSession();
     const c = createRalphController();
     c.attach(session);
     const si = c.tools.find((x) => x.name === "self_improve");
-    const stop = c.tools.find((x) => x.name === "ralph_stop");
+    const stop = c.tools.find((x) => x.name === "ap_stop");
     const armed = await si.handler({ max_iterations: 5 });
     assert.equal(armed.resultType, "success");
     const r = await stop.handler({ reason: "user wants out" });
@@ -792,15 +792,15 @@ test("self_improve stamps state.active.label and lastResult.label", async () => 
     const c = createRalphController();
     c.attach(session);
     const si = c.tools.find((x) => x.name === "self_improve");
-    const stop = c.tools.find((x) => x.name === "ralph_stop");
+    const stop = c.tools.find((x) => x.name === "ap_stop");
     await si.handler({ max_iterations: 5 });
     assert.equal(c.state.active.label, "self_improve");
     await stop.handler({ reason: "test" });
     assert.equal(c.state.lastResult.label, "self_improve");
 });
 
-test("ralph_stop success-text uses calling tool's label (self_improve / ralph_loop)", async () => {
-    // The ralph_stop success message used to hardcode "ralph_loop
+test("ap_stop success-text uses calling tool's label (self_improve / ap_loop)", async () => {
+    // The ap_stop success message used to hardcode "ap_loop
     // stopped after N/M iterations …" regardless of which tool armed
     // the loop. After label propagation it must read
     // "<state.active.label> stopped after …" so a self_improve-armed
@@ -811,30 +811,30 @@ test("ralph_stop success-text uses calling tool's label (self_improve / ralph_lo
         const c = createRalphController();
         c.attach(session);
         const si = c.tools.find((x) => x.name === "self_improve");
-        const stop = c.tools.find((x) => x.name === "ralph_stop");
+        const stop = c.tools.find((x) => x.name === "ap_stop");
         await si.handler({ max_iterations: 5 });
         const r = await stop.handler({ reason: "done" });
         assert.equal(r.resultType, "success");
         assert.match(r.textResultForLlm, /^self_improve stopped after 0\/5 iterations/);
-        assert.doesNotMatch(r.textResultForLlm, /^ralph_loop stopped/);
+        assert.doesNotMatch(r.textResultForLlm, /^ap_loop stopped/);
     }
-    // ralph_loop-armed branch (regression guard for the original
-    // wording — must still say "ralph_loop stopped …"):
+    // ap_loop-armed branch (regression guard for the original
+    // wording — must still say "ap_loop stopped …"):
     {
         const session = makeFakeSession();
         const c = createRalphController();
         c.attach(session);
-        const ralph = c.tools.find((x) => x.name === "ralph_loop");
-        const stop = c.tools.find((x) => x.name === "ralph_stop");
+        const ralph = c.tools.find((x) => x.name === "ap_loop");
+        const stop = c.tools.find((x) => x.name === "ap_stop");
         await ralph.handler({ prompt: "go", max_iterations: 7 });
         const r = await stop.handler({});
         assert.equal(r.resultType, "success");
-        assert.match(r.textResultForLlm, /^ralph_loop stopped after 0\/7 iterations/);
+        assert.match(r.textResultForLlm, /^ap_loop stopped after 0\/7 iterations/);
         assert.doesNotMatch(r.textResultForLlm, /^self_improve stopped/);
     }
 });
 
-test("self_improve per-iteration log line uses self_improve label, not ralph_loop", async () => {
+test("self_improve per-iteration log line uses self_improve label, not ap_loop", async () => {
     const session = makeFakeSession();
     const c = createRalphController();
     c.attach(session);
@@ -848,8 +848,8 @@ test("self_improve per-iteration log line uses self_improve label, not ralph_loo
         `expected "🔁 self_improve iter 1/5" log line, got: ${JSON.stringify(session.logs)}`,
     );
     assert.ok(
-        !session.logs.some((l) => /^🔁 ralph_loop iter/.test(l)),
-        "must not leak ralph_loop label into a self_improve-armed iteration",
+        !session.logs.some((l) => /^🔁 ap_loop iter/.test(l)),
+        "must not leak ap_loop label into a self_improve-armed iteration",
     );
 });
 
@@ -861,10 +861,10 @@ test("arm-time log line '🔁 <label> armed —' carries the calling tool's labe
     const session1 = makeFakeSession();
     const c1 = createRalphController();
     c1.attach(session1);
-    await c1.tools.find((x) => x.name === "ralph_loop").handler({ prompt: "go", max_iterations: 5 });
+    await c1.tools.find((x) => x.name === "ap_loop").handler({ prompt: "go", max_iterations: 5 });
     assert.ok(
-        session1.logs.some((l) => /^🔁 ralph_loop armed — /.test(l)),
-        `expected "🔁 ralph_loop armed —" log line, got: ${JSON.stringify(session1.logs)}`,
+        session1.logs.some((l) => /^🔁 ap_loop armed — /.test(l)),
+        `expected "🔁 ap_loop armed —" log line, got: ${JSON.stringify(session1.logs)}`,
     );
     const session2 = makeFakeSession();
     const c2 = createRalphController();
@@ -875,55 +875,55 @@ test("arm-time log line '🔁 <label> armed —' carries the calling tool's labe
         `expected "🔁 self_improve armed —" log line, got: ${JSON.stringify(session2.logs)}`,
     );
     assert.ok(
-        !session2.logs.some((l) => /^🔁 ralph_loop armed/.test(l)),
-        "must not leak ralph_loop label into a self_improve arm log",
+        !session2.logs.some((l) => /^🔁 ap_loop armed/.test(l)),
+        "must not leak ap_loop label into a self_improve arm log",
     );
 });
 
-test("ralph_loop per-iteration log line uses ralph_loop label, not self_improve", async () => {
+test("ap_loop per-iteration log line uses ap_loop label, not self_improve", async () => {
     // Mirror of the self_improve label test above — when armed via
-    // ralph_loop, the iter-log line must read "🔁 ralph_loop iter N/M"
+    // ap_loop, the iter-log line must read "🔁 ap_loop iter N/M"
     // and never carry a "🔁 self_improve" prefix.
     const session = makeFakeSession();
     const c = createRalphController();
     c.attach(session);
-    const ralph = c.tools.find((x) => x.name === "ralph_loop");
+    const ralph = c.tools.find((x) => x.name === "ap_loop");
     await ralph.handler({ prompt: "go", max_iterations: 5 });
     session.emit("session.idle", { data: {} });
     await new Promise((r) => setTimeout(r, 0));
     assert.ok(
-        session.logs.some((l) => /^🔁 ralph_loop iter 1\/5/.test(l)),
-        `expected "🔁 ralph_loop iter 1/5" log line, got: ${JSON.stringify(session.logs)}`,
+        session.logs.some((l) => /^🔁 ap_loop iter 1\/5/.test(l)),
+        `expected "🔁 ap_loop iter 1/5" log line, got: ${JSON.stringify(session.logs)}`,
     );
     assert.ok(
         !session.logs.some((l) => /^🔁 self_improve iter/.test(l)),
-        "must not leak self_improve label into a ralph_loop-armed iteration",
+        "must not leak self_improve label into a ap_loop-armed iteration",
     );
 });
 
-test("ralph_loop stamps state.active.label and lastResult.label", async () => {
+test("ap_loop stamps state.active.label and lastResult.label", async () => {
     const session = makeFakeSession();
     const c = createRalphController();
     c.attach(session);
-    const ralph = c.tools.find((x) => x.name === "ralph_loop");
-    const stop = c.tools.find((x) => x.name === "ralph_stop");
+    const ralph = c.tools.find((x) => x.name === "ap_loop");
+    const stop = c.tools.find((x) => x.name === "ap_stop");
     await ralph.handler({ prompt: "go", max_iterations: 5 });
-    assert.equal(c.state.active.label, "ralph_loop");
+    assert.equal(c.state.active.label, "ap_loop");
     await stop.handler({ reason: "test" });
-    assert.equal(c.state.lastResult.label, "ralph_loop");
+    assert.equal(c.state.lastResult.label, "ap_loop");
 });
 
-test("PROMPT_SELF_IMPROVE does not leak internal tool names (ralph_loop/ralph_stop/self_improve)", () => {
+test("PROMPT_SELF_IMPROVE does not leak internal tool names (ap_loop/ap_stop/self_improve)", () => {
     // Defence against copy-paste drift: the SDLC prompt is text shown
     // to the agent doing the work, not to a tool dispatcher. Mentioning
-    // ralph_loop / ralph_stop / self_improve inside it would either
-    // confuse the agent (does it call ralph_stop itself?) or make the
+    // ap_loop / ap_stop / self_improve inside it would either
+    // confuse the agent (does it call ap_stop itself?) or make the
     // prompt project-specific (the goal is project-AGNOSTIC). Pin
     // their absence so a future "let's reference the tool by name"
     // edit fails loudly.
     const p = PROMPT_SELF_IMPROVE;
-    assert.equal(/\bralph_loop\b/.test(p), false, "PROMPT_SELF_IMPROVE must not mention ralph_loop");
-    assert.equal(/\bralph_stop\b/.test(p), false, "PROMPT_SELF_IMPROVE must not mention ralph_stop");
+    assert.equal(/\bralph_loop\b/.test(p), false, "PROMPT_SELF_IMPROVE must not mention ap_loop");
+    assert.equal(/\bralph_stop\b/.test(p), false, "PROMPT_SELF_IMPROVE must not mention ap_stop");
     assert.equal(/\bself_improve\b/.test(p), false, "PROMPT_SELF_IMPROVE must not mention self_improve (it IS self_improve)");
 });
 
@@ -1121,16 +1121,16 @@ test("self_improve actually arms with the real SDLC prompt", async () => {
     assert.equal(session.sent[0]?.prompt, PROMPT_SELF_IMPROVE);
 });
 
-test("PROMPT_GROW_PROJECT does not leak internal tool names (ralph_loop/ralph_stop/self_improve/grow_project)", () => {
+test("PROMPT_GROW_PROJECT does not leak internal tool names (ap_loop/ap_stop/self_improve/grow_project)", () => {
     // The baked SDLC prompt is fired into a sub-agent that has no
     // notion of this extension's internal tool names. Leaking
-    // `ralph_loop` / `ralph_stop` / `self_improve` / `grow_project`
+    // `ap_loop` / `ap_stop` / `self_improve` / `grow_project`
     // into the prompt confuses the agent (it tries to invoke them)
     // and couples the prompt body to extension internals. Mirror the
     // PROMPT_SELF_IMPROVE leak guard.
     const p = PROMPT_GROW_PROJECT;
-    assert.equal(/\bralph_loop\b/.test(p), false, "PROMPT_GROW_PROJECT must not mention ralph_loop");
-    assert.equal(/\bralph_stop\b/.test(p), false, "PROMPT_GROW_PROJECT must not mention ralph_stop");
+    assert.equal(/\bralph_loop\b/.test(p), false, "PROMPT_GROW_PROJECT must not mention ap_loop");
+    assert.equal(/\bralph_stop\b/.test(p), false, "PROMPT_GROW_PROJECT must not mention ap_stop");
     assert.equal(/\bself_improve\b/.test(p), false, "PROMPT_GROW_PROJECT must not mention self_improve");
     assert.equal(/\bgrow_project\b/.test(p), false, "PROMPT_GROW_PROJECT must not mention grow_project (it IS grow_project)");
 });
@@ -1406,10 +1406,10 @@ test("PROMPT_GROW_PROJECT bakes the dual Co-authored-by trailer + RALPH_NO_ATTRI
     assert.match(p, /\balways\s+ship/i, "must promise the Copilot trailer (and Closes #N) always ship");
 });
 
-test("BAKED_RALPH_LOOP_RIDER bakes the dual Co-authored-by trailer + RALPH_NO_ATTRIBUTION opt-out (issue #1, ralph_loop parity)", () => {
-    // ralph_loop parity with self_improve / grow_project: every
+test("BAKED_RALPH_LOOP_RIDER bakes the dual Co-authored-by trailer + RALPH_NO_ATTRIBUTION opt-out (issue #1, ap_loop parity)", () => {
+    // ap_loop parity with self_improve / grow_project: every
     // loop-driven commit must carry the dual trailer. Because
-    // ralph_loop's prompt is user-supplied, the rider is appended
+    // ap_loop's prompt is user-supplied, the rider is appended
     // at arm time. Pin the same invariants the SDLC prompts enforce
     // so a future edit can't silently drop the bot-account trailer
     // or invert the opt-out polarity.
@@ -1424,7 +1424,7 @@ test("BAKED_RALPH_LOOP_RIDER bakes the dual Co-authored-by trailer + RALPH_NO_AT
     // surfaces the first co-author more prominently).
     assert.ok(r.indexOf(BAKED_COPILOT_TRAILER) < r.indexOf(BAKED_RALPH_TRAILER), "Copilot trailer must appear before copilot-ralph in the rider");
     // Rider must be inert when no commit is created — generic
-    // ralph_loop tasks (log analysis, etc.) shouldn't be forced
+    // ap_loop tasks (log analysis, etc.) shouldn't be forced
     // to invent a commit just to satisfy the trailer policy.
     assert.match(r, /no commit|creates no commit|does not commit|do(?: not|n't) commit/i, "rider must explicitly opt out when the iteration creates no commit");
 });
@@ -1452,8 +1452,8 @@ test("composeRalphLoopPrompt rejects a user prompt that would push the composed 
     assert.match(r.error ?? "", new RegExp(`exceeds ${MAX_PROMPT_CHARS}`));
 });
 
-test("ralph_loop handler appends the rider to the user-supplied prompt before re-injection", async () => {
-    // Behavioral test: arm ralph_loop with a generic prompt and assert
+test("ap_loop handler appends the rider to the user-supplied prompt before re-injection", async () => {
+    // Behavioral test: arm ap_loop with a generic prompt and assert
     // that the prompt ACTUALLY sent via session.send each iteration
     // contains both trailers + the opt-out env var. This closes the
     // loophole where a future refactor could compute the rider but
@@ -1461,7 +1461,7 @@ test("ralph_loop handler appends the rider to the user-supplied prompt before re
     const session = makeFakeSession();
     const controller = createRalphController();
     controller.attach(session);
-    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
+    const ralph = controller.tools.find((t) => t.name === "ap_loop");
     await ralph.handler({ prompt: "investigate the logs", max_iterations: 3 });
     session.emit("session.idle", { data: {} });
     runTurn(session, "still working");
@@ -1659,7 +1659,7 @@ test("grow_project appends focus text to PROMPT_GROW_PROJECT", async () => {
 });
 
 test("calling grow_project before attach fails fast with a grow_project-labelled error and does NOT arm", async () => {
-    // Mirror of the self_improve / ralph_loop pins. requireAttachedSession()
+    // Mirror of the self_improve / ap_loop pins. requireAttachedSession()
     // weaves the calling tool's name through the message; a regression that
     // drops the label would lie about which tool the caller invoked.
     const c = createRalphController();
@@ -1673,7 +1673,7 @@ test("calling grow_project before attach fails fast with a grow_project-labelled
 test("grow_project rejects unknown keys with a grow_project-prefixed error", async () => {
     // validateOptionalArgShape catches typos and stale arg names before
     // they silently pass through validateArgs unrecognised. The error
-    // must carry the grow_project: prefix, not ralph_loop:.
+    // must carry the grow_project: prefix, not ap_loop:.
     const session = makeFakeSession();
     const c = createRalphController();
     c.attach(session);
@@ -1697,9 +1697,9 @@ test("self_improve respects max_iterations / min_iterations overrides", async ()
 });
 
 test("self_improve rejects min_iterations > max_iterations with self_improve prefix", async () => {
-    // Mirror of the ralph_loop "min_iterations must be ≤ max_iterations"
+    // Mirror of the ap_loop "min_iterations must be ≤ max_iterations"
     // test — self_improve delegates to validateArgs, which emits the
-    // error with a "ralph_loop:" prefix, then the handler must rewrite
+    // error with a "ap_loop:" prefix, then the handler must rewrite
     // it to "self_improve:" before returning.
     const session = makeFakeSession();
     const c = createRalphController();
@@ -1709,7 +1709,7 @@ test("self_improve rejects min_iterations > max_iterations with self_improve pre
     assert.equal(r.resultType, "failure");
     assert.match(r.textResultForLlm, /^self_improve:/);
     assert.match(r.textResultForLlm, /min_iterations/);
-    assert.doesNotMatch(r.textResultForLlm, /ralph_loop:/);
+    assert.doesNotMatch(r.textResultForLlm, /ap_loop:/);
 });
 
 test("self_improve rejects unknown args", async () => {
@@ -1763,7 +1763,7 @@ test("self_improve rejects array/primitive args; accepts null/undefined", async 
     assert.equal(ok1.resultType, "success");
     assert.equal(c.state.active.label, "self_improve");
     // Tear down before re-arming to satisfy the single-loop guard.
-    const stop = c.tools.find((x) => x.name === "ralph_stop");
+    const stop = c.tools.find((x) => x.name === "ap_stop");
     await stop.handler({});
     const ok2 = await t.handler(undefined);
     assert.equal(ok2.resultType, "success");
@@ -1773,7 +1773,7 @@ test("self_improve rejects array/primitive args; accepts null/undefined", async 
 test("arming grow_project sets state.active.label to 'grow_project'", async () => {
     // Pin the label because finish() logs ("<label>: stopped after …"),
     // the active-loop guard's "armed by <label>" wording, and the
-    // ralph_stop "stopped <label> after N iterations" line all derive
+    // ap_stop "stopped <label> after N iterations" line all derive
     // from state.active.label. A future refactor that armLoop'd
     // grow_project with the wrong literal (e.g. copy-pasted "self_improve"
     // from the sibling block) would silently mislabel every log line
@@ -1787,7 +1787,7 @@ test("arming grow_project sets state.active.label to 'grow_project'", async () =
     assert.equal(r.resultType, "success");
     assert.equal(c.state.active.label, "grow_project");
     assert.notEqual(c.state.active.label, "self_improve");
-    assert.notEqual(c.state.active.label, "ralph_loop");
+    assert.notEqual(c.state.active.label, "ap_loop");
 });
 
 test("self_improve schema declares max_iterations / min_iterations bounds matching runtime", () => {
@@ -1847,14 +1847,14 @@ test("self_improve and grow_project schema descriptions disclose the baked-promp
     assert.equal(/ABORT_NO_IMPROVEMENTS/.test(gpAp), false, "grow_project.abort_promise must NOT mention self_improve's token");
 });
 
-test("ralph_loop schema declares max/min/stagnation/completion/abort bounds matching runtime", () => {
-    // Mirror of the self_improve bounds tests: pin ralph_loop's
+test("ap_loop schema declares max/min/stagnation/completion/abort bounds matching runtime", () => {
+    // Mirror of the self_improve bounds tests: pin ap_loop's
     // numeric and string schema bounds so a future "harmless" tweak
     // to MAX_ALLOWED_ITERATIONS, MAX_PROMISE_CHARS, MAX_PROMPT_CHARS
     // or the DEFAULTS dict can't drift the schema away from the
     // runtime validator without a loud test-suite failure.
     const c = createRalphController();
-    const rl = c.tools.find((t) => t.name === "ralph_loop");
+    const rl = c.tools.find((t) => t.name === "ap_loop");
     const p = rl.parameters.properties;
 
     assert.equal(p.prompt.type, "string");
@@ -1889,7 +1889,7 @@ test("ralph_loop schema declares max/min/stagnation/completion/abort bounds matc
     assert.deepEqual(rl.parameters.required, ["prompt"], "prompt is the only required arg");
 });
 
-test("ralph_loop & ralph_stop schema properties match their KEYS sets", () => {
+test("ap_loop & ap_stop schema properties match their KEYS sets", () => {
     // Mirror of the self_improve schema-vs-KEYS-set drift test
     // (above). Same rationale: a divergence between the
     // JSON-schema's advertised properties and the Set used by
@@ -1897,7 +1897,7 @@ test("ralph_loop & ralph_stop schema properties match their KEYS sets", () => {
     // rejected" arg or an "accepted but undocumented" arg. Pin both
     // tools the same way so the invariant is enforced uniformly.
     const c = createRalphController();
-    const rl = c.tools.find((t) => t.name === "ralph_loop");
+    const rl = c.tools.find((t) => t.name === "ap_loop");
     assert.deepEqual(Object.keys(rl.parameters.properties).sort(), [
         "abort_promise",
         "adaptive_budget",
@@ -1910,10 +1910,10 @@ test("ralph_loop & ralph_stop schema properties match their KEYS sets", () => {
         "prompt",
         "stagnation_limit",
         "warn_at_pct",
-    ], "ralph_loop schema properties must match RALPH_LOOP_KEYS exactly");
-    const rs = c.tools.find((t) => t.name === "ralph_stop");
+    ], "ap_loop schema properties must match RALPH_LOOP_KEYS exactly");
+    const rs = c.tools.find((t) => t.name === "ap_stop");
     assert.deepEqual(Object.keys(rs.parameters.properties).sort(), ["reason"],
-        "ralph_stop schema properties must match RALPH_STOP_KEYS exactly");
+        "ap_stop schema properties must match RALPH_STOP_KEYS exactly");
 });
 
 test("self_improve schema properties match SELF_IMPROVE_KEYS membership exactly", () => {
@@ -2008,40 +2008,40 @@ test("grow_project schema declares max/min/completion/abort/stagnation/focus bou
     assert.equal(p.focus.maxLength, MAX_FOCUS_CHARS);
 });
 
-test("ralph_stop schema description names all three loop tools it can cancel", () => {
-    // Same family as the gp-15/gp-23 disclosure pins: ralph_stop is
+test("ap_stop schema description names all three loop tools it can cancel", () => {
+    // Same family as the gp-15/gp-23 disclosure pins: ap_stop is
     // the symmetric cancel endpoint for all three loop arms. Its
-    // description hardcoded "ralph_loop or self_improve" until iter
+    // description hardcoded "ap_loop or self_improve" until iter
     // gp-24 and never mentioned grow_project, so an LLM dispatcher
     // searching the schema for "grow_project" had no signal that
-    // ralph_stop was the right tool to cancel one. Pin the
+    // ap_stop was the right tool to cancel one. Pin the
     // disclosure for all three peers — symmetric with the per-tool
     // description pins — so a future fourth-tool addition is forced
     // to update this string too.
     const c = createRalphController();
-    const rs = c.tools.find((t) => t.name === "ralph_stop");
-    assert.match(rs.description, /ralph_loop/, "must name ralph_loop");
+    const rs = c.tools.find((t) => t.name === "ap_stop");
+    assert.match(rs.description, /ap_loop/, "must name ap_loop");
     assert.match(rs.description, /self_improve/, "must name self_improve");
     assert.match(rs.description, /grow_project/, "must name grow_project");
 });
 
-test("ralph_loop schema description discloses all three loop conflict siblings", () => {
+test("ap_loop schema description discloses all three loop conflict siblings", () => {
     // Mirror of the self_improve / grow_project disclosure pins.
-    // ralph_loop is the lowest-level tool but its activeLoopGuard
-    // blocks symmetrically — calling ralph_loop while a self_improve
+    // ap_loop is the lowest-level tool but its activeLoopGuard
+    // blocks symmetrically — calling ap_loop while a self_improve
     // or grow_project loop is active fails fast. The schema
     // description must surface that contract so the LLM dispatcher
     // doesn't have to learn it through a runtime failure.
     const c = createRalphController();
-    const rl = c.tools.find((t) => t.name === "ralph_loop");
+    const rl = c.tools.find((t) => t.name === "ap_loop");
     assert.match(rl.description, /self_improve/, "must disclose conflict with self_improve");
     assert.match(rl.description, /grow_project/, "must disclose conflict with grow_project");
-    assert.match(rl.description, /ralph_stop/, "must disclose ralph_stop as the cancel mechanism");
+    assert.match(rl.description, /ap_stop/, "must disclose ap_stop as the cancel mechanism");
 });
 
 test("self_improve schema description discloses all three loop conflict siblings", () => {
     // Iter gp-15 finding: when grow_project shipped as a third peer,
-    // self_improve's description still said "ralph_loop or
+    // self_improve's description still said "ap_loop or
     // self_improve" — it did not mention grow_project even though
     // grow_project now also blocks self_improve. Pin the disclosure
     // for all three peers symmetric with the grow_project pin so a
@@ -2050,23 +2050,23 @@ test("self_improve schema description discloses all three loop conflict siblings
     // is caught loudly).
     const c = createRalphController();
     const si = c.tools.find((t) => t.name === "self_improve");
-    assert.match(si.description, /ralph_loop/);
+    assert.match(si.description, /ap_loop/);
     assert.match(si.description, /grow_project/, "must disclose conflict with grow_project");
-    assert.match(si.description, /ralph_stop/, "must disclose ralph_stop as the cancel mechanism");
+    assert.match(si.description, /ap_stop/, "must disclose ap_stop as the cancel mechanism");
 });
 
 test("grow_project schema description mentions the active-loop conflict siblings", () => {
     // Schema description is the public contract the LLM sees. It must
-    // explicitly call out that grow_project / ralph_loop / self_improve
+    // explicitly call out that grow_project / ap_loop / self_improve
     // share state — otherwise the model has no way to learn about the
     // conflict until it hits a runtime failure. Pin the contract so a
     // future "trim the description" refactor can't silently drop the
     // disclosure.
     const c = createRalphController();
     const gp = c.tools.find((t) => t.name === "grow_project");
-    assert.match(gp.description, /ralph_loop/, "must disclose conflict with ralph_loop");
+    assert.match(gp.description, /ap_loop/, "must disclose conflict with ap_loop");
     assert.match(gp.description, /self_improve/, "must disclose conflict with self_improve");
-    assert.match(gp.description, /ralph_stop/, "must disclose ralph_stop as the cancel mechanism");
+    assert.match(gp.description, /ap_stop/, "must disclose ap_stop as the cancel mechanism");
 });
 
 test("self_improve schema declares completion/abort/stagnation bounds matching runtime", () => {
@@ -2158,7 +2158,7 @@ test("self_improve rejects non-string focus", async () => {
 test("grow_project rejects focus over MAX_FOCUS_CHARS, accepts the boundary, and rejects whitespace/non-string", async () => {
     // Mirror of the four self_improve focus-bound pins, consolidated:
     // each path must surface the grow_project: prefix (not the
-    // delegated ralph_loop: prefix from validateArgs).
+    // delegated ap_loop: prefix from validateArgs).
     const c = createRalphController();
     const session = makeFakeSession();
     c.attach(session);
@@ -2167,7 +2167,7 @@ test("grow_project rejects focus over MAX_FOCUS_CHARS, accepts the boundary, and
     const tooBig = await t.handler({ focus: "x".repeat(MAX_FOCUS_CHARS + 1) });
     assert.equal(tooBig.resultType, "failure");
     assert.match(tooBig.textResultForLlm, new RegExp(`^grow_project: focus exceeds ${MAX_FOCUS_CHARS}`));
-    assert.doesNotMatch(tooBig.textResultForLlm, /ralph_loop:/);
+    assert.doesNotMatch(tooBig.textResultForLlm, /ap_loop:/);
 
     // Boundary: trimmed.length === MAX_FOCUS_CHARS must arm. The
     // handler check is `> MAX_FOCUS_CHARS`, so an off-by-one
@@ -2327,12 +2327,12 @@ test("all three tools arm with completionPromise='COMPLETE' when caller omits co
     // changed DEFAULTS.completion_promise) would silently mis-arm: the
     // baked PROMPT_* prompts emit "COMPLETE" but the loop watcher would
     // be looking for something else, so completion would never fire.
-    for (const name of ["ralph_loop", "self_improve", "grow_project"]) {
+    for (const name of ["ap_loop", "self_improve", "grow_project"]) {
         const session = makeFakeSession();
         const c = createRalphController();
         c.attach(session);
         const t = c.tools.find((x) => x.name === name);
-        const args = name === "ralph_loop"
+        const args = name === "ap_loop"
             ? { prompt: "x", max_iterations: 1, min_iterations: 1 }
             : { max_iterations: 1, min_iterations: 1 };
         const r = await t.handler(args);
@@ -2344,7 +2344,7 @@ test("all three tools arm with completionPromise='COMPLETE' when caller omits co
 
 test("grow_project rewrites delegated bound errors with grow_project prefix", async () => {
     // Mirror of iter 17/the equivalent self_improve test: validateArgs
-    // emits ralph_loop:-prefixed errors; the handler rewrites them so
+    // emits ap_loop:-prefixed errors; the handler rewrites them so
     // the caller sees grow_project: in the error stream.
     const session = makeFakeSession();
     const c = createRalphController();
@@ -2353,7 +2353,7 @@ test("grow_project rewrites delegated bound errors with grow_project prefix", as
     const tooBig = await t.handler({ max_iterations: 99999 });
     assert.equal(tooBig.resultType, "failure");
     assert.match(tooBig.textResultForLlm, /^grow_project:/);
-    assert.doesNotMatch(tooBig.textResultForLlm, /ralph_loop:/);
+    assert.doesNotMatch(tooBig.textResultForLlm, /ap_loop:/);
     const tooSmall = await t.handler({ max_iterations: 0 });
     assert.equal(tooSmall.resultType, "failure");
     assert.match(tooSmall.textResultForLlm, /^grow_project:/);
@@ -2367,7 +2367,7 @@ test("grow_project rejects stagnation_limit=1 with grow_project prefix", async (
     const r = await t.handler({ stagnation_limit: 1 });
     assert.equal(r.resultType, "failure");
     assert.match(r.textResultForLlm, /^grow_project:/);
-    assert.doesNotMatch(r.textResultForLlm, /ralph_loop:/);
+    assert.doesNotMatch(r.textResultForLlm, /ap_loop:/);
 });
 
 test("self_improve rewrites delegated bound errors with self_improve prefix", async () => {
@@ -2378,7 +2378,7 @@ test("self_improve rewrites delegated bound errors with self_improve prefix", as
     const tooBig = await t.handler({ max_iterations: 99999 });
     assert.equal(tooBig.resultType, "failure");
     assert.match(tooBig.textResultForLlm, /^self_improve:/);
-    assert.doesNotMatch(tooBig.textResultForLlm, /ralph_loop:/);
+    assert.doesNotMatch(tooBig.textResultForLlm, /ap_loop:/);
     const tooSmall = await t.handler({ max_iterations: 0 });
     assert.equal(tooSmall.resultType, "failure");
     assert.match(tooSmall.textResultForLlm, /^self_improve:/);
@@ -2392,7 +2392,7 @@ test("self_improve rejects stagnation_limit=1 with self_improve prefix", async (
     const r = await t.handler({ stagnation_limit: 1 });
     assert.equal(r.resultType, "failure");
     assert.match(r.textResultForLlm, /^self_improve:/);
-    assert.doesNotMatch(r.textResultForLlm, /ralph_loop:/);
+    assert.doesNotMatch(r.textResultForLlm, /ap_loop:/);
 });
 
 test("self_improve warns when completion_promise / abort_promise drift from the baked SDLC prompt's emit tokens", async () => {
@@ -2532,12 +2532,12 @@ test("self_improve rejects overlapping completion/abort phrases with self_improv
     assert.equal(r.resultType, "failure");
     assert.match(r.textResultForLlm, /^self_improve:/);
     assert.match(r.textResultForLlm, /overlap/i);
-    assert.doesNotMatch(r.textResultForLlm, /ralph_loop:/);
+    assert.doesNotMatch(r.textResultForLlm, /ap_loop:/);
 });
 
 test("grow_project rejects overlapping completion/abort phrases with grow_project prefix", async () => {
     // Mirror of the self_improve overlap-rejection test for grow_project's
-    // error-prefix rewrite (`ralph_loop:` → `grow_project:`). The most
+    // error-prefix rewrite (`ap_loop:` → `grow_project:`). The most
     // intuitive footgun here is *swapping* the baked tokens — passing
     // completion_promise: "ABORT_NO_BACKLOG", abort_promise: "COMPLETE"
     // — because both substrings are baked into PROMPT_GROW_PROJECT and
@@ -2545,7 +2545,7 @@ test("grow_project rejects overlapping completion/abort phrases with grow_projec
     // The substring-overlap check ("ABORT_NO_BACKLOG" ⊃ "COMPLETE"? no;
     // but identical-or-substring catches the more common "DONE"/"DONE_NOW"
     // case) must surface with the `grow_project:` prefix, not the inner
-    // `ralph_loop:` prefix from the shared validator.
+    // `ap_loop:` prefix from the shared validator.
     const session = makeFakeSession();
     const c = createRalphController();
     c.attach(session);
@@ -2554,7 +2554,7 @@ test("grow_project rejects overlapping completion/abort phrases with grow_projec
     assert.equal(r.resultType, "failure");
     assert.match(r.textResultForLlm, /^grow_project:/);
     assert.match(r.textResultForLlm, /overlap/i);
-    assert.doesNotMatch(r.textResultForLlm, /ralph_loop:/);
+    assert.doesNotMatch(r.textResultForLlm, /ap_loop:/);
 });
 
 test("public tools and hooks surface is frozen (defensive against accidental mutation)", () => {
@@ -2567,7 +2567,7 @@ test("public tools and hooks surface is frozen (defensive against accidental mut
     assert.throws(() => { c.hooks.onUserPromptSubmitted = null; }, TypeError);
     // Deep freeze: nested parameters/properties also locked so a consumer
     // can't tweak the declared JSON-schema bounds at runtime.
-    const ralphTool = c.tools.find((t) => t.name === "ralph_loop");
+    const ralphTool = c.tools.find((t) => t.name === "ap_loop");
     assert.ok(Object.isFrozen(ralphTool.parameters));
     assert.ok(Object.isFrozen(ralphTool.parameters.properties));
     assert.ok(Object.isFrozen(ralphTool.parameters.properties.prompt));
@@ -2584,8 +2584,8 @@ test("public tools and hooks surface is frozen (defensive against accidental mut
     assert.ok(Object.isFrozen(ralphTool.parameters.required));
     assert.throws(() => { ralphTool.parameters.required.push("max_iterations"); }, TypeError);
     assert.throws(() => { ralphTool.parameters.properties.max_iterations.maximum = 999999; }, TypeError);
-    // ralph_stop tool surface is also frozen (same defensive contract).
-    const stopTool = c.tools.find((t) => t.name === "ralph_stop");
+    // ap_stop tool surface is also frozen (same defensive contract).
+    const stopTool = c.tools.find((t) => t.name === "ap_stop");
     assert.ok(Object.isFrozen(stopTool.parameters));
     assert.ok(Object.isFrozen(stopTool.parameters.properties));
     assert.throws(() => { stopTool.parameters.properties.reason.maxLength = 9999; }, TypeError);
@@ -2624,16 +2624,16 @@ test("DEFAULTS object is frozen — defaults cannot be mutated at runtime", () =
     assert.equal(DEFAULTS.stagnation_limit, 3);
 });
 
-test("ralph_loop tool spec includes stagnation_limit and required prompt", () => {
+test("ap_loop tool spec includes stagnation_limit and required prompt", () => {
     const c = createRalphController();
-    const t = c.tools.find((x) => x.name === "ralph_loop");
+    const t = c.tools.find((x) => x.name === "ap_loop");
     assert.ok(t.parameters.properties.stagnation_limit);
     assert.deepEqual(t.parameters.required, ["prompt"]);
 });
 
-test("ralph_loop tool spec declares numeric ranges (minimum/maximum) on integer params", () => {
+test("ap_loop tool spec declares numeric ranges (minimum/maximum) on integer params", () => {
     const c = createRalphController();
-    const t = c.tools.find((x) => x.name === "ralph_loop");
+    const t = c.tools.find((x) => x.name === "ap_loop");
     const p = t.parameters.properties;
     // max_iterations: 1..MAX_ALLOWED_ITERATIONS — bound to the runtime cap
     // so a future bump to MAX_ALLOWED_ITERATIONS automatically widens the
@@ -2660,9 +2660,9 @@ test("ralph_loop tool spec declares numeric ranges (minimum/maximum) on integer 
     assert.equal(p.prompt.maxLength, MAX_PROMPT_CHARS);
 });
 
-test("ralph_stop tool spec declares maxLength on optional reason", () => {
+test("ap_stop tool spec declares maxLength on optional reason", () => {
     const c = createRalphController();
-    const t = c.tools.find((x) => x.name === "ralph_stop");
+    const t = c.tools.find((x) => x.name === "ap_stop");
     // Locked to PREVIEW_CHARS / truncateNote cap so clients learn the bound up-front
     // and a runtime cap change automatically updates the schema.
     assert.equal(t.parameters.properties.reason.maxLength, PREVIEW_CHARS);
@@ -2676,7 +2676,7 @@ test("schema `default` fields stay in lockstep with the DEFAULTS source-of-truth
     // LLM sees one number and the runtime applies another — the user gets
     // mysterious "expected default" surprises. Pin the equality.
     const c = createRalphController();
-    const p = c.tools.find((x) => x.name === "ralph_loop").parameters.properties;
+    const p = c.tools.find((x) => x.name === "ap_loop").parameters.properties;
     const { DEFAULTS } = __test__;
     assert.equal(p.max_iterations.default, DEFAULTS.max_iterations);
     assert.equal(p.min_iterations.default, DEFAULTS.min_iterations);
@@ -2702,14 +2702,14 @@ test("tool parameters round-trip through JSON.stringify without losing fields", 
     }
 });
 
-test("ralph_loop tool description matches the actual refire trigger (session.idle)", () => {
+test("ap_loop tool description matches the actual refire trigger (session.idle)", () => {
     // Pin the user-facing description so a future refactor that changes the
     // event we listen on (or vice-versa, that re-introduces a stale "turn_end"
     // mention) is caught by tests rather than mis-informing tool consumers.
     // The earlier description still claimed "assistant turn_end" long after
     // the implementation switched to session.idle.
     const c = createRalphController();
-    const t = c.tools.find((x) => x.name === "ralph_loop");
+    const t = c.tools.find((x) => x.name === "ap_loop");
     assert.match(t.description, /session\.idle/, "description must mention session.idle");
     assert.doesNotMatch(t.description, /turn_end/, "description must not mention the obsolete turn_end trigger");
 });
@@ -2746,12 +2746,12 @@ test("arming twice while active is rejected", async () => {
     assert.equal(controller.state.active.i, 1);
     // Same paren-balance guard as the "already armed" branch — the
     // "running" template path is rendered separately, so pin it too.
-    assert.match(r.textResultForLlm, /\(iteration 1\/9\) — call ralph_stop first\.$/);
+    assert.match(r.textResultForLlm, /\(iteration 1\/9\) — call ap_stop first\.$/);
     assert.doesNotMatch(r.textResultForLlm, /first\)\./);
 });
 
 test("arming twice before first turn_end shows clearer 'armed' message", async () => {
-    // Race: ralph_loop called, then ralph_loop called again before any
+    // Race: ap_loop called, then ap_loop called again before any
     // turn_end has fired (state.active.i === 0). The error message used to
     // confusingly say "iteration 0/max"; now it says "armed (iteration 1/max
     // pending …)".
@@ -2767,7 +2767,7 @@ test("arming twice before first turn_end shows clearer 'armed' message", async (
     // Parens around the status clause must be balanced and the sentence
     // must end with a clean period — guards against a regression where
     // the close-paren was misplaced after the period ("first).").
-    assert.match(r.textResultForLlm, /\(iteration 1\/7 pending\) — call ralph_stop first\.$/);
+    assert.match(r.textResultForLlm, /\(iteration 1\/7 pending\) — call ap_stop first\.$/);
     assert.doesNotMatch(r.textResultForLlm, /first\)\./);
 });
 
@@ -3056,9 +3056,9 @@ test("stagnation: two identical empty-string responses trigger stagnation (silen
     assert.equal(controller.state.lastResult.iterations, 2);
 });
 
-// ── ralph_stop tool ───────────────────────────────────────────────────────
+// ── ap_stop tool ───────────────────────────────────────────────────────
 
-test("ralph_stop cancels an active loop and reports iteration count", async () => {
+test("ap_stop cancels an active loop and reports iteration count", async () => {
     const { session, controller, stop } = await arm({ max_iterations: 10 });
     session.emit("session.idle", { data: {} });
     runTurn(session, "still going");
@@ -3070,8 +3070,8 @@ test("ralph_stop cancels an active loop and reports iteration count", async () =
     assert.equal(controller.state.lastResult.reason, "user_stopped");
 });
 
-test("ralph_stop success result has EXACTLY { textResultForLlm, resultType, iterations, note } — no stray keys", async () => {
-    // Mirrors the arm-success "no stray keys" pin. ralph_stop returns
+test("ap_stop success result has EXACTLY { textResultForLlm, resultType, iterations, note } — no stray keys", async () => {
+    // Mirrors the arm-success "no stray keys" pin. ap_stop returns
     // `success(message, { iterations, note })`, where note is undefined
     // when no reason is supplied. Lock the closed key set so a future
     // refactor can't silently widen the LLM-facing return with internal
@@ -3096,7 +3096,7 @@ test("ralph_stop success result has EXACTLY { textResultForLlm, resultType, iter
     assert.equal(r2.note, "explicit");
 });
 
-test("ralph_stop accepts an optional reason and records it as note", async () => {
+test("ap_stop accepts an optional reason and records it as note", async () => {
     const { stop, controller, session } = await arm({ max_iterations: 5 });
     runTurn(session, "still working");
     const r = await stop.handler({ reason: "user changed plan" });
@@ -3106,7 +3106,7 @@ test("ralph_stop accepts an optional reason and records it as note", async () =>
     assert.equal(controller.state.lastResult.note, "user changed plan");
 });
 
-test("ralph_stop trims surrounding whitespace from reason before storing as note", async () => {
+test("ap_stop trims surrounding whitespace from reason before storing as note", async () => {
     // The trim happens at handler.mjs ~line 651 (`reason.trim()`). Without
     // this pin, a future change that stored the raw value would surface
     // padded notes ("  hello  ") in the additionalContext bracket and the
@@ -3120,7 +3120,7 @@ test("ralph_stop trims surrounding whitespace from reason before storing as note
     assert.match(r.textResultForLlm, /\(hello world\)\.$/, "user-facing suffix must use the trimmed value verbatim");
 });
 
-test("ralph_stop with empty/whitespace-only reason silently drops it (note=undefined)", async () => {
+test("ap_stop with empty/whitespace-only reason silently drops it (note=undefined)", async () => {
     // The note path requires `reason.trim()` to be non-empty (handler.mjs
     // ~line 634). An empty-string or whitespace-only reason is treated
     // the same as omitting it: loop stops, no note attached, no quote
@@ -3141,12 +3141,12 @@ test("ralph_stop with empty/whitespace-only reason silently drops it (note=undef
     }
 });
 
-test("ralph_stop with non-string reason rejects loudly with typed error (loop still active)", async () => {
-    // ralph_stop's `reason` arg used to accept the loose contract
+test("ap_stop with non-string reason rejects loudly with typed error (loop still active)", async () => {
+    // ap_stop's `reason` arg used to accept the loose contract
     // "string or missing" and silently drop a number / object / array.
     // That made buggy callers' miscoercion invisible — the loop stopped
     // but the user's intended note vanished. We tightened the contract
-    // to surface a typed failure, matching how ralph_loop validates
+    // to surface a typed failure, matching how ap_loop validates
     // every other typed field (see fix(handler): durationMs cohort).
     // The deliberate-decision sentinel comment in the prior version of
     // this test is now resolved: rejection is loud, the loop stays
@@ -3154,7 +3154,7 @@ test("ralph_stop with non-string reason rejects loudly with typed error (loop st
     const { stop, controller } = await arm({ max_iterations: 5 });
     const r = await stop.handler({ reason: 42 });
     assert.equal(r.resultType, "failure");
-    assert.match(r.textResultForLlm, /^ralph_stop: reason must be a string \(got number\)\./);
+    assert.match(r.textResultForLlm, /^ap_stop: reason must be a string \(got number\)\./);
     assert.notEqual(controller.state.active, null, "loop must not be stopped when validation fails");
     // A correctly-typed call still works.
     const ok = await stop.handler({ reason: "ok" });
@@ -3162,8 +3162,8 @@ test("ralph_stop with non-string reason rejects loudly with typed error (loop st
     assert.equal(controller.state.lastResult.note, "ok");
 });
 
-test("ralph_stop rejects unknown keys (typo guard, mirrors ralph_loop)", async () => {
-    // Without this, `ralph_stop({ resaon: "..." })` would silently drop
+test("ap_stop rejects unknown keys (typo guard, mirrors ap_loop)", async () => {
+    // Without this, `ap_stop({ resaon: "..." })` would silently drop
     // the user's note instead of surfacing it. The active loop must
     // remain untouched on validation failure (no premature finish()).
     const { stop, controller } = await arm({ max_iterations: 5 });
@@ -3179,14 +3179,14 @@ test("ralph_stop rejects unknown keys (typo guard, mirrors ralph_loop)", async (
     assert.equal(controller.state.lastResult.note, "ok");
 });
 
-test("ralph_stop with no active loop returns failure", async () => {
+test("ap_stop with no active loop returns failure", async () => {
     const c = createRalphController();
-    const stop = c.tools.find((t) => t.name === "ralph_stop");
+    const stop = c.tools.find((t) => t.name === "ap_stop");
     const r = await stop.handler({});
     assert.equal(r.resultType, "failure");
 });
 
-test("ralph_stop with no active loop reports 'no loop' even if args have a typo", async () => {
+test("ap_stop with no active loop reports 'no loop' even if args have a typo", async () => {
     // Priority pin: when no loop is active, the "nothing to stop" error
     // takes precedence over the unknown-arg shape error. The typo is
     // moot if there's nothing to act on, and reporting the validation
@@ -3194,24 +3194,24 @@ test("ralph_stop with no active loop reports 'no loop' even if args have a typo"
     // Pin this priority so a future refactor that hoists validateArgShape
     // above the active-check doesn't silently flip the message order.
     const c = createRalphController();
-    const stop = c.tools.find((t) => t.name === "ralph_stop");
+    const stop = c.tools.find((t) => t.name === "ap_stop");
     const r = await stop.handler({ resaon: "typo" });
     assert.equal(r.resultType, "failure");
-    assert.match(r.textResultForLlm, /no ralph_loop, self_improve, or grow_project is currently running/);
+    assert.match(r.textResultForLlm, /no ap_loop, self_improve, or grow_project is currently running/);
     assert.doesNotMatch(r.textResultForLlm, /unknown argument/);
 });
 
-test("no-active-loop failure wording is identical (modulo tool name) across ralph_stop / ralph_pause / ralph_resume", async () => {
+test("no-active-loop failure wording is identical (modulo tool name) across ap_stop / ap_pause / ap_resume", async () => {
     // Drift guard: every loop-mutating tool surfaces the SAME error
     // string when called with no active loop, only the leading
     // `<tool>:` prefix differs. Centralised in noActiveLoopFailure() —
     // this test pins the contract so a future refactor that re-words
-    // one site (e.g. swapping in "ralph_loop" only when other tools
-    // still say "ralph_loop / self_improve / grow_project") immediately
+    // one site (e.g. swapping in "ap_loop" only when other tools
+    // still say "ap_loop / self_improve / grow_project") immediately
     // surfaces the inconsistency. Downstream agents + log scrapers
     // pattern-match on this exact string, so drift is a real bug.
     const c = createRalphController();
-    const tools = ["ralph_stop", "ralph_pause", "ralph_resume"];
+    const tools = ["ap_stop", "ap_pause", "ap_resume"];
     const messages = [];
     for (const name of tools) {
         const tool = c.tools.find((t) => t.name === name);
@@ -3221,14 +3221,14 @@ test("no-active-loop failure wording is identical (modulo tool name) across ralp
     }
     // Strip the per-tool prefix and assert the remainder is byte-identical.
     const tails = messages.map((m, i) => m.replace(new RegExp(`^${tools[i]}: `), ""));
-    assert.equal(tails[0], tails[1], "ralph_stop and ralph_pause no-loop wording must match");
-    assert.equal(tails[1], tails[2], "ralph_pause and ralph_resume no-loop wording must match");
+    assert.equal(tails[0], tails[1], "ap_stop and ap_pause no-loop wording must match");
+    assert.equal(tails[1], tails[2], "ap_pause and ap_resume no-loop wording must match");
     // Exact wording pin — a refactor that drops "self_improve" or
     // "grow_project" should fail this test loudly.
-    assert.equal(tails[0], "no ralph_loop, self_improve, or grow_project is currently running.");
+    assert.equal(tails[0], "no ap_loop, self_improve, or grow_project is currently running.");
 });
 
-test("ralph_stop tolerates null/undefined args; rejects array shape loudly", async () => {
+test("ap_stop tolerates null/undefined args; rejects array shape loudly", async () => {
     const { session, controller, stop } = await arm({ max_iterations: 5 });
     session.emit("session.idle", { data: {} });
     // null instead of {} — JS default params don't catch null
@@ -3243,7 +3243,7 @@ test("ralph_stop tolerates null/undefined args; rejects array shape loudly", asy
     const r2 = await stop.handler(undefined);
     assert.equal(r2.resultType, "success");
 
-    // Array: rejected loudly (mirrors ralph_loop's shape guard) so a caller
+    // Array: rejected loudly (mirrors ap_loop's shape guard) so a caller
     // who passed e.g. ["reason"] gets a clear error instead of silently
     // stopping with no note.
     await controller.tools[0].handler({ prompt: "go", max_iterations: 5 });
@@ -3364,7 +3364,7 @@ test("abort event falls back to top-level ev.reason when ev.data.reason is absen
 
 test("abort log line carries calling tool's label (self_improve)", async () => {
     // The "⏹ <label> interrupted by session abort" log line was
-    // hardcoded to "ralph_loop" and missed the iter-14 label sweep.
+    // hardcoded to "ap_loop" and missed the iter-14 label sweep.
     // When armed via self_improve, the abort log must read
     // "⏹ self_improve interrupted by session abort …".
     const session = makeFakeSession();
@@ -3376,7 +3376,7 @@ test("abort log line carries calling tool's label (self_improve)", async () => {
     session.emit("abort", { data: { reason: "user changed plan" } });
     const joined = session.logs.join("\n");
     assert.match(joined, /⏹ self_improve interrupted by session abort \(user changed plan\)/);
-    assert.doesNotMatch(joined, /⏹ ralph_loop interrupted/);
+    assert.doesNotMatch(joined, /⏹ ap_loop interrupted/);
 });
 
 test("abort event prefers ev.data.reason over ev.reason when both are present", async () => {
@@ -3424,14 +3424,14 @@ test("abort event with oversized reason truncates BOTH the log line and result.n
     assert.ok(controller.state.lastResult.note.length <= PREVIEW_CHARS);
     const abortLog = session.logs.find((l) => /interrupted by session abort/.test(l));
     assert.ok(abortLog, "expected abort log line");
-    // Wrapper text "⏹ ralph_loop interrupted by session abort (…)." adds
+    // Wrapper text "⏹ ap_loop interrupted by session abort (…)." adds
     // ~50 chars; PREVIEW_CHARS + a generous slack still rules out 50KB.
     assert.ok(abortLog.length < PREVIEW_CHARS + 200, `abort log too long: ${abortLog.length}`);
 });
 
-test("calling ralph_stop immediately after arm (before any session.idle) finishes with iterations=0", async () => {
+test("calling ap_stop immediately after arm (before any session.idle) finishes with iterations=0", async () => {
     // Arm but never emit session.idle — so the loop never even gets to
-    // iteration 1. ralph_stop must still be able to clean up cleanly,
+    // iteration 1. ap_stop must still be able to clean up cleanly,
     // and the recorded iteration count must reflect reality (0), not
     // the user-facing "iter 1/max" label that pre-fire arming uses
     // for the "already armed" error message.
@@ -3448,8 +3448,8 @@ test("calling ralph_stop immediately after arm (before any session.idle) finishe
     assert.equal(controller.state.lastResult.preview, "");
 });
 
-test("calling ralph_stop twice in a row: 2nd call reports no active loop", async () => {
-    // After ralph_stop succeeds, finish() nulls state.active. A retried
+test("calling ap_stop twice in a row: 2nd call reports no active loop", async () => {
+    // After ap_stop succeeds, finish() nulls state.active. A retried
     // stop (e.g. caller wasn't sure the first one landed) must not
     // silently succeed — the loop is already gone, and reporting
     // success would falsely imply we just stopped a fresh loop.
@@ -3459,21 +3459,21 @@ test("calling ralph_stop twice in a row: 2nd call reports no active loop", async
     assert.equal(controller.state.lastResult.reason, "user_stopped");
     const r2 = await stop.handler({ reason: "second" });
     assert.equal(r2.resultType, "failure");
-    assert.match(r2.textResultForLlm, /no ralph_loop, self_improve, or grow_project is currently running/);
+    assert.match(r2.textResultForLlm, /no ap_loop, self_improve, or grow_project is currently running/);
     // The original result must NOT be overwritten by the failed second stop.
     assert.equal(controller.state.lastResult.note, "first");
 });
 
-test("ralph_stop no-loop failure mentions BOTH ralph_loop and self_improve", async () => {
-    // ralph_stop tears down either flavor of armed loop, so the failure
+test("ap_stop no-loop failure mentions BOTH ap_loop and self_improve", async () => {
+    // ap_stop tears down either flavor of armed loop, so the failure
     // message must name both — otherwise an LLM that only ever called
-    // self_improve will think ralph_stop refers to a different state
+    // self_improve will think ap_stop refers to a different state
     // machine and won't realize it's the right cancellation tool.
     const c = createRalphController();
-    const stop = c.tools.find((t) => t.name === "ralph_stop");
+    const stop = c.tools.find((t) => t.name === "ap_stop");
     const r = await stop.handler({});
     assert.equal(r.resultType, "failure");
-    assert.match(r.textResultForLlm, /ralph_loop/);
+    assert.match(r.textResultForLlm, /ap_loop/);
     assert.match(r.textResultForLlm, /self_improve/);
 });
 
@@ -3525,7 +3525,7 @@ test("onUserPromptSubmitted injects additionalContext exactly once after a finis
     assert.equal(controller.state.lastResult.reason, "completion_promise");
 
     const r1 = await controller.hooks.onUserPromptSubmitted({ prompt: "next" });
-    assert.match(r1.additionalContext, /ralph_loop just finished/);
+    assert.match(r1.additionalContext, /ap_loop just finished/);
     assert.match(r1.additionalContext, /reason=completion_promise/);
     // Injection should be visible in the session log so users can see
     // why the next prompt was rewritten.
@@ -3543,7 +3543,7 @@ test("onUserPromptSubmitted bracket reflects the calling tool's label (self_impr
     const c = createRalphController();
     c.attach(session);
     const si = c.tools.find((x) => x.name === "self_improve");
-    const stop = c.tools.find((x) => x.name === "ralph_stop");
+    const stop = c.tools.find((x) => x.name === "ap_stop");
     await si.handler({ max_iterations: 5 });
     await stop.handler({ reason: "test" });
     assert.equal(c.state.lastResult.label, "self_improve");
@@ -3551,7 +3551,7 @@ test("onUserPromptSubmitted bracket reflects the calling tool's label (self_impr
     assert.ok(r?.additionalContext, "expected additionalContext after a finished self_improve loop");
     assert.match(r.additionalContext, /^\[self_improve just finished/,
         `expected bracket prefix to be self_improve, got: ${r.additionalContext}`);
-    assert.doesNotMatch(r.additionalContext, /ralph_loop just finished/);
+    assert.doesNotMatch(r.additionalContext, /ap_loop just finished/);
     assert.ok(
         session.logs.some((l) => /^self_improve: injecting post-loop context/.test(l)),
         "expected the self_improve-prefixed injection log line",
@@ -3564,13 +3564,13 @@ test("onUserPromptSubmitted bracket reflects the calling tool's label (grow_proj
     // "[grow_project just finished …]" in the additionalContext
     // injection AND a "grow_project: injecting post-loop context"
     // log line — proves state.lastResult.label is plumbed through the
-    // hook end-to-end. A regression that hardcodes "ralph_loop" or
+    // hook end-to-end. A regression that hardcodes "ap_loop" or
     // "self_improve" anywhere in the post-loop pipeline is caught.
     const session = makeFakeSession();
     const c = createRalphController();
     c.attach(session);
     const gp = c.tools.find((x) => x.name === "grow_project");
-    const stop = c.tools.find((x) => x.name === "ralph_stop");
+    const stop = c.tools.find((x) => x.name === "ap_stop");
     await gp.handler({ max_iterations: 5, min_iterations: 1 });
     await stop.handler({ reason: "test" });
     assert.equal(c.state.lastResult.label, "grow_project");
@@ -3578,7 +3578,7 @@ test("onUserPromptSubmitted bracket reflects the calling tool's label (grow_proj
     assert.ok(r?.additionalContext, "expected additionalContext after a finished grow_project loop");
     assert.match(r.additionalContext, /^\[grow_project just finished/,
         `expected bracket prefix to be grow_project, got: ${r.additionalContext}`);
-    assert.doesNotMatch(r.additionalContext, /ralph_loop just finished/);
+    assert.doesNotMatch(r.additionalContext, /ap_loop just finished/);
     assert.doesNotMatch(r.additionalContext, /self_improve just finished/);
     assert.ok(
         session.logs.some((l) => /^grow_project: injecting post-loop context/.test(l)),
@@ -3593,7 +3593,7 @@ test("onUserPromptSubmitted is a no-op when no loop has finished", async () => {
 });
 
 test("onUserPromptSubmitted consumes lastResult exactly once (no replay on subsequent prompts)", async () => {
-    // The hook injects [ralph_loop just finished — …] on the FIRST user
+    // The hook injects [ap_loop just finished — …] on the FIRST user
     // prompt after a loop ends, then clears state.lastResult so a
     // SECOND prompt isn't decorated with the same stale context. A
     // future refactor that forgets the `state.lastResult = null` line
@@ -3645,7 +3645,7 @@ test("finish log line collapses multi-line note (single-line timeline marker)", 
     session.emit("session.idle", { data: {} });
     await stop.handler({ reason: "line1\nline2\n  line3" });
     // Find the finish log entry.
-    const finishLog = session.logs.find((l) => /ralph_loop after \d+ iteration/.test(l));
+    const finishLog = session.logs.find((l) => /ap_loop after \d+ iteration/.test(l));
     assert.ok(finishLog, "expected a finish log line");
     assert.equal(finishLog.includes("\n"), false, `finish log contains newline: ${JSON.stringify(finishLog)}`);
     assert.match(finishLog, /note: line1 line2 line3/);
@@ -3738,7 +3738,7 @@ test("empty assistant.message content still flips observedMessageThisFire (next 
 });
 
 test("pre-arm assistant content is discarded — does not satisfy iter-1 completion check", async () => {
-    // The turn that *calls* ralph_loop is itself an assistant turn that
+    // The turn that *calls* ap_loop is itself an assistant turn that
     // can have already emitted text before the tool call resolved. If
     // the agent happened to mention the completion_promise in that
     // pre-arm content (e.g. quoting the user "I'll loop until DONE"),
@@ -3892,11 +3892,11 @@ test("assistant.message with non-string content is silently ignored (defensive t
 });
 
 
-test("sub-agent abort event does NOT terminate the root ralph_loop", async () => {
+test("sub-agent abort event does NOT terminate the root ap_loop", async () => {
     // Sub-agents (task / explore / rubber-duck …) emit their own abort
     // events when they fail or are cancelled. Per the SDK schema, those
     // events carry an `agentId` field while root-agent events don't.
-    // A sub-agent's abort must NOT tear down the root ralph_loop.
+    // A sub-agent's abort must NOT tear down the root ap_loop.
     const { session, controller } = await arm({ max_iterations: 5, stagnation_limit: 0 });
     session.emit("session.idle", { data: {} }); // fire iter 1
     assert.equal(controller.state.active.i, 1);
@@ -4086,7 +4086,7 @@ test("note truncation is silent — no '…' indicator (asymmetric with preview)
 
 test("note truncation does not split UTF-16 surrogate pairs", async () => {
     // 499 'a's + "🎉" + filler — same surrogate-edge as preview test, but
-    // exercising the note path via ralph_stop reason.
+    // exercising the note path via ap_stop reason.
     const longReason = "a".repeat(499) + "🎉" + "z".repeat(100);
     const { session, controller, stop } = await arm({ max_iterations: 5 });
     session.emit("session.idle", { data: {} });
@@ -4097,7 +4097,7 @@ test("note truncation does not split UTF-16 surrogate pairs", async () => {
     assert.deepEqual(JSON.parse(JSON.stringify(note)), note);
 });
 
-test("ralph_stop caps oversized user-supplied reason in response and result.note", async () => {
+test("ap_stop caps oversized user-supplied reason in response and result.note", async () => {
     // A pathologically large reason must not balloon the LLM-visible response
     // string nor the structured note field. Both should be ≤ PREVIEW_CHARS.
     const huge = "x".repeat(50_000);
@@ -4116,7 +4116,7 @@ test("ralph_stop caps oversized user-supplied reason in response and result.note
     assert.ok(controller.state.lastResult.note.length <= PREVIEW_CHARS);
 });
 
-test("ralph_stop reason at exactly PREVIEW_CHARS passes through unchanged (boundary)", async () => {
+test("ap_stop reason at exactly PREVIEW_CHARS passes through unchanged (boundary)", async () => {
     // Pin the boundary: reason length === PREVIEW_CHARS must NOT trip the
     // truncation path (no ellipsis added, no chars dropped). This guards
     // an off-by-one in truncateNote (uses `<=` not `<`) so the cap is
@@ -4183,7 +4183,7 @@ test("lastAssistantContent is capped at MAX_CONTENT_CHARS (1 MiB)", async () => 
 test("late send-rejection from a stale arming does NOT poison a freshly-armed loop", async () => {
     // Sequence:
     //  1. Arm loop A1; capture its pending send-promise so we can reject it later.
-    //  2. Stop A1 cleanly via ralph_stop. state.active becomes null.
+    //  2. Stop A1 cleanly via ap_stop. state.active becomes null.
     //  3. Arm loop A2.
     //  4. Late-reject the A1 promise. Without per-arming identity capture, the
     //     rejection handler would call finish('send_error') on A2 and kill it.
@@ -4214,8 +4214,8 @@ test("late send-rejection from a stale arming does NOT poison a freshly-armed lo
     };
     const controller = createRalphController();
     controller.attach(session);
-    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
-    const stop = controller.tools.find((t) => t.name === "ralph_stop");
+    const ralph = controller.tools.find((t) => t.name === "ap_loop");
+    const stop = controller.tools.find((t) => t.name === "ap_stop");
 
     // A1
     await ralph.handler({ prompt: "first", max_iterations: 5, stagnation_limit: 0 });
@@ -4241,7 +4241,7 @@ test("late send-rejection from a stale arming does NOT poison a freshly-armed lo
 
 // ── attach/detach ─────────────────────────────────────────────────────────
 
-test("calling ralph_loop before attach fails fast with a clear error and does NOT arm", async () => {
+test("calling ap_loop before attach fails fast with a clear error and does NOT arm", async () => {
     const c = createRalphController();
     // No attach() call.
     const r = await c.tools[0].handler({ prompt: "go" });
@@ -4251,7 +4251,7 @@ test("calling ralph_loop before attach fails fast with a clear error and does NO
 });
 
 test("calling self_improve before attach fails fast with a self_improve-labelled error and does NOT arm", async () => {
-    // Mirror of the ralph_loop pin above. requireAttachedSession() weaves
+    // Mirror of the ap_loop pin above. requireAttachedSession() weaves
     // the calling tool's name through the message, so the failure must
     // carry "self_improve:" rather than the previous hardcoded prefix —
     // a regression that drops the label would lie about which tool the
@@ -4562,7 +4562,7 @@ test("durationMs is clamped to ≥ 0 if the system clock jumps backward", async 
     }
 });
 
-test("arming a fresh ralph_loop clears stale lastResult from prior run", async () => {
+test("arming a fresh ap_loop clears stale lastResult from prior run", async () => {
     // First loop completes and records a result.
     const { session, controller, ralph } = await arm({ max_iterations: 2 });
     session.emit("session.idle", { data: {} });   // first idle fires iter 1 prompt
@@ -4579,7 +4579,7 @@ test("arming a fresh ralph_loop clears stale lastResult from prior run", async (
         "prior lastResult must be cleared on re-arm to prevent stale post-loop context");
 });
 
-test("self_improve re-arm clears prior lastResult (mirror of ralph_loop)", async () => {
+test("self_improve re-arm clears prior lastResult (mirror of ap_loop)", async () => {
     // Symmetric guarantee: re-arming via self_improve after a previous
     // self_improve completed must clear state.lastResult so the
     // additionalContext hook can't bleed the previous run's preview
@@ -4648,31 +4648,31 @@ test("finish log marker differentiates by reason category", async () => {
     c1.attach(session1);
     await c1.tools[0].handler({ prompt: "go", max_iterations: 5 });
     session1.emit("session.idle", { data: {} });
-    assert.match(session1.logs.join("\n"), /⚠️ ended ralph_loop.*reason: send_error/);
+    assert.match(session1.logs.join("\n"), /⚠️ ended ap_loop.*reason: send_error/);
 
     // user_stopped → ⏹ stopped (not ⚠️)
     const { session: s2, stop } = await arm({ max_iterations: 5 });
     s2.emit("session.idle", { data: {} });
     await stop.handler({});
-    assert.match(s2.logs.join("\n"), /⏹ stopped ralph_loop.*reason: user_stopped/);
+    assert.match(s2.logs.join("\n"), /⏹ stopped ap_loop.*reason: user_stopped/);
 
     // aborted (SDK abort event) → ⚠️ ended (mirrors send_error: something went wrong).
     // Pins the second branch of the verb ladder, which previously had no
     // dedicated test — only send_error covered it.
     const { session: s3 } = await arm({ max_iterations: 5 });
     s3.emit("abort", { data: { reason: "user_cancelled" } });
-    assert.match(s3.logs.join("\n"), /⚠️ ended ralph_loop.*reason: aborted/);
+    assert.match(s3.logs.join("\n"), /⚠️ ended ap_loop.*reason: aborted/);
 
     // completion_promise → ✅ completed
     const { session: s4 } = await arm({ max_iterations: 5 });
     s4.emit("session.idle", { data: {} });
     runTurn(s4, "all done COMPLETE");
-    assert.match(s4.logs.join("\n"), /✅ completed ralph_loop.*reason: completion_promise/);
+    assert.match(s4.logs.join("\n"), /✅ completed ap_loop.*reason: completion_promise/);
 });
 
 test("finish log line carries the self_improve label for ⏹/✅/⚠️ verbs", async () => {
-    // Mirror of the ralph_loop verb-ladder test above, exercised through
-    // self_improve so a regression that hardcodes "ralph_loop" back into
+    // Mirror of the ap_loop verb-ladder test above, exercised through
+    // self_improve so a regression that hardcodes "ap_loop" back into
     // the finish log line — bypassing state.active.label — is caught.
     // Three branches: user_stopped (⏹), completion_promise (✅), and
     // send_error (⚠️) cover all three verbs in VERB_BY_REASON's fallback
@@ -4684,7 +4684,7 @@ test("finish log line carries the self_improve label for ⏹/✅/⚠️ verbs", 
         const c = createRalphController();
         c.attach(session);
         const si = c.tools.find((t) => t.name === "self_improve");
-        const stop = c.tools.find((t) => t.name === "ralph_stop");
+        const stop = c.tools.find((t) => t.name === "ap_stop");
         await si.handler({ max_iterations: 5, min_iterations: 1 });
         session.emit("session.idle", { data: {} });
         await stop.handler({});
@@ -4715,7 +4715,7 @@ test("finish log line carries the self_improve label for ⏹/✅/⚠️ verbs", 
 
 test("finish log line carries the grow_project label for ⏹/✅/⚠️ verbs", async () => {
     // Mirror of the self_improve verb-ladder test above, exercised
-    // through grow_project so a regression that hardcodes "ralph_loop"
+    // through grow_project so a regression that hardcodes "ap_loop"
     // (or "self_improve") back into the finish log line — bypassing
     // state.active.label — is caught for the new tool too. Three
     // branches cover all three verbs in VERB_BY_REASON's fallback
@@ -4727,7 +4727,7 @@ test("finish log line carries the grow_project label for ⏹/✅/⚠️ verbs", 
         const c = createRalphController();
         c.attach(session);
         const gp = c.tools.find((t) => t.name === "grow_project");
-        const stop = c.tools.find((t) => t.name === "ralph_stop");
+        const stop = c.tools.find((t) => t.name === "ap_stop");
         await gp.handler({ max_iterations: 5, min_iterations: 1 });
         session.emit("session.idle", { data: {} });
         await stop.handler({});
@@ -4841,7 +4841,7 @@ test("ARCHITECTURE.md tool surface table lists every registered tool", () => {
     const c = createRalphController();
     for (const tool of c.tools) {
         // Each row uses backtick-wrapped tool name in the leading cell,
-        // e.g. `| \`ralph_pause\` | …`.
+        // e.g. `| \`ap_pause\` | …`.
         const needle = `\`${tool.name}\``;
         assert.ok(
             arch.includes(needle),
@@ -4850,7 +4850,7 @@ test("ARCHITECTURE.md tool surface table lists every registered tool", () => {
     }
 });
 
-test("README documents every ralph_loop parameter the schema advertises", () => {
+test("README documents every ap_loop parameter the schema advertises", () => {
     // Pin the docs↔code agreement: the README "Tool parameters" table
     // is where users look up defaults. Until iter 19 it omitted the
     // three adaptive_* params even though the JSON schema had been
@@ -4858,15 +4858,15 @@ test("README documents every ralph_loop parameter the schema advertises", () => 
     // README row would silently drift again. This test fails fast.
     const readme = readFileSync(resolve(REPO_ROOT, "README.md"), "utf8");
     const c = createRalphController();
-    const ralphLoop = c.tools.find((t) => t.name === "ralph_loop");
+    const ralphLoop = c.tools.find((t) => t.name === "ap_loop");
     const props = Object.keys(ralphLoop.parameters.properties);
-    assert.ok(props.length > 0, "schema must declare ralph_loop properties");
+    assert.ok(props.length > 0, "schema must declare ap_loop properties");
     for (const name of props) {
         // Each row uses backtick-wrapped param name in the leading cell.
         const needle = `\`${name}\``;
         assert.ok(
             readme.includes(needle),
-            `README must mention the ralph_loop param ${name} (in the Tool parameters table)`,
+            `README must mention the ap_loop param ${name} (in the Tool parameters table)`,
         );
     }
 });
@@ -5066,9 +5066,9 @@ test("README install Option headings are unique (no duplicate H3 anchors)", () =
 
 test("README `tools: controller.tools` comment lists every controller.tools name in order", () => {
     // Drift guard for the inline tool list in README's "How it works"
-    // code block. The previous form (`ralph_loop + ralph_stop +
-    // self_improve + grow_project`) drifted out of date when ralph_pause,
-    // ralph_resume, and ralph_status shipped — a contributor reading
+    // code block. The previous form (`ap_loop + ap_stop +
+    // self_improve + grow_project`) drifted out of date when ap_pause,
+    // ap_resume, and ap_status shipped — a contributor reading
     // README would have built the wrong mental model of the tool surface.
     // Pin the comment to the actual order of names exported by
     // `controller.tools` so adding a new tool fails this test loudly.
@@ -5643,7 +5643,7 @@ async function armWithCaffeinate({ env = {}, platform = "darwin", spawnSpy } = {
         },
     });
     controller.attach(session);
-    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
+    const ralph = controller.tools.find((t) => t.name === "ap_loop");
     const armResult = await ralph.handler({ prompt: "go", max_iterations: 3 });
     return { session, controller, armResult, ralph };
 }
@@ -5706,14 +5706,14 @@ test("caffeinate: child is killed on loop completion", async () => {
     assert.deepEqual(spy.children[0].killArgs, ["SIGTERM"]);
 });
 
-test("caffeinate: child is killed on ralph_stop", async () => {
+test("caffeinate: child is killed on ap_stop", async () => {
     const spy = makeCaffeinateSpy();
     const { controller } = await armWithCaffeinate({
         env: { RALPH_CAFFEINATE: "1" },
         platform: "darwin",
         spawnSpy: spy,
     });
-    const stop = controller.tools.find((t) => t.name === "ralph_stop");
+    const stop = controller.tools.find((t) => t.name === "ap_stop");
     await stop.handler({});
     assert.equal(spy.children[0].killed, true);
 });
@@ -5773,7 +5773,7 @@ test("caffeinate: README documents env vars and macOS-only scope", () => {
     assert.match(readme, /macOS only|darwin/i, "README must clarify macOS-only scope");
 });
 
-// ── ralph_status tool (issue #5) ──────────────────────────────────────────
+// ── ap_status tool (issue #5) ──────────────────────────────────────────
 
 function makeGitStub(scripts = {}) {
     // scripts: map "first-arg" → { ok, stdout } or full handler fn(args)
@@ -5795,8 +5795,8 @@ async function armStatusable({ git } = {}) {
     const session = makeFakeSession();
     const controller = createRalphController(git ? { git: { exec: git.exec, cwd: "/tmp/fake" } } : undefined);
     controller.attach(session);
-    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
-    const status = controller.tools.find((t) => t.name === "ralph_status");
+    const ralph = controller.tools.find((t) => t.name === "ap_loop");
+    const status = controller.tools.find((t) => t.name === "ap_status");
     return { session, controller, ralph, status };
 }
 
@@ -5812,12 +5812,12 @@ test("createRalphController: throwing gitExec is normalized to { ok: false } at 
         git: { exec: () => { throw new Error("boom"); }, cwd: "/tmp/fake" },
     });
     controller.attach(session);
-    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
-    const status = controller.tools.find((t) => t.name === "ralph_status");
+    const ralph = controller.tools.find((t) => t.name === "ap_loop");
+    const status = controller.tools.find((t) => t.name === "ap_status");
     const r = await ralph.handler({ prompt: "test prompt" });
-    assert.equal(r.resultType, "success", "throwing gitExec must not break ralph_loop arm");
+    assert.equal(r.resultType, "success", "throwing gitExec must not break ap_loop arm");
     assert.equal(r.armed, true);
-    // ralph_status mid-loop must also tolerate the throw (it calls
+    // ap_status mid-loop must also tolerate the throw (it calls
     // gitExec twice via buildStatusSnapshot).
     const s = await status.handler({});
     assert.equal(s.resultType, "success");
@@ -5833,7 +5833,7 @@ test("createRalphController: throwing adaptive.gitExec is normalized at boundary
         adaptive: { gitExec: () => { throw new Error("adaptive boom"); }, cwd: "/tmp/fake" },
     });
     controller.attach(session);
-    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
+    const ralph = controller.tools.find((t) => t.name === "ap_loop");
     const r = await ralph.handler({
         prompt: "go",
         max_iterations: 1,
@@ -5846,7 +5846,7 @@ test("createRalphController: throwing adaptive.gitExec is normalized at boundary
     // hence no extension granted -- but no crash.
 });
 
-test("ralph_status: with no active loop and no prior run returns { active: false }", async () => {
+test("ap_status: with no active loop and no prior run returns { active: false }", async () => {
     const { status } = await armStatusable();
     const r = await status.handler({});
     assert.equal(r.resultType, "success");
@@ -5854,14 +5854,14 @@ test("ralph_status: with no active loop and no prior run returns { active: false
     assert.equal(r.status.last, undefined);
 });
 
-test("ralph_status: rejects unknown args", async () => {
+test("ap_status: rejects unknown args", async () => {
     const { status } = await armStatusable();
     const r = await status.handler({ verbose: true });
     assert.equal(r.resultType, "failure");
     assert.match(r.textResultForLlm, /unknown/i);
 });
 
-test("ralph_status: during active loop reports iteration, elapsed, promises", async () => {
+test("ap_status: during active loop reports iteration, elapsed, promises", async () => {
     const git = makeGitStub({
         "rev-parse HEAD": { ok: false }, // not a repo
     });
@@ -5871,7 +5871,7 @@ test("ralph_status: during active loop reports iteration, elapsed, promises", as
     const r = await status.handler({});
     assert.equal(r.resultType, "success");
     assert.equal(r.status.active, true);
-    assert.equal(r.status.label, "ralph_loop");
+    assert.equal(r.status.label, "ap_loop");
     assert.equal(r.status.max_iterations, 5);
     assert.equal(r.status.min_iterations, 2);
     assert.equal(r.status.completion_promise, "COMPLETE");
@@ -5885,7 +5885,7 @@ test("ralph_status: during active loop reports iteration, elapsed, promises", as
     assert.match(r.textResultForLlm, /iteration \d+\/5/);
 });
 
-test("ralph_status: includes git block + files_changed when armedGit.isRepo", async () => {
+test("ap_status: includes git block + files_changed when armedGit.isRepo", async () => {
     const git = makeGitStub({
         "rev-parse HEAD": { ok: true, stdout: "abc1234\n" },
         "rev-parse --abbrev-ref HEAD": { ok: true, stdout: "feature/x\n" },
@@ -5915,7 +5915,7 @@ test("ralph_status: includes git block + files_changed when armedGit.isRepo", as
     assert.deepEqual(r.status.files_changed.deleted, ["src/old.ts"]);
 });
 
-test("ralph_status: never mutates loop state (read-only)", async () => {
+test("ap_status: never mutates loop state (read-only)", async () => {
     const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
     const { ralph, status, controller } = await armStatusable({ git });
     await ralph.handler({ prompt: "go", max_iterations: 5 });
@@ -5929,7 +5929,7 @@ test("ralph_status: never mutates loop state (read-only)", async () => {
     assert.equal(after.startedAt, before.startedAt);
 });
 
-test("ralph_status: after loop finishes, returns { active: false } + last summary", async () => {
+test("ap_status: after loop finishes, returns { active: false } + last summary", async () => {
     const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
     const { ralph, status, session } = await armStatusable({ git });
     await ralph.handler({ prompt: "go", max_iterations: 3 });
@@ -5938,14 +5938,14 @@ test("ralph_status: after loop finishes, returns { active: false } + last summar
     const r = await status.handler({});
     assert.equal(r.status.active, false);
     assert.ok(r.status.last, "must include last-run summary");
-    assert.equal(r.status.last.label, "ralph_loop");
+    assert.equal(r.status.last.label, "ap_loop");
     assert.equal(r.status.last.reason, "completion_promise");
     assert.match(r.status.last.started_at, /^\d{4}-\d{2}-\d{2}T/);
     assert.match(r.status.last.finished_at, /^\d{4}-\d{2}-\d{2}T/);
     assert.equal(typeof r.status.last.duration_ms, "number");
 });
 
-test("ralph_status: last_iteration_at advances each iteration", async () => {
+test("ap_status: last_iteration_at advances each iteration", async () => {
     const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
     const { ralph, status, session } = await armStatusable({ git });
     await ralph.handler({ prompt: "go", max_iterations: 5, stagnation_limit: 0 });
@@ -5960,28 +5960,28 @@ test("ralph_status: last_iteration_at advances each iteration", async () => {
     assert.notEqual(a, b);
 });
 
-test("ralph_status: README documents the tool", () => {
+test("ap_status: README documents the tool", () => {
     const readme = readFileSync(resolve(REPO_ROOT, "README.md"), "utf8");
-    assert.match(readme, /\bralph_status\b/, "README must mention the ralph_status tool");
+    assert.match(readme, /\bap_status\b/, "README must mention the ap_status tool");
     // Pause fields are part of the documented payload shape — the
     // example JSON block and the prose blurb must both mention them
-    // so a docs reader sees the same surface a live `ralph_status`
+    // so a docs reader sees the same surface a live `ap_status`
     // would return.
     for (const field of ["paused", "pause_reason", "paused_at", "paused_for_ms", "total_paused_ms"]) {
         assert.ok(
             readme.includes(`"${field}"`),
-            `README's ralph_status example payload must include the ${field} field`,
+            `README's ap_status example payload must include the ${field} field`,
         );
     }
-    assert.match(readme, /pause state/i, "README prose must mention pause state in the ralph_status overview");
+    assert.match(readme, /pause state/i, "README prose must mention pause state in the ap_status overview");
     // Tool description in handler.mjs must agree.
     const handler = readFileSync(resolve(REPO_ROOT, "extension/handler.mjs"), "utf8");
-    assert.match(handler, /pause state/i, "ralph_status tool description must mention pause state");
+    assert.match(handler, /pause state/i, "ap_status tool description must mention pause state");
 });
 
-test("ralph_status: surfaces paused state (paused, pause_reason, paused_at, paused_for_ms, total_paused_ms)", async () => {
+test("ap_status: surfaces paused state (paused, pause_reason, paused_at, paused_for_ms, total_paused_ms)", async () => {
     // Reliability gap fix: before this, a paused loop was indistinguishable
-    // from a live-but-slow one in ralph_status — `iteration` and `elapsed_ms`
+    // from a live-but-slow one in ap_status — `iteration` and `elapsed_ms`
     // keep advancing while the loop is silent. Without these fields, an
     // operator who paused the loop and queried status had no way to confirm
     // the pause took effect or see how long the loop had been parked.
@@ -5999,7 +5999,7 @@ test("ralph_status: surfaces paused state (paused, pause_reason, paused_at, paus
     assert.ok(!/PAUSED/.test(live.textResultForLlm), "live summary must not claim paused");
 
     // Pause it.
-    const pauseTool = controller.tools.find((t) => t.name === "ralph_pause");
+    const pauseTool = controller.tools.find((t) => t.name === "ap_pause");
     await pauseTool.handler({ reason: "manual diagnostic break" });
 
     const paused = await status.handler({});
@@ -6014,7 +6014,7 @@ test("ralph_status: surfaces paused state (paused, pause_reason, paused_at, paus
 
     // Resume — now total_paused_ms must reflect the prior pause window
     // and the live counters must zero out again.
-    const resumeTool = controller.tools.find((t) => t.name === "ralph_resume");
+    const resumeTool = controller.tools.find((t) => t.name === "ap_resume");
     await resumeTool.handler({});
     const resumed = await status.handler({});
     assert.equal(resumed.status.paused, false);
@@ -6046,7 +6046,7 @@ async function armAdaptive(args = {}, gitStub) {
     const session = makeFakeSession();
     const controller = createRalphController(gitStub ? { adaptive: { gitExec: gitStub.exec } } : {});
     controller.attach(session);
-    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
+    const ralph = controller.tools.find((t) => t.name === "ap_loop");
     const armResult = await ralph.handler({ prompt: "go", max_iterations: 2, adaptive_budget: true, adaptive_extension: 2, adaptive_max_total: 6, ...args });
     return { session, controller, armResult };
 }
@@ -6147,37 +6147,37 @@ test("adaptive_budget: when feature is OFF, finish() result has no adaptive bloc
     assert.equal(r.adaptive, undefined, "no adaptive block when adaptive_budget is false");
 });
 
-// ── ralph_pause / ralph_resume (issue #3) ──────────────────────────────
+// ── ap_pause / ap_resume (issue #3) ──────────────────────────────
 
-test("ralph_pause: with no active loop returns failure", async () => {
+test("ap_pause: with no active loop returns failure", async () => {
     const c = createRalphController();
     c.attach(makeFakeSession());
-    const pause = c.tools.find((t) => t.name === "ralph_pause");
+    const pause = c.tools.find((t) => t.name === "ap_pause");
     const r = await pause.handler({});
     assert.equal(r.resultType, "failure");
-    assert.match(r.textResultForLlm, /no ralph_loop/);
+    assert.match(r.textResultForLlm, /no ap_loop/);
 });
 
-test("ralph_resume: with no active loop returns failure", async () => {
+test("ap_resume: with no active loop returns failure", async () => {
     const c = createRalphController();
     c.attach(makeFakeSession());
-    const resume = c.tools.find((t) => t.name === "ralph_resume");
+    const resume = c.tools.find((t) => t.name === "ap_resume");
     const r = await resume.handler({});
     assert.equal(r.resultType, "failure");
-    assert.match(r.textResultForLlm, /no ralph_loop/);
+    assert.match(r.textResultForLlm, /no ap_loop/);
 });
 
-test("ralph_resume: on a non-paused loop returns failure", async () => {
+test("ap_resume: on a non-paused loop returns failure", async () => {
     const { controller } = await arm({ max_iterations: 5 });
-    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const resume = controller.tools.find((t) => t.name === "ap_resume");
     const r = await resume.handler({});
     assert.equal(r.resultType, "failure");
     assert.match(r.textResultForLlm, /not paused/);
 });
 
-test("ralph_pause: short-circuits onIdle so iteration counter does not advance", async () => {
+test("ap_pause: short-circuits onIdle so iteration counter does not advance", async () => {
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     runTurn(session, "boot");
     runTurn(session, "first");
     const beforePause = controller.state.active.i;
@@ -6193,9 +6193,9 @@ test("ralph_pause: short-circuits onIdle so iteration counter does not advance",
     assert.ok(controller.state.active, "loop must still be active (paused, not stopped)");
 });
 
-test("ralph_pause is idempotent — pausing an already-paused loop is a no-op success", async () => {
+test("ap_pause is idempotent — pausing an already-paused loop is a no-op success", async () => {
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     runTurn(session, "boot");
     await pause.handler({ reason: "first" });
     const r = await pause.handler({ reason: "second" });
@@ -6204,7 +6204,7 @@ test("ralph_pause is idempotent — pausing an already-paused loop is a no-op su
     assert.equal(controller.state.active.pauseReason, "first", "first reason wins; second pause is a no-op");
 });
 
-test("ralph_pause idempotent path returns the FIRST reason, not the second caller's reason", async () => {
+test("ap_pause idempotent path returns the FIRST reason, not the second caller's reason", async () => {
     // Iter 171 — the test above pins that `state.active.pauseReason`
     // stays "first" after a redundant pause. But the no-op success
     // ALSO returns `reason` to the caller (handler.mjs ~line 2195:
@@ -6212,14 +6212,14 @@ test("ralph_pause idempotent path returns the FIRST reason, not the second calle
     // that swapped the idempotent-branch return to `args?.reason ?? null`
     // (or, worse, dropped the `?? null` and let `undefined` ride out)
     // would silently leak the second caller's reason into the success
-    // payload — an automation polling `ralph_pause({reason})` to
+    // payload — an automation polling `ap_pause({reason})` to
     // confirm pause state would see its own input echoed back rather
     // than the original reason that the user typed in the first
     // (effective) pause. Pin both the returned `reason` field AND the
     // single-line `textResultForLlm` rendering so a regression in
     // either surface fires this test.
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     runTurn(session, "boot");
     await pause.handler({ reason: "first" });
     const r = await pause.handler({ reason: "second" });
@@ -6233,24 +6233,24 @@ test("ralph_pause idempotent path returns the FIRST reason, not the second calle
         "the second caller's reason must NOT leak into the success message");
 });
 
-test("ralph_pause: multi-line / whitespace-noisy reason is flattened at entry", async () => {
+test("ap_pause: multi-line / whitespace-noisy reason is flattened at entry", async () => {
     // Pause reasons land in three user-visible places: the timeline log
     // line ("⏸ <label> paused at i/max (reason)"), the `pause` event's
-    // `reason` field, and the `pause_reason` slot in the ralph_status
+    // `reason` field, and the `pause_reason` slot in the ap_status
     // JSON snapshot. A multi-line paste (Error stack, blockquote,
     // CRLF input) into any of those would visually break the layout.
     // Flattening at entry (boundedNoteForLog: collapseNote +
     // truncateNote) keeps every downstream consumer single-line.
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
-    const status = controller.tools.find((t) => t.name === "ralph_status");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
+    const status = controller.tools.find((t) => t.name === "ap_status");
     runTurn(session, "boot");
     const r = await pause.handler({ reason: "  going to lunch\n\twith newlines\r\nand   spaces  " });
     assert.equal(r.resultType, "success");
     // Pinned canonical form (single line, single-spaced, trimmed).
     assert.equal(r.reason, "going to lunch with newlines and spaces");
     assert.equal(controller.state.active.pauseReason, "going to lunch with newlines and spaces");
-    // Surfaces single-line in ralph_status JSON snapshot.
+    // Surfaces single-line in ap_status JSON snapshot.
     const s = await status.handler({});
     assert.equal(s.status.pause_reason, "going to lunch with newlines and spaces");
     // Timeline log marker stays single-line.
@@ -6260,12 +6260,12 @@ test("ralph_pause: multi-line / whitespace-noisy reason is flattened at entry", 
     assert.equal(/[\t\r\f]/.test(pausedLog), false, `paused log marker contains tab/CR/FF: ${JSON.stringify(pausedLog)}`);
 });
 
-test("ralph_pause: reason that is whitespace-only after flatten resolves to null (not empty string)", async () => {
+test("ap_pause: reason that is whitespace-only after flatten resolves to null (not empty string)", async () => {
     // `"   \n\t  "` collapses to "" — must be stored as null so the
     // success message ("paused at i/max") does not render an empty
-    // " ()" suffix and ralph_status surfaces null rather than "".
+    // " ()" suffix and ap_status surfaces null rather than "".
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     runTurn(session, "boot");
     const r = await pause.handler({ reason: "   \n\t  " });
     assert.equal(r.resultType, "success");
@@ -6275,10 +6275,10 @@ test("ralph_pause: reason that is whitespace-only after flatten resolves to null
 });
 
 
-test("ralph_resume: re-arms the loop and the next idle fires the next iteration", async () => {
+test("ap_resume: re-arms the loop and the next idle fires the next iteration", async () => {
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
-    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
+    const resume = controller.tools.find((t) => t.name === "ap_resume");
     runTurn(session, "boot");
     runTurn(session, "first");
     const before = controller.state.active.i;
@@ -6292,8 +6292,8 @@ test("ralph_resume: re-arms the loop and the next idle fires the next iteration"
     assert.ok(controller.state.active.i > before, "iteration counter must advance after resume");
 });
 
-test("ralph_resume: totalPausedMs ACCUMULATES across multiple pause/resume cycles", async () => {
-    // ralph_resume's handler does `a.totalPausedMs += pausedFor` — the
+test("ap_resume: totalPausedMs ACCUMULATES across multiple pause/resume cycles", async () => {
+    // ap_resume's handler does `a.totalPausedMs += pausedFor` — the
     // `+=` is load-bearing. A future "simplify" that wrote
     // `a.totalPausedMs = pausedFor` would silently lose every prior
     // pause window: a user who paused twice (e.g. for two
@@ -6303,8 +6303,8 @@ test("ralph_resume: totalPausedMs ACCUMULATES across multiple pause/resume cycle
     // time as "running" when it wasn't. Pin accumulation so the
     // contract survives a refactor.
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
-    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
+    const resume = controller.tools.find((t) => t.name === "ap_resume");
     runTurn(session, "boot");
 
     // Cycle 1: pause, backdate pausedAt to inject a deterministic
@@ -6341,15 +6341,15 @@ test("ralph_resume: totalPausedMs ACCUMULATES across multiple pause/resume cycle
     );
 });
 
-test("ralph_stop: multi-line reason is flattened at entry (parallel ralph_pause)", async () => {
-    // Iter 36: parseUserReason now consolidates ralph_pause + ralph_stop
-    // reason normalization. ralph_stop's stored result.note is now the
+test("ap_stop: multi-line reason is flattened at entry (parallel ap_pause)", async () => {
+    // Iter 36: parseUserReason now consolidates ap_pause + ap_stop
+    // reason normalization. ap_stop's stored result.note is now the
     // canonical single-line form so the textResultForLlm success message,
     // the additionalContext line (`note=...`), and the terminal event
     // payload all stay single-line — same downstream surfaces that
-    // motivated the ralph_pause fix in iter 35.
+    // motivated the ap_pause fix in iter 35.
     const { session, controller } = await arm({ max_iterations: 5 });
-    const stop = controller.tools.find((t) => t.name === "ralph_stop");
+    const stop = controller.tools.find((t) => t.name === "ap_stop");
     runTurn(session, "boot");
     const r = await stop.handler({ reason: "  user requested\n\twith newlines\r\nand   spaces  " });
     assert.equal(r.resultType, "success");
@@ -6359,9 +6359,9 @@ test("ralph_stop: multi-line reason is flattened at entry (parallel ralph_pause)
     assert.doesNotMatch(r.textResultForLlm, /\n|\r|\t|\f/, "success message must be single-line");
 });
 
-test("ralph_stop: whitespace-only reason resolves to undefined (no empty parens)", async () => {
+test("ap_stop: whitespace-only reason resolves to undefined (no empty parens)", async () => {
     const { session, controller } = await arm({ max_iterations: 5 });
-    const stop = controller.tools.find((t) => t.name === "ralph_stop");
+    const stop = controller.tools.find((t) => t.name === "ap_stop");
     runTurn(session, "boot");
     const r = await stop.handler({ reason: "   \n\t  " });
     assert.equal(r.resultType, "success");
@@ -6369,7 +6369,7 @@ test("ralph_stop: whitespace-only reason resolves to undefined (no empty parens)
     assert.doesNotMatch(r.textResultForLlm, /\(\)/, "user-facing text must not render an empty `()` suffix");
 });
 
-test("ralph_pause before iter 1 fires keeps pendingFire true; resume then idle fires iter 1", async () => {
+test("ap_pause before iter 1 fires keeps pendingFire true; resume then idle fires iter 1", async () => {
     // Reliability: pause/resume during the transient pre-iter-1 window.
     // After arm, `pendingFire` is true and i=0; the FIRST session.idle
     // is what fires iter 1. If a user pauses before that idle lands, the
@@ -6378,8 +6378,8 @@ test("ralph_pause before iter 1 fires keeps pendingFire true; resume then idle f
     // first-iteration response). This test pins the contract on both
     // sides of the resume so the loop survives an early pause cleanly.
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
-    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
+    const resume = controller.tools.find((t) => t.name === "ap_resume");
     const a = controller.state.active;
     assert.equal(a.pendingFire, true, "armed loop starts with pendingFire=true");
     assert.equal(a.i, 0);
@@ -6401,10 +6401,10 @@ test("ralph_pause before iter 1 fires keeps pendingFire true; resume then idle f
     assert.equal(session.sent.length, sentBeforePause + 1, "exactly one prompt queued after resume + idle");
 });
 
-test("ralph_stop while paused still works and tears the loop down", async () => {
+test("ap_stop while paused still works and tears the loop down", async () => {
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
-    const stop = controller.tools.find((t) => t.name === "ralph_stop");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
+    const stop = controller.tools.find((t) => t.name === "ap_stop");
     runTurn(session, "boot");
     runTurn(session, "first");
     await pause.handler({});
@@ -6414,10 +6414,10 @@ test("ralph_stop while paused still works and tears the loop down", async () => 
     assert.equal(controller.state.lastResult.reason, "user_stopped");
 });
 
-test("ralph_pause / ralph_resume reject unknown args", async () => {
+test("ap_pause / ap_resume reject unknown args", async () => {
     const { controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
-    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
+    const resume = controller.tools.find((t) => t.name === "ap_resume");
     const r1 = await pause.handler({ reason: "ok", bogus: 1 });
     assert.equal(r1.resultType, "failure");
     assert.match(r1.textResultForLlm, /unknown|bogus/i);
@@ -6517,21 +6517,21 @@ test("evaluateAdaptiveSignals: ADAPTIVE_WINDOW is the documented constant 3", ()
     assert.equal(ADAPTIVE_WINDOW, 3);
 });
 
-test("reprefixRalphLoopError: rewrites a `ralph_loop:` prefix to the calling tool", () => {
+test("reprefixRalphLoopError: rewrites a `ap_loop:` prefix to the calling tool", () => {
     // self_improve / grow_project both delegate validation to validateArgs
-    // (which prefixes errors with "ralph_loop:") and then rewrite the
+    // (which prefixes errors with "ap_loop:") and then rewrite the
     // prefix to their own tool name. Pin the rewrite branch so a future
     // refactor that, say, swaps the regex anchor doesn't silently let
-    // "ralph_loop:" leak into self_improve / grow_project error streams.
-    const out = reprefixRalphLoopError("ralph_loop: prompt is required and must be non-empty.", "self_improve");
+    // "ap_loop:" leak into self_improve / grow_project error streams.
+    const out = reprefixRalphLoopError("ap_loop: prompt is required and must be non-empty.", "self_improve");
     assert.equal(out, "self_improve: prompt is required and must be non-empty.");
-    const out2 = reprefixRalphLoopError("ralph_loop: max_iterations must be …", "grow_project");
+    const out2 = reprefixRalphLoopError("ap_loop: max_iterations must be …", "grow_project");
     assert.equal(out2, "grow_project: max_iterations must be …");
 });
 
-test("reprefixRalphLoopError: forces a tool prefix on errors lacking the `ralph_loop:` prefix", () => {
+test("reprefixRalphLoopError: forces a tool prefix on errors lacking the `ap_loop:` prefix", () => {
     // Defensive fallback: if a future validateArgs path forgets the
-    // "ralph_loop:" prefix (e.g. a new validation branch returns a bare
+    // "ap_loop:" prefix (e.g. a new validation branch returns a bare
     // string), the helper must STILL stamp the calling tool's name on
     // the front so the user's error stream never carries a prefix-less
     // message. Pin both prefix-less and other-prefix variants.
@@ -6541,7 +6541,7 @@ test("reprefixRalphLoopError: forces a tool prefix on errors lacking the `ralph_
     );
     // A wrong-prefix string (e.g. some hypothetical ralph_v2:) must be
     // wrapped, NOT rewritten — the helper only swaps the exact
-    // "ralph_loop:" anchor, so any other prefix gets the tool name
+    // "ap_loop:" anchor, so any other prefix gets the tool name
     // glued to its left.
     assert.equal(
         reprefixRalphLoopError("ralph_v2: bogus", "grow_project"),
@@ -6583,7 +6583,7 @@ test("no CR (\\r) bytes in any shipped source file (LF-only line endings)", () =
 
 // -----------------------------------------------------------------------------
 // gitAheadBehind / gitUncommittedLines: pin the parsing edge cases that feed
-// ralph_status's "git" snapshot block. Both helpers degrade to null on parse
+// ap_status's "git" snapshot block. Both helpers degrade to null on parse
 // failure (a noisy snapshot is worse than a missing one), so verify each
 // failure mode produces null instead of a thrown TypeError or a partial
 // numeric result.
@@ -6657,7 +6657,7 @@ test("gitUncommittedLines: handles insertion-only and deletion-only output", () 
 // -----------------------------------------------------------------------------
 // docs/concepts.md drift guard: the "Pause / resume semantics" section makes
 // concrete behavioural claims (streak resets on resume; total_paused_ms
-// accumulates; ralph_resume errors when not paused). If a future refactor
+// accumulates; ap_resume errors when not paused). If a future refactor
 // changes one of those behaviours in handler.mjs but doesn't update the doc,
 // the docs would silently lie. This test pins the section's existence + its
 // most load-bearing factual claims.
@@ -6672,16 +6672,16 @@ test("docs/concepts.md: Pause / resume semantics section exists and pins core cl
     assert.match(doc, /idempotent/i, "docs must describe pause idempotency");
     assert.match(doc, /not\b[\s\S]*?idempotent/i, "docs must call out that resume is NOT idempotent");
     // Whichever direction the table runs, both verbs must appear in it.
-    assert.match(doc, /ralph_pause/, "table must reference ralph_pause");
-    assert.match(doc, /ralph_resume/, "table must reference ralph_resume");
-    assert.match(doc, /ralph_stop/, "table must reference ralph_stop");
+    assert.match(doc, /ap_pause/, "table must reference ap_pause");
+    assert.match(doc, /ap_resume/, "table must reference ap_resume");
+    assert.match(doc, /ap_stop/, "table must reference ap_stop");
 });
 
-test("docs document the iter-172 'first reason wins' contract for ralph_pause idempotent path", () => {
+test("docs document the iter-172 'first reason wins' contract for ap_pause idempotent path", () => {
     // Iter 173 — iter 172 pinned via test that the idempotent
-    // `ralph_pause` branch returns the FIRST committed reason, not
+    // `ap_pause` branch returns the FIRST committed reason, not
     // the second caller's reason. Automation polling pause state
-    // depends on this contract: a redundant `ralph_pause({reason:
+    // depends on this contract: a redundant `ap_pause({reason:
     // "newer"})` against an already-paused loop must not echo back
     // "newer" — it must surface the original "first" so the caller
     // can detect their input was rejected as a no-op. Pin both
@@ -6703,13 +6703,13 @@ test("docs document the iter-172 'first reason wins' contract for ralph_pause id
 // -----------------------------------------------------------------------------
 // validateArgShape: when a tool accepts NO arguments at all (knownKeys empty),
 // the legacy wording "Valid keys: ." rendered with a stray dangling period
-// that read like a typo. Pin the cleaner phrasing for ralph_resume (the only
+// that read like a typo. Pin the cleaner phrasing for ap_resume (the only
 // shipped tool with an empty key set) and the no-bogus-period invariant.
 // -----------------------------------------------------------------------------
 
-test("ralph_resume: rejects unknown args with 'takes no arguments' guidance (no Valid keys: . typo)", async () => {
+test("ap_resume: rejects unknown args with 'takes no arguments' guidance (no Valid keys: . typo)", async () => {
     const { controller } = await arm({ max_iterations: 5 });
-    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const resume = controller.tools.find((t) => t.name === "ap_resume");
     const r = await resume.handler({ foo: 1 });
     assert.equal(r.resultType, "failure");
     assert.match(r.textResultForLlm, /unknown argument: "foo"/);
@@ -6719,9 +6719,9 @@ test("ralph_resume: rejects unknown args with 'takes no arguments' guidance (no 
     assert.doesNotMatch(r.textResultForLlm, /Valid keys: ?\./);
 });
 
-test("ralph_resume: pluralizes 'unknown arguments' when more than one bogus key supplied", async () => {
+test("ap_resume: pluralizes 'unknown arguments' when more than one bogus key supplied", async () => {
     const { controller } = await arm({ max_iterations: 5 });
-    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const resume = controller.tools.find((t) => t.name === "ap_resume");
     const r = await resume.handler({ foo: 1, bar: 2 });
     assert.equal(r.resultType, "failure");
     assert.match(r.textResultForLlm, /unknown arguments: "foo", "bar"/);
@@ -6731,8 +6731,8 @@ test("ralph_resume: pluralizes 'unknown arguments' when more than one bogus key 
 // -----------------------------------------------------------------------------
 // activeLoopGuard: when the active loop is paused, the refusal must say
 // "paused" rather than "running". The legacy form rendered "running
-// (iteration N/M)" even after ralph_pause, which was confusing — call sites
-// got told to ralph_stop first when ralph_resume might have been the right
+// (iteration N/M)" even after ap_pause, which was confusing — call sites
+// got told to ap_stop first when ap_resume might have been the right
 // remedy. Pin the priority order: paused > pendingFire > running.
 // -----------------------------------------------------------------------------
 
@@ -6743,8 +6743,8 @@ test("activeLoopGuard: reports 'paused' status when the active loop has been pau
     runTurn(session, "first response");
     await new Promise((r) => setImmediate(r));
     assert.equal(controller.state.active.i, 1);
-    // Pause via the ralph_pause tool (mirrors a real caller).
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    // Pause via the ap_pause tool (mirrors a real caller).
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     const pr = await pause.handler({});
     assert.equal(pr.resultType, "success");
     assert.equal(controller.state.active.paused, true);
@@ -6755,16 +6755,16 @@ test("activeLoopGuard: reports 'paused' status when the active loop has been pau
     assert.match(r.textResultForLlm, /\(iteration 1\/9\)/);
     assert.doesNotMatch(r.textResultForLlm, /running/);
     // Sentence-end remains clean (paren balance + period in the right place).
-    assert.match(r.textResultForLlm, /\(iteration 1\/9\) — call ralph_stop first\.$/);
+    assert.match(r.textResultForLlm, /\(iteration 1\/9\) — call ap_stop first\.$/);
 });
 
 test("activeLoopGuard: paused beats pendingFire when both flags are set", async () => {
-    // ralph_loop was armed but no turn_end fired yet; ralph_pause then runs
+    // ap_loop was armed but no turn_end fired yet; ap_pause then runs
     // before iter 1 lands. paused should still be the headline status.
     const { controller, ralph } = await arm({ max_iterations: 4 });
     assert.equal(controller.state.active.pendingFire, true);
     assert.equal(controller.state.active.i, 0);
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     const pr = await pause.handler({});
     assert.equal(pr.resultType, "success");
     assert.equal(controller.state.active.paused, true);
@@ -6874,7 +6874,7 @@ test("docs/faq.md is no longer the stub and answers core operational questions",
     // they ever drift away from the actual handler behaviour:
     // (a) RALPH_NO_ATTRIBUTION suppresses ONLY the second trailer.
     assert.match(faq, /suppresses [\s\S]{0,40}only[\s\S]{0,80}second[\s\S]{0,40}trailer/i);
-    // (b) ralph_pause is idempotent, ralph_resume is not.
+    // (b) ap_pause is idempotent, ap_resume is not.
     assert.match(faq, /pause[\s\S]{0,80}idempotent/i);
     assert.match(faq, /resume[\s\S]{0,40}\*\*not\*\* idempotent/i);
     // (c) The default runs root path — used by the events emitter.
@@ -6918,7 +6918,7 @@ test("finish: durationMs subtracts totalPausedMs from wall-clock elapsed", async
 });
 
 test("finish: durationMs also subtracts the not-yet-banked current pause window", async () => {
-    // If the user calls ralph_stop while the loop is still paused, the
+    // If the user calls ap_stop while the loop is still paused, the
     // current pause window hasn't been added to totalPausedMs yet — but
     // it's still time the loop wasn't running. Pin that finish() also
     // subtracts the live `Date.now() - pausedAt` window.
@@ -6947,7 +6947,7 @@ test("finish: durationMs clamped to 0 when totalPausedMs exceeds elapsed", async
     // Defensive guard: if a clock skew or buggy caller pushed
     // totalPausedMs past wall-clock elapsed, the result must NOT go
     // negative. Clamp at 0 so downstream consumers (TUI, JSON
-    // serializers, the ralph_status snapshot) never see a negative
+    // serializers, the ap_status snapshot) never see a negative
     // duration.
     const { controller, session, stop } = await arm({ max_iterations: 3 });
     runTurn(session, "first");
@@ -6958,39 +6958,39 @@ test("finish: durationMs clamped to 0 when totalPausedMs exceeds elapsed", async
     assert.equal(controller.state.lastResult.durationMs, 0);
 });
 
-test("ralph_stop: rejects non-string reason with typed error (number)", async () => {
+test("ap_stop: rejects non-string reason with typed error (number)", async () => {
     const { session, controller, stop } = await arm({ prompt: "p" });
     await runTurn(session, "first");
     const r = await stop.handler({ reason: 123 });
     assert.equal(r.resultType, "failure");
-    assert.match(r.textResultForLlm, /^ralph_stop: reason must be a string \(got number\)\./);
+    assert.match(r.textResultForLlm, /^ap_stop: reason must be a string \(got number\)\./);
     // State must be unchanged — a rejected stop is a no-op.
     assert.ok(controller.state.active, "loop should still be active after rejected stop");
 });
 
-test("ralph_stop: rejects non-string reason (boolean)", async () => {
+test("ap_stop: rejects non-string reason (boolean)", async () => {
     const { session, stop } = await arm({ prompt: "p" });
     await runTurn(session, "first");
     const r = await stop.handler({ reason: true });
     assert.equal(r.resultType, "failure");
-    assert.match(r.textResultForLlm, /^ralph_stop: reason must be a string \(got boolean\)\./);
+    assert.match(r.textResultForLlm, /^ap_stop: reason must be a string \(got boolean\)\./);
 });
 
-test("ralph_pause: rejects non-string reason with typed error (array)", async () => {
+test("ap_pause: rejects non-string reason with typed error (array)", async () => {
     const { session, controller, ralph } = await arm({ prompt: "p" });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     await runTurn(session, "first");
     const r = await pause.handler({ reason: ["a", "b"] });
     assert.equal(r.resultType, "failure");
-    assert.match(r.textResultForLlm, /^ralph_pause: reason must be a string \(got array\)\./);
+    assert.match(r.textResultForLlm, /^ap_pause: reason must be a string \(got array\)\./);
     // Ensure pause did NOT take effect.
     assert.equal(controller.state.active.paused, false);
     void ralph;
 });
 
-test("ralph_pause / ralph_stop: null reason still treated as not-supplied (no false rejection)", async () => {
+test("ap_pause / ap_stop: null reason still treated as not-supplied (no false rejection)", async () => {
     const { session, controller, stop } = await arm({ prompt: "p" });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     await runTurn(session, "first");
     // null is the SDK's "not supplied" sentinel for optional fields —
     // must continue to be accepted, not flipped to a typed error.
@@ -7104,7 +7104,7 @@ test("README pins the corrected durationMs semantics (active runtime, not raw wa
     assert.doesNotMatch(readme, /the final `durationMs` measure time from arming, not per-turn latency/);
 });
 
-test("ralph_resume clears lastAssistantContent so user-chat during pause cannot trigger completion_promise", async () => {
+test("ap_resume clears lastAssistantContent so user-chat during pause cannot trigger completion_promise", async () => {
     // Reliability: while paused, the user chats freely with the agent.
     // Each user-chat turn fires assistant.message events that accumulate
     // into state.lastAssistantContent (the buffer onIdle reads to
@@ -7114,8 +7114,8 @@ test("ralph_resume clears lastAssistantContent so user-chat during pause cannot 
     // on the first post-resume idle. Pin the contract: resume MUST
     // reset the buffer so post-resume evaluation starts clean.
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
-    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
+    const resume = controller.tools.find((t) => t.name === "ap_resume");
     runTurn(session, "boot");                 // fires iter 1
     runTurn(session, "iter 1 normal output"); // fires iter 2
     const iterBeforePause = controller.state.active.i;
@@ -7126,7 +7126,7 @@ test("ralph_resume clears lastAssistantContent so user-chat during pause cannot 
     await resume.handler({});
     // Post-condition 1: buffer reset.
     assert.equal(controller.state.lastAssistantContent, "",
-        "ralph_resume must clear lastAssistantContent so chat-during-pause cannot leak into completion evaluation");
+        "ap_resume must clear lastAssistantContent so chat-during-pause cannot leak into completion evaluation");
     // Post-condition 2: loop survives the next idle and advances —
     // it must NOT terminate on the chat content.
     runTurn(session, "iter N+1 output");
@@ -7136,13 +7136,13 @@ test("ralph_resume clears lastAssistantContent so user-chat during pause cannot 
     assert.equal(controller.state.lastResult, null, "no terminal result must have been recorded");
 });
 
-test("ralph_resume clears lastAssistantContent so user-chat during pause cannot trigger abort_promise either", async () => {
+test("ap_resume clears lastAssistantContent so user-chat during pause cannot trigger abort_promise either", async () => {
     // Symmetric guard for abort_promise. Different code path inside
     // onIdle (different terminator) so a future refactor that splits
     // resume's reset by reason kind would still need both pinned.
     const { session, controller } = await arm({ max_iterations: 5, abort_promise: "ABORT_NOW" });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
-    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
+    const resume = controller.tools.find((t) => t.name === "ap_resume");
     runTurn(session, "boot");
     runTurn(session, "iter 1 output");
     await pause.handler({});
@@ -7184,7 +7184,7 @@ test("`npm run check` is wired to scripts/check.mjs and exits 0 on a clean tree"
         "success output must include the CI-compatible marker line");
 });
 
-test("ralph_pause: pause-time assistant.message tokens are NOT credited to the loop budget", async () => {
+test("ap_pause: pause-time assistant.message tokens are NOT credited to the loop budget", async () => {
     // Reliability symmetric to iter 57's lastAssistantContent reset
     // (which fixed completion/abort contamination from pause-time chat).
     // Issue: while paused, the user chats freely with the agent. Each
@@ -7195,8 +7195,8 @@ test("ralph_pause: pause-time assistant.message tokens are NOT credited to the l
     // potentially triggering the max_tokens cap or warn_at_pct
     // threshold spuriously on the first post-resume idle.
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
-    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
+    const resume = controller.tools.find((t) => t.name === "ap_resume");
     // Fire iter 1 with real usage.
     emitUsage(session, { input: 100, output: 20, content: "iter 1 ok" });
     const a = controller.state.active;
@@ -7223,15 +7223,15 @@ test("ralph_pause: pause-time assistant.message tokens are NOT credited to the l
         "post-resume usage must be credited normally");
 });
 
-test("ralph_pause: pause-time chat with `max_tokens` would-be-exceeded does NOT terminate the loop", async () => {
+test("ap_pause: pause-time chat with `max_tokens` would-be-exceeded does NOT terminate the loop", async () => {
     // Concrete consequence of the byIteration/cumulative pollution test
     // above: without the guard, a long pause-time conversation would
     // push a.tokens past max_tokens and finish("max_tokens") would fire
     // on the first post-resume idle. This pins the practical user-
     // facing outcome.
     const { session, controller } = await arm({ max_iterations: 10, max_tokens: 1000, min_iterations: 1 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
-    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
+    const resume = controller.tools.find((t) => t.name === "ap_resume");
     emitUsage(session, { input: 100, output: 10, content: "iter 1 ok" });
     assert.ok(controller.state.active, "iter 1 must NOT trip the cap");
     await pause.handler({});
@@ -7246,14 +7246,14 @@ test("ralph_pause: pause-time chat with `max_tokens` would-be-exceeded does NOT 
     assert.notEqual(controller.state.lastResult?.reason, "max_tokens");
 });
 
-test("ralph_pause: pause-time content does NOT accumulate into state.lastAssistantContent", async () => {
+test("ap_pause: pause-time content does NOT accumulate into state.lastAssistantContent", async () => {
     // Iter 57 fix mitigated this via a resume-time reset; iter 59's
     // top-of-handler paused-guard is the root-cause defense. Both
     // should cooperate so even a partial future refactor that drops
     // one still keeps the contract: pause-time content is invisible
     // to the next iteration's evaluation.
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     runTurn(session, "iter 1 normal output");
     await pause.handler({});
     const beforePauseContent = controller.state.lastAssistantContent;
@@ -7265,7 +7265,7 @@ test("ralph_pause: pause-time content does NOT accumulate into state.lastAssista
 test("docs/concepts.md documents the iter-57 + iter-59 pause/resume isolation contracts", () => {
     // Drift guard: iters 57 + 59 changed the observable pause/resume
     // contract — pause-time chat is isolated from token budget AND
-    // completion/abort evaluation, and ralph_resume resets the
+    // completion/abort evaluation, and ap_resume resets the
     // lastAssistantContent buffer in addition to the stagnation
     // streak. Pin the doc so a future "trim the page" PR can't strip
     // these contracts without flagging.
@@ -7308,7 +7308,7 @@ test("sub-agent assistant.message during pause: sub-agent guard wins (no token c
     // no observedMessageThisFire mutation when a sub-agent fires
     // during pause.
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     // Fire iter 1 with real usage; a is the active state shorthand.
     emitUsage(session, { input: 100, output: 20, content: "iter 1 ok" });
     const a = controller.state.active;
@@ -7568,9 +7568,9 @@ test("release.yml runs `npm run check` so a release tag cannot ship a broken TUI
         "release.yml must run `npm run check` to syntax-validate shipped .mjs");
 });
 
-// Iter 67 — issue #7: ralph_status surfaces live token usage so the user can
+// Iter 67 — issue #7: ap_status surfaces live token usage so the user can
 // monitor budget consumption against `max_tokens` mid-run.
-test("ralph_status: includes tokens block with input/output/total/max_tokens", async () => {
+test("ap_status: includes tokens block with input/output/total/max_tokens", async () => {
     const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
     const { ralph, status, session } = await armStatusable({ git });
     await ralph.handler({ prompt: "go", max_iterations: 5, max_tokens: 999_999, stagnation_limit: 0 });
@@ -7589,7 +7589,7 @@ test("ralph_status: includes tokens block with input/output/total/max_tokens", a
     assert.equal(after.status.tokens.max_tokens, 999_999);
 });
 
-test("ralph_status: tokens.max_tokens is null when no cap was armed", async () => {
+test("ap_status: tokens.max_tokens is null when no cap was armed", async () => {
     const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
     const { ralph, status } = await armStatusable({ git });
     await ralph.handler({ prompt: "go", max_iterations: 3, stagnation_limit: 0 });
@@ -7601,10 +7601,10 @@ test("ralph_status: tokens.max_tokens is null when no cap was armed", async () =
     assert.equal(r.status.tokens.total, 0);
 });
 
-// Iter 68 — issue #7: ralph_status's `last` summary mirrors the live
+// Iter 68 — issue #7: ap_status's `last` summary mirrors the live
 // `tokens` block so a post-finish status call surfaces the run's token
 // totals without forcing the caller to parse the terminal result.
-test("ralph_status: last summary surfaces tokens block (input/output/total)", async () => {
+test("ap_status: last summary surfaces tokens block (input/output/total)", async () => {
     const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
     const { ralph, status, session } = await armStatusable({ git });
     await ralph.handler({ prompt: "go", max_iterations: 3, stagnation_limit: 0 });
@@ -7627,7 +7627,7 @@ test("ralph_status: last summary surfaces tokens block (input/output/total)", as
         "byModel must NOT bloat the snapshot's last.tokens block");
 });
 
-test("ralph_status: last.tokens omitted when run consumed zero tokens", async () => {
+test("ap_status: last.tokens omitted when run consumed zero tokens", async () => {
     const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
     const { ralph, status, session } = await armStatusable({ git });
     await ralph.handler({ prompt: "go", max_iterations: 3, stagnation_limit: 0 });
@@ -7647,17 +7647,17 @@ test("ralph_status: last.tokens omitted when run consumed zero tokens", async ()
 // token-tracking model added in iters 67/68 (live tokens block, post-finish
 // last.tokens, negative/NaN rejection, pause-time isolation, context-window
 // warnings). Pin the key terms so a future "trim concepts.md" PR cannot
-// silently drop the section that backs ralph_status's token visibility.
+// silently drop the section that backs ap_status's token visibility.
 test("docs/concepts.md documents the token-tracking model (issues #7 + iters 67/68)", () => {
     const concepts = readFileSync(resolve(REPO_ROOT, "docs/concepts.md"), "utf8");
     assert.match(concepts, /## Token tracking and context-window warnings/,
         "concepts.md must include the Token tracking section heading");
-    // Live snapshot fields surfaced by ralph_status (iter 67).
-    assert.match(concepts, /ralph_status\.tokens/);
+    // Live snapshot fields surfaced by ap_status (iter 67).
+    assert.match(concepts, /ap_status\.tokens/);
     assert.match(concepts, /\binput\b.*\boutput\b.*\btotal\b.*\bmax_tokens\b/s,
         "must list all four fields exposed on the live snapshot");
     // Post-finish summary mirror (iter 68).
-    assert.match(concepts, /ralph_status\.last\.tokens/);
+    assert.match(concepts, /ap_status\.last\.tokens/);
     // Two reliability contracts.
     assert.match(concepts, /Negative.*NaN.*Infinity.*reject/s,
         "must document the extractUsage rejection contract (iters 63/65)");
@@ -7713,19 +7713,19 @@ test("events-emit resolveRunsRoot: ignores non-string env override types", () =>
 });
 
 test("events-emit makeRunId: well-formed inputs produce `${label}-${ts}`", () => {
-    assert.equal(makeRunId("ralph_loop", 1730000000000), "ralph_loop-1730000000000");
+    assert.equal(makeRunId("ap_loop", 1730000000000), "ap_loop-1730000000000");
     assert.equal(makeRunId("self_improve", 0), "self_improve-0");
     assert.equal(makeRunId("grow_project", 1), "grow_project-1");
 });
 
 test("events-emit makeRunId: substitutes Date.now() for non-finite startedAt", () => {
     // Reliability contract: a NaN / Infinity / undefined / string startedAt
-    // must NOT collide on a literal "ralph_loop-undefined" directory path
+    // must NOT collide on a literal "ap_loop-undefined" directory path
     // (which would silently overwrite events across runs). The helper
     // substitutes Date.now() so each call gets a unique, sortable id.
     for (const bad of [undefined, null, NaN, Infinity, -Infinity, "1730000000000", {}, []]) {
-        const id = makeRunId("ralph_loop", bad);
-        assert.match(id, /^ralph_loop-\d+$/,
+        const id = makeRunId("ap_loop", bad);
+        assert.match(id, /^ap_loop-\d+$/,
             `non-finite startedAt ${displayValue(bad)} must yield a numeric id (got ${id})`);
         assert.doesNotMatch(id, /undefined|NaN|Infinity|object|\[/i,
             `non-finite startedAt ${displayValue(bad)} must NOT leak its repr into id (got ${id})`);
@@ -7743,20 +7743,20 @@ test("events-emit makeRunId: sanitizes filesystem-unsafe label characters", () =
     // uses [^A-Za-z0-9_-] → "_".
     assert.equal(makeRunId("../etc/passwd", 1), "___etc_passwd-1",
         "path traversal characters must be replaced with _");
-    assert.equal(makeRunId("ralph loop", 1), "ralph_loop-1",
+    assert.equal(makeRunId("ap loop", 1), "ap_loop-1",
         "spaces must be replaced with _");
     assert.equal(makeRunId("ralph;rm -rf", 1), "ralph_rm_-rf-1",
         "shell metacharacters must be replaced with _");
-    assert.equal(makeRunId("", 1), "ralph_loop-1",
-        "empty label falls back to the default `ralph_loop`");
-    assert.equal(makeRunId(null, 1), "ralph_loop-1",
-        "null label falls back to the default `ralph_loop`");
+    assert.equal(makeRunId("", 1), "ap_loop-1",
+        "empty label falls back to the default `ap_loop`");
+    assert.equal(makeRunId(null, 1), "ap_loop-1",
+        "null label falls back to the default `ap_loop`");
 });
 
-// Iter 71 — issue #7: ralph_status's textResultForLlm summary now appends
+// Iter 71 — issue #7: ap_status's textResultForLlm summary now appends
 // `, tokens X/Y` when max_tokens is configured so an LLM consumer reading
 // only the summary line (not the JSON snapshot) can see budget pressure.
-test("ralph_status: textResultForLlm appends tokens X/Y when max_tokens armed", async () => {
+test("ap_status: textResultForLlm appends tokens X/Y when max_tokens armed", async () => {
     const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
     const { ralph, status, session } = await armStatusable({ git });
     await ralph.handler({ prompt: "go", max_iterations: 5, max_tokens: 100_000, stagnation_limit: 0 });
@@ -7770,7 +7770,7 @@ test("ralph_status: textResultForLlm appends tokens X/Y when max_tokens armed", 
         "summary must show cumulative input+output against the cap");
 });
 
-test("ralph_status: textResultForLlm omits tokens segment when no max_tokens", async () => {
+test("ap_status: textResultForLlm omits tokens segment when no max_tokens", async () => {
     const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
     const { ralph, status, session } = await armStatusable({ git });
     await ralph.handler({ prompt: "go", max_iterations: 5, stagnation_limit: 0 });
@@ -7786,13 +7786,13 @@ test("ralph_status: textResultForLlm omits tokens segment when no max_tokens", a
     assert.equal(r.status.tokens.output, 2500);
 });
 
-test("ralph_status: paused summary still includes tokens segment when capped", async () => {
+test("ap_status: paused summary still includes tokens segment when capped", async () => {
     // Reliability: the PAUSED suffix is concatenated AFTER the tokens
     // segment so a paused loop with a cap still surfaces both pieces.
     const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
     const { ralph, status, controller } = await armStatusable({ git });
     await ralph.handler({ prompt: "go", max_iterations: 5, max_tokens: 50_000, stagnation_limit: 0 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     await pause.handler({ reason: "review diff" });
     const r = await status.handler({});
     assert.match(r.textResultForLlm, /tokens 0\/50000/);
@@ -7813,7 +7813,7 @@ test("finish log marker: abort_promise → ⚠️ ended (matches terminal event 
     session.emit("session.idle", { data: {} });
     runTurn(session, "we hit FAIL state");
     assert.match(session.logs.join("\n"),
-        /⚠️ ended ralph_loop.*reason: abort_promise/,
+        /⚠️ ended ap_loop.*reason: abort_promise/,
         "abort_promise log must use ⚠️ ended (not ⏹ stopped)");
 });
 
@@ -7823,7 +7823,7 @@ test("finish log marker: stagnation → ⚠️ ended (matches terminal event typ
     runTurn(session, "");
     runTurn(session, "");
     assert.match(session.logs.join("\n"),
-        /⚠️ ended ralph_loop.*reason: stagnation/,
+        /⚠️ ended ap_loop.*reason: stagnation/,
         "stagnation log must use ⚠️ ended (not ⏹ stopped)");
 });
 
@@ -7836,14 +7836,14 @@ test("finish log marker: max_iterations + user_stopped + max_tokens still use �
     a.session.emit("session.idle", { data: {} });
     runTurn(a.session, "iter 1, no completion");
     assert.match(a.session.logs.join("\n"),
-        /⏹ stopped ralph_loop.*reason: max_iterations/);
+        /⏹ stopped ap_loop.*reason: max_iterations/);
     // user_stopped already covered by an earlier test, but add a bare
     // sanity check here for symmetry with the ⚠️ tests above.
     const b = await arm({ max_iterations: 5 });
     b.session.emit("session.idle", { data: {} });
     await b.stop.handler({});
     assert.match(b.session.logs.join("\n"),
-        /⏹ stopped ralph_loop.*reason: user_stopped/);
+        /⏹ stopped ap_loop.*reason: user_stopped/);
 });
 
 // Iter 73 — README drift guard: the closing-line verb sentence in
@@ -7883,8 +7883,8 @@ test("README closing-line verb sentence matches VERB_BY_REASON contract", async 
 });
 
 // Iter 74 — parseUserReason direct unit tests. The helper is the
-// shared normaliser for the optional `reason` argument of ralph_pause
-// and ralph_stop. It's only covered by integration tests today; pin
+// shared normaliser for the optional `reason` argument of ap_pause
+// and ap_stop. It's only covered by integration tests today; pin
 // the documented contract directly so a future refactor (e.g.
 // inlining the helper, or swapping boundedNoteForLog for a stricter
 // trim) can't silently change behaviour for either tool.
@@ -7932,7 +7932,7 @@ test("parseUserReason: normal strings pass through bounded + flattened", () => {
 test("parseUserReason: long string is truncated at PREVIEW_CHARS", () => {
     // truncateNote enforces the PREVIEW_CHARS cap surrogate-safely.
     // A reason longer than the cap must be truncated so log markers
-    // (`paused ralph_loop (reason: …)`) cannot be flooded by a
+    // (`paused ap_loop (reason: …)`) cannot be flooded by a
     // pathological payload from a buggy automation caller.
     const long = "x".repeat(PREVIEW_CHARS + 50);
     const out = parseUserReason(long);
@@ -8021,9 +8021,9 @@ test("adaptive_budget=true: strict bounds checks are unchanged (regression guard
     assert.match(r2.error, /adaptive_max_total must be an integer in \[max_iterations=50,/);
 });
 
-test("docs/concepts.md pins the ralph_status one-line summary format (drift guard)", async () => {
+test("docs/concepts.md pins the ap_status one-line summary format (drift guard)", async () => {
     // Iter 71 added a `textResultForLlm` summary line on every
-    // `ralph_status` result. Iter 77 documented its exact slot
+    // `ap_status` result. Iter 77 documented its exact slot
     // layout in docs/concepts.md so callers can rely on a stable
     // contract. Pin the doc here so a future refactor that renames
     // a slot — `iteration` → `iter`, drops the trailing `ms` unit,
@@ -8035,7 +8035,7 @@ test("docs/concepts.md pins the ralph_status one-line summary format (drift guar
     const here = path.dirname(url.fileURLToPath(import.meta.url));
     const concepts = await fs.readFile(path.join(here, "..", "docs", "concepts.md"), "utf8");
     // Active-loop format must mention every slot the handler emits.
-    assert.match(concepts, /## `ralph_status` one-line summary/, "section heading must exist");
+    assert.match(concepts, /## `ap_status` one-line summary/, "section heading must exist");
     assert.match(concepts, /iteration \{N\}\/\{M\}, elapsed \{ms\}ms/, "active-loop summary template must list iteration + elapsed slots in order");
     assert.match(concepts, /tokens \{X\}\/\{Y\}/, "active-loop summary must document the optional tokens segment");
     assert.match(concepts, /PAUSED — \{reason\}, for \{ms\}ms/, "active-loop summary must document the optional pause segment");
@@ -8063,7 +8063,7 @@ test("coerceNumberField: rejects non-{number,string} types with type-aware error
     ]) {
         const r = coerceNumberField("max_iterations", raw);
         assert.ok(r.error, `must error on ${label}`);
-        assert.match(r.error, /^ralph_loop: max_iterations must be a number/);
+        assert.match(r.error, /^ap_loop: max_iterations must be a number/);
     }
 });
 
@@ -8223,10 +8223,10 @@ test("compareSemver: spec example chain (SemVer §11)", () => {
     }
 });
 
-test("README pins ralph_status elapsed_ms wall-clock semantics (drift guard)", async () => {
+test("README pins ap_status elapsed_ms wall-clock semantics (drift guard)", async () => {
     // Iter 77 documented in docs/concepts.md that elapsed_ms is
     // wall-clock (includes pause time). Iter 82 surfaces the same
-    // claim in README's ralph_status behaviour-notes block, since
+    // claim in README's ap_status behaviour-notes block, since
     // README is the doc most users read first. This drift guard
     // pins the README sentence so a future refactor that switches
     // elapsed_ms to active-only time (or quietly subtracts pause
@@ -8400,8 +8400,8 @@ test("RALPH_*_KEYS constants are module-level (no inline new Set in tool handler
     // every loop-control tool uses the same module-level
     // `validateOptionalArgShape(..., RALPH_*_KEYS)` shape. The
     // previous form allocated a fresh `new Set()` inline per
-    // ralph_status invocation — cheap but drift-prone (a future
-    // refactor that adds an arg to ralph_status would have to
+    // ap_status invocation — cheap but drift-prone (a future
+    // refactor that adds an arg to ap_status would have to
     // update the call site rather than a module constant).
     //
     // This drift guard pins:
@@ -8427,7 +8427,7 @@ test("RALPH_*_KEYS constants are module-level (no inline new Set in tool handler
     );
 });
 
-test("ralph_pause re-pause: pausedAt + textResultForLlm preserve the FIRST pause's identity", async () => {
+test("ap_pause re-pause: pausedAt + textResultForLlm preserve the FIRST pause's identity", async () => {
     // Iter 89 hardens the idempotency contract beyond the simpler
     // "second call returns success and first reason wins" test
     // already in place. The full contract a re-pause must honor:
@@ -8437,14 +8437,14 @@ test("ralph_pause re-pause: pausedAt + textResultForLlm preserve the FIRST pause
     //      a subsequent pause call. Otherwise the pause-duration
     //      math (`totalPausedMs += Date.now() - pausedAt` on
     //      resume) would silently undercount, hiding the time the
-    //      loop was actually paused from `ralph_status`.
+    //      loop was actually paused from `ap_status`.
     //   3. `textResultForLlm` echoes the FIRST reason — agents that
     //      read the message back must see the canonical reason,
     //      not the one they just sent. Otherwise an agent that
     //      "re-pauses with a more specific reason" would believe
     //      its update landed when it silently did not.
     const { session, controller } = await arm({ max_iterations: 5 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     runTurn(session, "boot");
     await pause.handler({ reason: "first" });
     const a = controller.state.active;
@@ -8785,7 +8785,7 @@ function captureEmitter(opts = {}) {
         mkdirSync: (p) => { dirsCreated.push(String(p)); },
         appendFileSync: (p, line) => { writes.push({ path: String(p), line: String(line) }); },
     };
-    const w = _eeCreate({ label: "ralph_loop", startedAt: 1, env: { RALPH_EVENTS_DIR: "/tmp/ralph-iter98" }, fs, ...opts });
+    const w = _eeCreate({ label: "ap_loop", startedAt: 1, env: { RALPH_EVENTS_DIR: "/tmp/ralph-iter98" }, fs, ...opts });
     return { writer: w, writes, dirsCreated };
 }
 
@@ -8854,7 +8854,7 @@ test("createEventEmitter.write: armed event also appends to the index file", () 
     // `type: "armed"` — without the index entry, `ralph-tui list` and
     // `ralph-tui stats` would skip every run this emitter records.
     const { writer, writes } = captureEmitter();
-    writer.write({ type: "armed", runId: writer.runId, label: "ralph_loop", startedAt: 1, maxIterations: 100, minIterations: 1 });
+    writer.write({ type: "armed", runId: writer.runId, label: "ap_loop", startedAt: 1, maxIterations: 100, minIterations: 1 });
     assert.equal(writes.length, 2, "armed must append to BOTH events.jsonl and index.jsonl");
     const paths = writes.map((w) => w.path);
     assert.ok(paths.some((p) => p.endsWith("events.jsonl")), "one write must target events.jsonl");
@@ -8863,7 +8863,7 @@ test("createEventEmitter.write: armed event also appends to the index file", () 
     const parsed = JSON.parse(idxLine.line.trimEnd());
     assert.equal(parsed.type, "armed", "index entry must carry type=armed (TUI filters on this)");
     assert.equal(parsed.runId, writer.runId);
-    assert.equal(parsed.label, "ralph_loop");
+    assert.equal(parsed.label, "ap_loop");
 });
 
 test("createEventEmitter.write: malformed (null/undefined/string/number) event types must not throw", () => {
@@ -9206,7 +9206,7 @@ test("install.sh: cleanup() returns 0 explicitly so the EXIT trap cannot leak a 
 // prints it on both the dry-run header (`Version:   vX.Y.Z`) and
 // the post-install success line (`Installed ralph extension vX.Y.Z
 // to …`). Single source of truth: handler.mjs's VERSION constant
-// is what the running extension reports via `ralph_status`, so the
+// is what the running extension reports via `ap_status`, so the
 // install output cannot drift away from what's actually loaded.
 test("install.sh: --dry-run header prints `Version: vX.Y.Z` matching extension/handler.mjs VERSION", () => {
     const handler = readFileSync(resolve(REPO_ROOT, "extension/handler.mjs"), "utf8");
@@ -9233,7 +9233,7 @@ test("install.sh: success line prints `Installed ralph extension vX.Y.Z` matchin
         assert.equal(r.status, 0, `install.sh exited ${r.status}; stderr=${r.stderr}`);
         const re = new RegExp(`✅ Installed ralph extension v${version.replace(/\./g, "\\.")} to `);
         assert.match(r.stdout, re,
-            `success line must echo "Installed ralph extension v${version} to …" so the post-install confirmation matches what ralph_status reports at runtime`);
+            `success line must echo "Installed ralph extension v${version} to …" so the post-install confirmation matches what ap_status reports at runtime`);
     } finally {
         rmSync(sandboxHome, { recursive: true, force: true });
     }
@@ -9322,8 +9322,8 @@ test("docs/RELEASING.md and AGENTS.md describe the same canonical CHANGELOG head
         "AGENTS.md must not document a date suffix on release headings — no existing CHANGELOG section uses one, and adding one would break the manual extraction awk in RELEASING.md");
 });
 
-// Iter 111 — ralph_status one-line summary when paused WITHOUT a
-// reason. `docs/concepts.md` §"`ralph_status` one-line summary"
+// Iter 111 — ap_status one-line summary when paused WITHOUT a
+// reason. `docs/concepts.md` §"`ap_status` one-line summary"
 // explicitly documents that the em-dash + reason are omitted when
 // no reason was provided, leaving the literal ` (PAUSED, for
 // {ms}ms)` segment. The em-dash-with-reason case is pinned by
@@ -9332,11 +9332,11 @@ test("docs/RELEASING.md and AGENTS.md describe the same canonical CHANGELOG head
 // asserted, so a future ternary refactor could silently render
 // ` (PAUSED — , for {ms}ms)` (stray em-dash + empty reason)
 // without any failing test. Pin the documented format.
-test("ralph_status: paused-without-reason summary uses ` (PAUSED, for {ms}ms)` form (no em-dash)", async () => {
+test("ap_status: paused-without-reason summary uses ` (PAUSED, for {ms}ms)` form (no em-dash)", async () => {
     const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
     const { ralph, status, controller } = await armStatusable({ git });
     await ralph.handler({ prompt: "go", max_iterations: 5, stagnation_limit: 0 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     // Pause WITHOUT supplying `reason`. parseUserReason coerces a
     // missing field to null, so the summary builder must drop the
     // em-dash + reason fragment entirely.
@@ -9348,7 +9348,7 @@ test("ralph_status: paused-without-reason summary uses ` (PAUSED, for {ms}ms)` f
         `summary must NOT include the em-dash separator when no pause reason was provided — that would render ' (PAUSED — , for …)' with an empty reason slot. Got: ${JSON.stringify(r.textResultForLlm)}`);
 });
 
-test("ralph_status: paused-without-reason summary preserves docs format even after whitespace-only reason input", async () => {
+test("ap_status: paused-without-reason summary preserves docs format even after whitespace-only reason input", async () => {
     // Companion guard: parseUserReason flattens whitespace-only
     // strings to null (iter 7559 test pins the helper). Ensure the
     // summary path inherits the same coercion — a user passing
@@ -9358,7 +9358,7 @@ test("ralph_status: paused-without-reason summary preserves docs format even aft
     const git = makeGitStub({ "rev-parse HEAD": { ok: false } });
     const { ralph, status, controller } = await armStatusable({ git });
     await ralph.handler({ prompt: "go", max_iterations: 5, stagnation_limit: 0 });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     await pause.handler({ reason: "   \t\n   " });
     const r = await status.handler({});
     assert.match(r.textResultForLlm, / \(PAUSED, for \d+ms\)/,
@@ -9469,7 +9469,7 @@ test("install.sh: FILES array places entry-point extension.mjs LAST for atomic-r
 // no-reason summary as ` (PAUSED, for {ms}ms)` (no em-dash) but the
 // README still claimed the em-dash form was unconditional. A
 // contributor consuming the README to write a regex against
-// ralph_status output would have built `/PAUSED — /` and missed every
+// ap_status output would have built `/PAUSED — /` and missed every
 // reasonless pause. Pin the docs accuracy so a future "shorten the
 // README" PR can't silently re-introduce the drift.
 test("README documents both PAUSED summary forms (with-reason em-dash + bare no-reason)", () => {
@@ -10457,13 +10457,13 @@ test("docs/concepts.md mentions zero/zero pair rejection in token-credit contrac
         "concepts.md credit-rejection bullet must mention the at-least-one-positive clause");
 });
 
-test("ralph_resume: clamps pausedFor to >= 0 when system clock skews backward (clock-rewind guard)", async () => {
+test("ap_resume: clamps pausedFor to >= 0 when system clock skews backward (clock-rewind guard)", async () => {
     // Iter 154 — `finish()` (handler.mjs:1400) already guards
     // currentPauseMs with `Math.max(0, finishedAt - pausedAt)` for
     // exactly the case where the system clock moves backward
     // between pause and finish (NTP correction, manual clock change,
     // a daylight-savings transition on a host without monotonic-time
-    // backing). The companion `ralph_resume` path computed
+    // backing). The companion `ap_resume` path computed
     // `pausedFor = a.pausedAt > 0 ? Date.now() - a.pausedAt : 0`
     // with NO clamp, so a clock rewind during a pause would credit
     // a NEGATIVE pause duration to `totalPausedMs` — which is
@@ -10474,11 +10474,11 @@ test("ralph_resume: clamps pausedFor to >= 0 when system clock skews backward (c
     const controller = createRalphController();
     const sess = makeFakeSession();
     controller.attach(sess);
-    await controller.tools.find((t) => t.name === "ralph_loop").handler({
+    await controller.tools.find((t) => t.name === "ap_loop").handler({
         prompt: "x", max_iterations: 5, min_iterations: 1,
     });
-    const pauseTool = controller.tools.find((t) => t.name === "ralph_pause");
-    const resumeTool = controller.tools.find((t) => t.name === "ralph_resume");
+    const pauseTool = controller.tools.find((t) => t.name === "ap_pause");
+    const resumeTool = controller.tools.find((t) => t.name === "ap_resume");
     await pauseTool.handler({ reason: "clock-skew test" });
     // Simulate clock skew: shove pausedAt INTO the future so the
     // resume's `Date.now() - pausedAt` would compute negative.
@@ -10496,12 +10496,12 @@ test("ralph_resume: clamps pausedFor to >= 0 when system clock skews backward (c
     // And totalPausedMs must NOT have been credited a negative value.
     assert.ok(controller.state.active.totalPausedMs >= 0,
         `totalPausedMs must remain >= 0 (got ${controller.state.active.totalPausedMs})`);
-    await controller.tools.find((t) => t.name === "ralph_stop").handler({});
+    await controller.tools.find((t) => t.name === "ap_stop").handler({});
 });
 
 test("pauseElapsedFromAt: never-paused sentinel + clock-skew clamp (direct)", () => {
     // Iter 155 — the helper extracted from three formerly-duplicated
-    // call sites (finish(), ralph_status, ralph_resume) that all
+    // call sites (finish(), ap_status, ap_resume) that all
     // computed "elapsed ms since pausedAt, clamped >= 0, with a
     // never-paused sentinel of 0". Pre-iter-155 the resume site had
     // drifted off the clamp (fixed iter 154); centralising the
@@ -10530,7 +10530,7 @@ test("docs/faq.md pausedForMs section reflects iter-154 Math.max(0, …) clamp",
     // Iter 157 — `docs/faq.md` "Why is pausedForMs zero on a resume
     // event?" section described pausedForMs as `now - pausedAt` —
     // the pre-iter-154 unclamped formula. After iter 154 (the
-    // ralph_resume clamp fix) and iter 155 (the pauseElapsedFromAt
+    // ap_resume clamp fix) and iter 155 (the pauseElapsedFromAt
     // helper extraction), the runtime computes
     // `pausedAt > 0 ? Math.max(0, now - pausedAt) : 0`. A user on a
     // system with NTP correction or a manual clock change would

--- a/test/handler-events.test.mjs
+++ b/test/handler-events.test.mjs
@@ -59,8 +59,8 @@ async function arm(extra = {}, eventsOpt = true) {
     const session = makeFakeSession();
     const controller = createRalphController({ events });
     controller.attach(session);
-    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
-    const stop = controller.tools.find((t) => t.name === "ralph_stop");
+    const ralph = controller.tools.find((t) => t.name === "ap_loop");
+    const stop = controller.tools.find((t) => t.name === "ap_stop");
     await ralph.handler({ prompt: "go", max_iterations: 5, ...extra });
     return { session, controller, ralph, stop, calls, closes };
 }
@@ -85,9 +85,9 @@ test("events: emits armed → iteration_start → iteration_end → complete seq
         "complete",
     ]);
     const armed = calls[0].events[0];
-    assert.equal(armed.label, "ralph_loop");
+    assert.equal(armed.label, "ap_loop");
     assert.equal(armed.maxIterations, 2);
-    assert.match(armed.runId, /^ralph_loop-\d+$/);
+    assert.match(armed.runId, /^ap_loop-\d+$/);
     const done = calls[0].events.at(-1);
     assert.equal(done.reason, "completion_promise");
     assert.equal(done.iterations, 2);
@@ -127,8 +127,8 @@ test("events: aborted reason maps to type=abort, not type=complete", async () =>
 test("events: pause/resume emit dedicated events keyed to the active runId", async () => {
     const { session, controller, calls } = await arm({ max_iterations: 5 });
     session.emit("session.idle", { data: {} });   // iter 1 fires
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
-    const resume = controller.tools.find((t) => t.name === "ralph_resume");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
+    const resume = controller.tools.find((t) => t.name === "ap_resume");
     await pause.handler({ reason: "lunch" });
     await resume.handler({});
     runTurn(session, "back");
@@ -137,14 +137,14 @@ test("events: pause/resume emit dedicated events keyed to the active runId", asy
     assert.ok(types.includes("resume"));
     const pauseEv = calls[0].events.find((e) => e.type === "pause");
     assert.equal(pauseEv.reason, "lunch");
-    assert.match(pauseEv.runId, /^ralph_loop-\d+$/);
+    assert.match(pauseEv.runId, /^ap_loop-\d+$/);
 });
 
 test("events: opts.events undefined ⇒ no writer attached, no emit", async () => {
     const session = makeFakeSession();
     const controller = createRalphController(); // no events at all
     controller.attach(session);
-    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
+    const ralph = controller.tools.find((t) => t.name === "ap_loop");
     await ralph.handler({ prompt: "go", max_iterations: 1, completion_promise: "X" });
     session.emit("session.idle", { data: {} });
     assert.equal(controller.state.active.events, null);
@@ -166,7 +166,7 @@ test("events: factory throwing is swallowed; loop runs without events", async ()
         events: { factory: () => { throw new Error("boom"); } },
     });
     controller.attach(session);
-    const ralph = controller.tools.find((t) => t.name === "ralph_loop");
+    const ralph = controller.tools.find((t) => t.name === "ap_loop");
     const r = await ralph.handler({ prompt: "go", max_iterations: 1, completion_promise: "X" });
     assert.equal(r.resultType, "success");
     assert.equal(controller.state.active.events, null);
@@ -203,7 +203,7 @@ test("events: iteration_end carries excerpt and per-iter token totals", async ()
 test("events: pause event reason is null when reason is absent", async () => {
     const { session, controller, calls } = await arm({ max_iterations: 5 });
     session.emit("session.idle", { data: {} });   // iter 1 fires
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     await pause.handler({});
     const pauseEv = calls[0].events.find((e) => e.type === "pause");
     assert.ok(pauseEv, "pause event must be emitted");
@@ -217,7 +217,7 @@ test("events: pause event reason is null when reason is absent", async () => {
 test("events: pause event reason is null when reason is whitespace-only", async () => {
     const { session, controller, calls } = await arm({ max_iterations: 5 });
     session.emit("session.idle", { data: {} });   // iter 1 fires
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     // Mix every common whitespace shape: spaces, tabs, newlines, CRLF.
     await pause.handler({ reason: "   \t\r\n   " });
     const pauseEv = calls[0].events.find((e) => e.type === "pause");
@@ -230,8 +230,8 @@ test("events: pause event reason is null when reason is whitespace-only", async 
 });
 
 // Iter 124 — pin that the JSONL `pause` event is emitted exactly ONCE
-// per logical pause. `ralph_pause` is idempotent at the handler level
-// (test/extension.test.mjs:"ralph_pause is idempotent — pausing an
+// per logical pause. `ap_pause` is idempotent at the handler level
+// (test/extension.test.mjs:"ap_pause is idempotent — pausing an
 // already-paused loop is a no-op success") — the second call returns
 // success with the FIRST pause's reason and does not mutate state. But
 // the JSONL emitter side has no equivalent runtime guard: if a future
@@ -246,10 +246,10 @@ test("events: pause event reason is null when reason is whitespace-only", async 
 // invariant directly catches a copy-paste regression that test
 // 5959-5968 would not — that test only inspects in-memory state, not
 // the durable JSONL trace.
-test("events: ralph_pause is idempotent on the JSONL emit side too — exactly one pause event per logical pause", async () => {
+test("events: ap_pause is idempotent on the JSONL emit side too — exactly one pause event per logical pause", async () => {
     const { session, controller, calls } = await arm({ max_iterations: 5 });
     session.emit("session.idle", { data: {} });
-    const pause = controller.tools.find((t) => t.name === "ralph_pause");
+    const pause = controller.tools.find((t) => t.name === "ap_pause");
     await pause.handler({ reason: "first" });
     await pause.handler({ reason: "second" });
     await pause.handler({ reason: "third" });
@@ -257,7 +257,7 @@ test("events: ralph_pause is idempotent on the JSONL emit side too — exactly o
     assert.equal(
         pauseEvents.length,
         1,
-        `idempotent ralph_pause must emit exactly ONE pause event in the JSONL stream; got ${pauseEvents.length}: ${JSON.stringify(pauseEvents)}`,
+        `idempotent ap_pause must emit exactly ONE pause event in the JSONL stream; got ${pauseEvents.length}: ${JSON.stringify(pauseEvents)}`,
     );
     // First pause's reason wins (first-write-wins matches the in-memory
     // pauseReason semantics asserted in test 5959-5968).


### PR DESCRIPTION
## Stage 1 of `copilot-ralph-extension` → `autopilot` rename (refs #49)

Draft PR — first slice of the multi-stage rename tracked by [issue
#49](https://github.com/kloba/copilot-ralph-extension/issues/49).
Stays in draft until subsequent stage commits land on this branch
and the full `feat!:` surface is ready to ship as a single
squash-merge per [issue #49 "Execution"
decision](https://github.com/kloba/copilot-ralph-extension/issues/49).

### What this slice does

Drops the *project-branding* "Ralph Wiggum"-style prose:

- root `package.json` description + `keywords[]` (drop `ralph-wiggum`)
- `packages/tui/package.json` `keywords[]` (drop `ralph-wiggum`)
- `mkdocs.yml` `site_description`
- `extension/extension.mjs` and `extension/handler.mjs` file-header
  comments
- `extension/handler.mjs` `ralph_loop` tool description (lead phrase
  only — the test-pinned substrings `ralph_stop` / `ralph_loop` /
  `self_improve` / `grow_project` / `session.idle` are unchanged)
- `README.md` subtitle
- `docs/index.md` subtitle and the "Why 'Ralph'?" section (renamed
  to "Why a loop?")

### What this slice does NOT do

- **Factual external attribution** to Anthropic's original Ralph
  Wiggum Claude Code plugin is preserved verbatim:
  - `README.md` "Inspired by Anthropic Ralph Wiggum" badge
  - `README.md` "What is Ralph Wiggum?" technique-explainer section
  - `docs/ARCHITECTURE.md` factual hyperlink to
    `anthropics/claude-code/.../plugins/ralph-wiggum`
  - `docs/index.md` Anthropic-plugin link in the new "Why a loop?"
    section
- The `copilot-ralph` co-author trailer literal stays untouched
  (issue #49 "Decisions already locked": KEEP verbatim).
- Package name (`copilot-ralph-extension`), TUI sub-package
  (`@copilot-ralph-extension/tui`), binary (`ralph-tui`), tool names
  (`ralph_{loop,status,pause,resume,stop}`), env vars (`RALPH_*`),
  and runtime paths (`~/.copilot/ralph*`) are all **unchanged in
  this slice** — they land in subsequent commits on this branch.

### Validation

- `npm test` — **920/920 green** (same as `main` baseline).
- `npm run check` — green (22 .mjs files syntax-checked).
- `## Unreleased` `### Documentation` entry placed after the
  existing first-batch `### Features` block to respect AGENTS.md's
  section-name order — pinned by the
  `test/extension.test.mjs` "AGENTS.md section-name order matches
  the order used in CHANGELOG.md's `## Unreleased` block"
  drift-guard test.

### Why a separate small slice?

The full rename touches ~46 files / ~700+ string hits / 5 still-open
decisions ([#49 A-E](https://github.com/kloba/copilot-ralph-extension/issues/49)).
Landing the entire rename in a single iteration risks leaving the
branch in a half-broken state. This slice is the lowest-blast-radius
chunk that's still user-visible (npm metadata + docs prose) and lets
future iters extend the same branch incrementally with
tree-green-between-commits.

Refs #49.
