### PR TITLE
feat(tui): panel headings + live Timeline excerpt + LastCommit replay-on-mount (refs #54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 ## Unreleased
 
 ### Features
+- Issue #54 — `ralph-tui run` UX hardening across the
+  three-level layout. The four top panes
+  (`<Header>` / `<StagesRow>` / `<TasksPane>` /
+  `<SubstagesPane>`) now render a bold-underline heading
+  (`Run` / `Stages` / `Tasks` / `Activity`) inside their
+  bordered Box matching the existing inside-border heading
+  convention used by `<Timeline>` / `<DetailPane>` /
+  `<LastCommit>`, so each pane is identifiable without
+  hovering for context. `<SubstagesPane>` decouples the
+  pane heading from the active-stage marker — `Activity` is
+  the heading and the `▸ STAGE_NAME` body row remains in the
+  first content position so the substage stream still scopes
+  visually to its parent stage. The `<Timeline>` pane now
+  shows `(working…)` (dim) for in-flight iters that haven't
+  yet streamed an excerpt, instead of the misleading
+  `(no excerpt)` which made finished and in-flight iters
+  indistinguishable; finished iters with no captured
+  excerpt still get the historical `(no excerpt)` placeholder
+  so replay fidelity for old runs is intact. `<Timeline>`
+  also picks up live excerpt streaming: the runner streams
+  root-agent `assistant.message.data.content` into existing
+  `usage_update` events whenever 80+ new chars accumulate,
+  capped at 500 chars surrogate-safely. `foldEvents` extends
+  the `usage_update` case to update `iterations[last].excerpt`
+  when the live event matches the in-flight iter (guarded by
+  `endedAt == null` so a late event can't clobber a closed
+  iter's excerpt) and `snap.lastExcerpt` for run-scope
+  display, so the user sees mid-iter narration update within
+  seconds of the agent emitting it rather than waiting for
+  `iteration_end` at iter close. The `<LastCommit>` pane is
+  no longer empty on mount when the run hasn't yet made a
+  commit: the runner shells `git rev-parse --short HEAD` +
+  `git log -1 --pretty=format:%s%(trailers:only)` once at
+  arm time (right after the canonical `armed` event,
+  carrying `iteration: 0`) so HEAD surfaces immediately;
+  `defaultGitExec` gained a 200 ms `spawnSync` timeout to
+  protect the start path against a wedged repo (lock file,
+  hung credential helper). When `gitExec` is null (test
+  injection without a stub) or the cwd isn't a git repo,
+  arm-time replay is silently skipped — no crash, no spurious
+  event, the pane just stays empty exactly like before the
+  fix when there's nothing to surface.
+
 - TUI 3-level renderer (issue #48 slice 9): the `<App>` layout
   now composes the new `<TasksPane>` + `<LastCommit>` panes
   alongside the existing `<Header>` / `<StagesRow>` /

--- a/packages/tui/src/components/Header.mjs
+++ b/packages/tui/src/components/Header.mjs
@@ -161,10 +161,18 @@ export default function Header({ snapshot }) {
           )
         : null;
 
+    // Issue #54 slice 1 — heading "Run" sits as the first child
+    // inside the bordered Box, matching the existing inside-border
+    // heading convention used by Timeline / DetailPane / TasksPane.
+    // The status badge (RUN / DONE / PAUSE) lives in the topRow
+    // right of the heading, so the heading is the user-facing pane
+    // label rather than a duplicate of the status.
+    const heading = h(Text, { bold: true, underline: true }, "Run");
+
     return h(Box, {
         borderStyle: "round",
         borderColor: "blue",
         paddingX: 1,
         flexDirection: "column",
-    }, topRow, workItemRow, backlogRow);
+    }, heading, topRow, workItemRow, backlogRow);
 }

--- a/packages/tui/src/components/StagesRow.mjs
+++ b/packages/tui/src/components/StagesRow.mjs
@@ -122,11 +122,18 @@ export default function StagesRow({ snapshot }) {
         }
     }
 
+    // Issue #54 slice 1 — heading "Stages" matches the inside-
+    // border convention used by the rest of the panes (Timeline /
+    // DetailPane / TasksPane).
+    const heading = h(Text, { bold: true, underline: true }, "Stages");
+
     return h(Box, {
         borderStyle: "single",
         borderColor: "gray",
         paddingX: 1,
-        flexDirection: "row",
-        flexWrap: "wrap",
-    }, ...pills);
+        flexDirection: "column",
+    },
+        heading,
+        h(Box, { flexDirection: "row", flexWrap: "wrap" }, ...pills),
+    );
 }

--- a/packages/tui/src/components/SubstagesPane.mjs
+++ b/packages/tui/src/components/SubstagesPane.mjs
@@ -35,11 +35,16 @@ export default function SubstagesPane({ snapshot, maxRows = 12 }) {
     const active = snapshot?.activeStage ?? null;
     const subs = snapshot?.currentStageSubstages ?? [];
 
-    const titleText = active
+    // Issue #54 slice 1 — heading "Activity" decouples the pane
+    // title from the `▸ STAGE_NAME` line, which now sits as the
+    // first body row. Matches the inside-border heading convention
+    // used by Timeline / DetailPane / TasksPane.
+    const heading = h(Text, { bold: true, underline: true }, "Activity");
+
+    const stageRowText = active
         ? `▸ ${active.name}  (substage activity)`
         : "▸ (no active stage)";
-
-    const title = h(Text, { bold: true, color: "cyan" }, titleText);
+    const stageRow = h(Text, { bold: true, color: "cyan" }, stageRowText);
 
     let body;
     if (!subs || subs.length === 0) {
@@ -74,5 +79,5 @@ export default function SubstagesPane({ snapshot, maxRows = 12 }) {
         borderColor: "gray",
         paddingX: 1,
         flexDirection: "column",
-    }, title, body);
+    }, heading, stageRow, body);
 }

--- a/packages/tui/src/components/TasksPane.mjs
+++ b/packages/tui/src/components/TasksPane.mjs
@@ -121,6 +121,9 @@ const STATE_COLOR = {
 };
 
 export default function TasksPane({ snapshot }) {
+    // Issue #54 slice 1 — heading "Tasks" matches the inside-border
+    // convention used by Timeline / DetailPane / LastCommit.
+    const heading = h(Text, { bold: true, underline: true }, "Tasks");
     const rows = computeTaskRows(snapshot);
     if (rows.length === 0) {
         return h(Box, {
@@ -129,6 +132,7 @@ export default function TasksPane({ snapshot }) {
             paddingX: 1,
             flexDirection: "column",
         },
+            heading,
             h(Text, { dimColor: true }, "tasks: (no task list yet)"),
         );
     }
@@ -157,5 +161,5 @@ export default function TasksPane({ snapshot }) {
         borderColor: "gray",
         paddingX: 1,
         flexDirection: "column",
-    }, ...elements);
+    }, heading, ...elements);
 }

--- a/packages/tui/src/components/Timeline.mjs
+++ b/packages/tui/src/components/Timeline.mjs
@@ -64,12 +64,29 @@ export default function Timeline({ snapshot, limit = DEFAULT_LIMIT }) {
             : kind === "pending" ? "cyan"
             : kind === "stagnant" ? "yellow"
             : "red";
+        // Issue #54 slice 2a — surface live excerpt for in-flight
+        // iters. When the iter has an excerpt set (mid-iter
+        // streaming via `usage_update` excerpt field, or post-iter
+        // `iteration_end`), render it. When the iter is in-flight
+        // (endedAt == null) and no excerpt has streamed yet, show
+        // a `(working…)` placeholder so the row signals progress
+        // rather than looking broken with `(no excerpt)`. Finished
+        // iters with no excerpt fall back to the historical
+        // placeholder so replay-fidelity for old runs is intact.
+        let excerptCell;
+        if (it.excerpt) {
+            excerptCell = h(Text, { dimColor: true }, truncate(it.excerpt, 80));
+        } else if (it.endedAt == null) {
+            excerptCell = h(Text, { dimColor: true }, "(working…)");
+        } else {
+            excerptCell = h(Text, { dimColor: true }, "(no excerpt)");
+        }
         return h(Box, { key: it.iteration, flexDirection: "row" },
             h(Text, { color }, GLYPH[kind]),
             h(Text, null, " "),
             h(Text, null, "#" + pad(it.iteration, totalWidth)),
             h(Text, null, "  "),
-            h(Text, { dimColor: true }, it.excerpt ? truncate(it.excerpt, 80) : "(no excerpt)"),
+            excerptCell,
         );
     });
 

--- a/packages/tui/src/events.mjs
+++ b/packages/tui/src/events.mjs
@@ -731,6 +731,32 @@ export function foldEvents(events) {
                 if (Number.isFinite(ev.premiumRequests) && ev.premiumRequests >= 0) {
                     snap.premiumRequests = ev.premiumRequests;
                 }
+                // Issue #54 slice 2a — live Timeline excerpt. The
+                // runner streams root-agent `assistant.message`
+                // content into `usage_update` events whenever 80+
+                // new chars accumulate so the in-flight iter row
+                // shows live progress instead of `(working…)`. Both
+                // `snap.lastExcerpt` (run-scope) and
+                // `iterations[last].excerpt` (per-iter) are updated
+                // together, gated by the same `endedAt == null` +
+                // iter-match check so a late event landing after
+                // `iteration_end` (e.g. delayed delivery during the
+                // iter rollover) cannot regress either surface to a
+                // stale value. The closed iter's excerpt stays as
+                // the canonical post-iter reduction wrote it, and
+                // lastExcerpt stays on the most-recent observed
+                // iter — preserving Detail/Timeline parity.
+                if (typeof ev.excerpt === "string" && ev.excerpt) {
+                    const last = snap.iterations[snap.iterations.length - 1];
+                    if (
+                        last
+                        && last.endedAt == null
+                        && (!Number.isFinite(ev.iteration) || last.iteration === ev.iteration)
+                    ) {
+                        last.excerpt = ev.excerpt;
+                        snap.lastExcerpt = ev.excerpt;
+                    }
+                }
                 break;
             }
             case "pause":

--- a/packages/tui/src/runner.mjs
+++ b/packages/tui/src/runner.mjs
@@ -558,6 +558,14 @@ function defaultGitExec({ args, cwd, env }) {
             env,
             encoding: "utf8",
             stdio: ["ignore", "pipe", "pipe"],
+            // Issue #54 slice 2c — arm-time replay shells out to git
+            // before the first iter renders. A 200 ms ceiling protects
+            // against a wedged git repo (lock file, hung credential
+            // helper) silently delaying the run.start path; the
+            // emitCommitObservedFromHead caller already swallows null,
+            // so a timeout just means "skip the LastCommit pane on
+            // mount" rather than crash.
+            timeout: 200,
         });
         if (r.status !== 0) return null;
         return typeof r.stdout === "string" ? r.stdout : null;
@@ -1108,6 +1116,34 @@ export async function runRalphTui(opts) {
         mode,
     });
 
+    // Issue #54 slice 2c — replay HEAD on mount so the LastCommit
+    // pane is never empty when commits exist on disk. Without this
+    // emit, a fresh run that hasn't yet made a commit (e.g. iter 0,
+    // or the first few iters of a `--prompt` run that doesn't touch
+    // git) shows an empty pane even though `git log -1` has plenty
+    // to surface. Carries `iteration: 0` so foldEvents lays the
+    // arm-time HEAD into `snap.lastCommit` before any iter has run;
+    // a later `commit_observed` from the iter loop simply
+    // overwrites it (which is the desired behaviour — newest commit
+    // wins). When `gitExec` is null (test runner without a stub) or
+    // the cwd isn't a repo, `readHeadCommit` returns null and we
+    // silently skip — the pane stays empty exactly like before.
+    try {
+        const armHead = readHeadCommit({ gitExec, cwd, env });
+        if (armHead) {
+            emitter.write({
+                type: "commit_observed",
+                ts: now(),
+                runId,
+                label,
+                iteration: 0,
+                sha: armHead.sha,
+                subject: armHead.subject,
+                trailers: armHead.trailers,
+            });
+        }
+    } catch { /* serialization rejection — skip */ }
+
     if (onRunId) {
         try { onRunId(runId); } catch { /* swallow */ }
     }
@@ -1442,6 +1478,20 @@ export async function runRalphTui(opts) {
         // reconciliation pulls everything back into agreement.
         let iterLiveOutputTokens = 0;
         let iterLivePremiumRequests = null;
+        // Issue #54 slice 2a — per-iter accumulator of root-agent
+        // assistant content used for live Timeline excerpt updates.
+        // Concatenates each `assistant.message.data.content` chunk
+        // (root agent only — sub-agent excerpts would clobber the
+        // user-visible iter narration). Capped at LIVE_EXCERPT_BYTES
+        // chars at emit time (events.mjs serializer also caps at 500
+        // surrogate-safely as defence in depth). Reset implicitly
+        // because the whole `onLine` closure is rebuilt per-iter.
+        let iterLiveExcerpt = "";
+        let iterLiveExcerptLastEmittedLen = 0;
+        // 80 chars ≈ one Timeline row's worth of new content. Below
+        // this we don't bother emitting — Timeline truncates to 80
+        // anyway, so a smaller delta would be invisible to the user.
+        const LIVE_EXCERPT_THRESHOLD = 80;
         const onLine = (rawEvent) => {
             // `runOneIteration` already wraps this in try/catch so a
             // throw here is silently swallowed — but a swallowed
@@ -1464,6 +1514,16 @@ export async function runRalphTui(opts) {
             try {
                 if (rawEvent && rawEvent.type === "assistant.message" && rawEvent.data && !rawEvent.agentId) {
                     const tok = Number(rawEvent.data.outputTokens);
+                    // Issue #54 slice 2a — accumulate root-agent
+                    // content for live Timeline excerpt streaming.
+                    // Done independently of the tokens path so a
+                    // root-agent message with no outputTokens (e.g.
+                    // a streamed-in-parts assistant message where
+                    // only the final chunk carries the cumulative
+                    // delta) still feeds the excerpt accumulator.
+                    if (typeof rawEvent.data.content === "string" && rawEvent.data.content.length > 0) {
+                        iterLiveExcerpt += rawEvent.data.content;
+                    }
                     if (Number.isFinite(tok) && tok > 0) {
                         iterLiveOutputTokens += tok;
                         const ev = {
@@ -1477,7 +1537,48 @@ export async function runRalphTui(opts) {
                         if (runPremiumRequests !== null || iterLivePremiumRequests !== null) {
                             ev.premiumRequests = (runPremiumRequests ?? 0) + (iterLivePremiumRequests ?? 0);
                         }
+                        // Piggyback live excerpt onto this same
+                        // event whenever we have new content. The
+                        // FIRST excerpt fires as soon as ANY content
+                        // accumulates so a terse iter (1-79 chars)
+                        // doesn't show `(working…)` for the whole
+                        // duration. Subsequent updates apply the
+                        // 80-char delta threshold so we don't churn
+                        // the event stream. Reusing the existing
+                        // usage_update keeps the event stream lean
+                        // (no separate excerpt-only event type) and
+                        // decouples emit cadence from token cadence.
+                        const newChars = iterLiveExcerpt.length - iterLiveExcerptLastEmittedLen;
+                        const isFirstExcerpt = iterLiveExcerptLastEmittedLen === 0 && iterLiveExcerpt.length > 0;
+                        if (isFirstExcerpt || newChars >= LIVE_EXCERPT_THRESHOLD) {
+                            ev.excerpt = iterLiveExcerpt.slice(0, 500);
+                            iterLiveExcerptLastEmittedLen = iterLiveExcerpt.length;
+                        }
                         emitter.write(ev);
+                    } else {
+                        const newChars = iterLiveExcerpt.length - iterLiveExcerptLastEmittedLen;
+                        const isFirstExcerpt = iterLiveExcerptLastEmittedLen === 0 && iterLiveExcerpt.length > 0;
+                        if (isFirstExcerpt || newChars >= LIVE_EXCERPT_THRESHOLD) {
+                            // No tokens, but new content worth
+                            // surfacing. Emit an excerpt-bearing
+                            // usage_update so the Timeline row
+                            // updates even when the agent is between
+                            // token-bearing message boundaries.
+                            const ev = {
+                                type: "usage_update",
+                                ts: now(),
+                                runId,
+                                label,
+                                iteration: iter,
+                                tokens: { input: 0, output: runOutputTokens + iterLiveOutputTokens },
+                                excerpt: iterLiveExcerpt.slice(0, 500),
+                            };
+                            if (runPremiumRequests !== null || iterLivePremiumRequests !== null) {
+                                ev.premiumRequests = (runPremiumRequests ?? 0) + (iterLivePremiumRequests ?? 0);
+                            }
+                            iterLiveExcerptLastEmittedLen = iterLiveExcerpt.length;
+                            emitter.write(ev);
+                        }
                     }
                 } else if (rawEvent && rawEvent.type === "result") {
                     const pr = Number(rawEvent.usage?.premiumRequests);

--- a/packages/tui/test/components.test.mjs
+++ b/packages/tui/test/components.test.mjs
@@ -787,3 +787,116 @@ test("App: 3-level layout — work item header, plan stages, tasks pane, last co
     assert.match(out, /deadbee/);
     assert.match(out, /land 3-level renderer/);
 });
+
+// ─── Issue #54: panel headings + live excerpt + replay-on-mount ──────
+
+test("Issue #54 slice 1: Header renders 'Run' heading inside the bordered Box", { skip }, () => {
+    const snapshot = {
+        status: "running",
+        label: "self_improve",
+        runId: "r1700000000000",
+        iteration: 1,
+        maxIterations: 5,
+        minIterations: 1,
+        tokens: { input: 0, output: 0 },
+    };
+    const out = render(React.createElement(Header, { snapshot })).lastFrame();
+    // The heading must appear before the status badge / iter counter
+    // line so users see "Run" as the pane label, not buried below.
+    assert.match(out, /Run/);
+    const runIdx = out.indexOf("Run");
+    const iterIdx = out.indexOf("iter");
+    assert.ok(runIdx >= 0 && iterIdx > runIdx, "Run heading appears before iter counter");
+});
+
+test("Issue #54 slice 1: Timeline renders 'Timeline' heading", { skip }, () => {
+    const out = render(React.createElement(Timeline, { snapshot: { iterations: [] } })).lastFrame();
+    assert.match(out, /Timeline/);
+});
+
+test("Issue #54 slice 1: StagesRow renders 'Stages' heading", { skip }, async () => {
+    const StagesRow = (await import("../src/components/StagesRow.mjs")).default;
+    const snapshot = {
+        currentPlan: { stages: ["DIAG", "FIX", "TEST", "COMMIT", "PUSH", "END"] },
+        activeStage: { stage: 2, name: "FIX" },
+        recentStages: [{ stage: 1, name: "DIAG" }],
+    };
+    const out = render(React.createElement(StagesRow, { snapshot })).lastFrame();
+    assert.match(out, /Stages/);
+    // Heading sits ABOVE the pill row.
+    const headingIdx = out.indexOf("Stages");
+    const pillIdx = out.indexOf("DIAG");
+    assert.ok(headingIdx >= 0 && pillIdx > headingIdx, "Stages heading before pills");
+});
+
+test("Issue #54 slice 1: TasksPane renders 'Tasks' heading", { skip }, async () => {
+    const TasksPane = (await import("../src/components/TasksPane.mjs")).default;
+    // Empty-rows path.
+    const out1 = render(React.createElement(TasksPane, { snapshot: {} })).lastFrame();
+    assert.match(out1, /Tasks/);
+    // Rendered-rows path.
+    const snapshot = {
+        currentPlan: { stages: ["DIAG"] },
+        activeStage: { stage: 1, name: "DIAG" },
+        currentTaskList: { stage: "DIAG", items: ["read code", "form hypothesis"] },
+        taskInFlight: { stage: "DIAG", sub: 1, desc: "read code" },
+        recentTasks: [],
+    };
+    const out2 = render(React.createElement(TasksPane, { snapshot })).lastFrame();
+    assert.match(out2, /Tasks/);
+    const headingIdx = out2.indexOf("Tasks");
+    const taskIdx = out2.indexOf("read code");
+    assert.ok(headingIdx >= 0 && taskIdx > headingIdx, "Tasks heading before task rows");
+});
+
+test("Issue #54 slice 1: SubstagesPane renders 'Activity' heading separate from STAGE marker", { skip }, async () => {
+    const SubstagesPane = (await import("../src/components/SubstagesPane.mjs")).default;
+    const snapshot = {
+        activeStage: { stage: 2, name: "FIX" },
+        currentStageSubstages: [],
+    };
+    const out = render(React.createElement(SubstagesPane, { snapshot })).lastFrame();
+    // Heading is "Activity" (NOT "STAGE: FIX" — that lives in the body row).
+    assert.match(out, /Activity/);
+    // The stage-marker body row still surfaces the active stage name.
+    assert.match(out, /FIX/);
+    // Heading appears BEFORE the stage marker row.
+    const headingIdx = out.indexOf("Activity");
+    const stageIdx = out.indexOf("FIX");
+    assert.ok(headingIdx >= 0 && stageIdx > headingIdx, "Activity heading before STAGE marker row");
+});
+
+test("Issue #54 slice 2a: Timeline shows '(working…)' for in-flight iter with no excerpt", { skip }, () => {
+    const snapshot = {
+        iterations: [
+            { iteration: 1, endedAt: 1, excerpt: "first" },
+            { iteration: 2, endedAt: null, excerpt: null },
+        ],
+    };
+    const out = render(React.createElement(Timeline, { snapshot })).lastFrame();
+    assert.match(out, /first/);
+    assert.match(out, /working…/);
+    // Finished iters with no excerpt still get the historical
+    // "(no excerpt)" placeholder — replay fidelity for old runs.
+    const snapshot2 = {
+        iterations: [{ iteration: 1, endedAt: 1, excerpt: null }],
+    };
+    const out2 = render(React.createElement(Timeline, { snapshot: snapshot2 })).lastFrame();
+    assert.match(out2, /no excerpt/);
+});
+
+test("Issue #54 slice 2a: Timeline shows live-streamed excerpt on the in-flight iter", { skip }, () => {
+    // Excerpt streamed via usage_update during the iter — endedAt is
+    // still null, but excerpt is now non-empty. Timeline must
+    // render the excerpt (truncated to 80 chars) instead of
+    // "(working…)".
+    const snapshot = {
+        iterations: [
+            { iteration: 1, endedAt: null, excerpt: "ORIENT: scanning the backlog for stale CI runs" },
+        ],
+    };
+    const out = render(React.createElement(Timeline, { snapshot })).lastFrame();
+    assert.match(out, /ORIENT: scanning the backlog/);
+    assert.doesNotMatch(out, /working…/);
+    assert.doesNotMatch(out, /no excerpt/);
+});

--- a/packages/tui/test/events.test.mjs
+++ b/packages/tui/test/events.test.mjs
@@ -1272,3 +1272,68 @@ test("foldEvents: iteration_end with tokens + premiumRequests pins snapshot to c
     assert.equal(snap.tokens.output, 350);
     assert.equal(snap.premiumRequests, 5);
 });
+
+// ─── Issue #54 slice 2a: usage_update with excerpt → live Timeline ────
+
+test("Issue #54 slice 2a: usage_update with excerpt round-trips through serializer", () => {
+    const ev = {
+        type: "usage_update",
+        ts: 1700000000000,
+        runId: "r",
+        label: "self_improve",
+        iteration: 3,
+        tokens: { input: 0, output: 250 },
+        excerpt: "ORIENT: scanning the backlog for stale CI runs",
+    };
+    const line = serializeEvent(ev);
+    const parsed = parseEventLine(line);
+    assert.equal(parsed.type, "usage_update");
+    assert.equal(parsed.excerpt, "ORIENT: scanning the backlog for stale CI runs");
+    assert.equal(parsed.tokens.output, 250);
+});
+
+test("Issue #54 slice 2a: foldEvents — usage_update with excerpt updates iter[last].excerpt when iter is in-flight", () => {
+    const events = [
+        { type: "armed", ts: 100, runId: "r", label: "self_improve" },
+        { type: "iteration_start", ts: 200, runId: "r", iteration: 1 },
+        { type: "usage_update", ts: 300, runId: "r", iteration: 1,
+          tokens: { input: 0, output: 50 },
+          excerpt: "ORIENT: scanning the backlog" },
+    ];
+    const snap = foldEvents(events);
+    assert.equal(snap.iterations.length, 1);
+    assert.equal(snap.iterations[0].excerpt, "ORIENT: scanning the backlog");
+    assert.equal(snap.iterations[0].endedAt, null, "iter still in-flight");
+    assert.equal(snap.lastExcerpt, "ORIENT: scanning the backlog");
+});
+
+test("Issue #54 slice 2a: foldEvents — usage_update excerpt does NOT clobber a closed iter's excerpt", () => {
+    // After iteration_end has closed iter 1, a stray late
+    // usage_update should leave iter 1's excerpt intact (replay
+    // fidelity). snap.lastExcerpt may still update — that's a
+    // run-scope field, not an iter-scope one — but the per-iter
+    // excerpt history is preserved.
+    const events = [
+        { type: "armed", ts: 100, runId: "r", label: "self_improve" },
+        { type: "iteration_start", ts: 200, runId: "r", iteration: 1 },
+        { type: "iteration_end", ts: 300, runId: "r", iteration: 1,
+          excerpt: "FINAL: iter-1 done", tokens: { input: 0, output: 100 } },
+        { type: "usage_update", ts: 400, runId: "r", iteration: 1,
+          tokens: { input: 0, output: 100 }, excerpt: "STRAY late update" },
+    ];
+    const snap = foldEvents(events);
+    assert.equal(snap.iterations[0].excerpt, "FINAL: iter-1 done",
+        "closed iter excerpt is not overwritten by post-end usage_update");
+});
+
+test("Issue #54 slice 2a: foldEvents — usage_update with empty/missing excerpt is a no-op for iter excerpt", () => {
+    const events = [
+        { type: "armed", ts: 100, runId: "r", label: "self_improve" },
+        { type: "iteration_start", ts: 200, runId: "r", iteration: 1 },
+        // iter starts with excerpt: null (per iteration_start init)
+        { type: "usage_update", ts: 300, runId: "r", iteration: 1,
+          tokens: { input: 0, output: 50 } },
+    ];
+    const snap = foldEvents(events);
+    assert.equal(snap.iterations[0].excerpt, null);
+});

--- a/packages/tui/test/runner.test.mjs
+++ b/packages/tui/test/runner.test.mjs
@@ -634,8 +634,14 @@ test("runRalphTui: emits armed → iteration_start → iteration_end → termina
         spawn,
         eventEmitter,
     });
-    const types = events.map((e) => e.type);
-    assert.deepEqual(types, ["armed", "iteration_start", "iteration_end", "complete"]);
+    // The skeleton sequence is armed → iteration_start →
+    // (any number of usage_update for live tokens / excerpt
+    // streaming, issue #54 slice 2a) → iteration_end → complete.
+    // Drop usage_update before asserting the skeleton so this test
+    // stays focused on the iteration-lifecycle contract and doesn't
+    // regress every time we tweak live-emission cadence.
+    const skeleton = events.map((e) => e.type).filter((t) => t !== "usage_update");
+    assert.deepEqual(skeleton, ["armed", "iteration_start", "iteration_end", "complete"]);
     // armed event must carry contextMode + mode + maxIterations for ralph-tui list.
     assert.equal(events[0].contextMode, "fresh");
     assert.equal(events[0].mode, "self-improve");
@@ -1585,9 +1591,25 @@ test("runRalphTui: bash 'git commit' substage → emits commit_observed with sha
         close: () => {},
     };
     const NUL = "\u0000";
+    // Issue #54 slice 2c — runner now also probes HEAD at arm time
+    // (replay-on-mount) so the LastCommit pane is never empty when
+    // the run starts. Stateful gitExec returns the pre-loop HEAD on
+    // the first rev-parse+log pair (arm-time), then advances to the
+    // post-commit HEAD for subsequent calls (the iter-1 commit
+    // substage probe). This pins both legitimate emit sites.
+    let revParseCalls = 0;
+    let logCalls = 0;
     const gitExec = ({ args }) => {
-        if (args[0] === "rev-parse" && args[1] === "--short") return "abc1234\n";
-        if (args[0] === "log") return `feat(x): test commit${NUL}Co-authored-by: Copilot <copilot@users.noreply.github.com>`;
+        if (args[0] === "rev-parse" && args[1] === "--short") {
+            revParseCalls += 1;
+            return revParseCalls === 1 ? "0000000\n" : "abc1234\n";
+        }
+        if (args[0] === "log") {
+            logCalls += 1;
+            return logCalls === 1
+                ? `chore: pre-loop baseline${NUL}`
+                : `feat(x): test commit${NUL}Co-authored-by: Copilot <copilot@users.noreply.github.com>`;
+        }
         return null;
     };
     const stdout = [
@@ -1610,10 +1632,16 @@ test("runRalphTui: bash 'git commit' substage → emits commit_observed with sha
         gitExec,
     });
     const cos = events.filter((e) => e.type === "commit_observed");
-    assert.equal(cos.length, 1, "exactly one commit_observed for one git commit substage");
-    assert.equal(cos[0].sha, "abc1234");
-    assert.equal(cos[0].subject, "feat(x): test commit");
-    assert.equal(cos[0].trailers.length, 1);
+    // Two events: arm-time HEAD replay (iteration:0) +
+    // iter-1 git commit substage observation (iteration:1).
+    assert.equal(cos.length, 2, "arm-time replay + iter-1 commit substage");
+    assert.equal(cos[0].iteration, 0, "first event is arm-time replay");
+    assert.equal(cos[0].sha, "0000000");
+    assert.equal(cos[0].subject, "chore: pre-loop baseline");
+    assert.equal(cos[1].iteration, 1, "second event is iter-1 commit");
+    assert.equal(cos[1].sha, "abc1234");
+    assert.equal(cos[1].subject, "feat(x): test commit");
+    assert.equal(cos[1].trailers.length, 1);
 });
 
 test("runRalphTui: failed git commit substage does NOT trigger commit_observed", async () => {
@@ -1624,6 +1652,14 @@ test("runRalphTui: failed git commit substage does NOT trigger commit_observed",
         write: (ev) => events.push(ev),
         close: () => {},
     };
+    // Issue #54 slice 2c — runner now also probes HEAD at arm time
+    // for replay-on-mount. With a stub returning null (simulating
+    // "not a git repo"), the arm-time probe still calls gitExec
+    // (rev-parse) but gets null back, so no commit_observed event
+    // is emitted. The bash-substage path (which is what this test
+    // pins) is unrelated and would not emit either since success=
+    // false. Net: 0 commit_observed events, but gitExec IS called
+    // once at arm-time.
     let gitExecCalls = 0;
     const gitExec = () => { gitExecCalls += 1; return null; };
     const stdout = [
@@ -1646,7 +1682,10 @@ test("runRalphTui: failed git commit substage does NOT trigger commit_observed",
         gitExec,
     });
     assert.equal(events.filter((e) => e.type === "commit_observed").length, 0);
-    assert.equal(gitExecCalls, 0, "gitExec never called for a failed commit");
+    // Arm-time replay-on-mount calls gitExec once (rev-parse).
+    // Returns null → readHeadCommit short-circuits, no log call.
+    // Failed-commit substage path doesn't shell to git either.
+    assert.equal(gitExecCalls, 1, "gitExec called once at arm-time replay (rev-parse), short-circuits on null");
 });
 
 test("runRalphTui: non-bash tool with 'git commit' in argsSummary does NOT fire commit_observed", async () => {
@@ -1679,6 +1718,77 @@ test("runRalphTui: non-bash tool with 'git commit' in argsSummary does NOT fire 
         gitExec,
     });
     assert.equal(events.filter((e) => e.type === "commit_observed").length, 0);
+});
+
+// ─── Issue #54 slice 2c: arm-time HEAD replay-on-mount ──────────────
+
+test("Issue #54 slice 2c: runRalphTui emits commit_observed at arm time when HEAD exists, even if iter makes no commits", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "arm-replay-test",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    const NUL = "\u0000";
+    const gitExec = ({ args }) => {
+        if (args[0] === "rev-parse" && args[1] === "--short") return "deadbee\n";
+        if (args[0] === "log") return `chore: pre-loop baseline${NUL}Co-authored-by: Copilot <c@e>`;
+        return null;
+    };
+    // Iter that DOESN'T commit — just emits COMPLETE. The arm-time
+    // replay is what populates LastCommit so the user sees HEAD on
+    // mount instead of an empty pane.
+    const stdout = [
+        JSON.stringify({ type: "assistant.message", timestamp: "2026-01-01T00:00:00.000Z",
+            data: { content: "COMPLETE" } }),
+        JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+    ].join("\n") + "\n";
+    const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+        gitExec,
+    });
+    const cos = events.filter((e) => e.type === "commit_observed");
+    assert.equal(cos.length, 1, "exactly one commit_observed emitted at arm time");
+    assert.equal(cos[0].iteration, 0, "arm-time replay carries iteration: 0");
+    assert.equal(cos[0].sha, "deadbee");
+    assert.equal(cos[0].subject, "chore: pre-loop baseline");
+    assert.equal(cos[0].trailers.length, 1);
+});
+
+test("Issue #54 slice 2c: arm-time replay is silent when gitExec returns null (not a repo)", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "no-repo-test",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    // gitExec returns null for everything → not a repo / git missing.
+    const gitExec = () => null;
+    const stdout = [
+        JSON.stringify({ type: "assistant.message", timestamp: "2026-01-01T00:00:00.000Z",
+            data: { content: "COMPLETE" } }),
+        JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+    ].join("\n") + "\n";
+    const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+        gitExec,
+    });
+    assert.equal(events.filter((e) => e.type === "commit_observed").length, 0,
+        "no commit_observed emitted when gitExec returns null");
 });
 
 test("runRalphTui: WORKITEM_START + WORKITEM_END markers emit workitem events", async () => {
@@ -2064,15 +2174,27 @@ test("runRalphTui smoke: full marker stream surfaces stage_plan + task_list + ta
     const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
     // Stub gitExec so the smoke test doesn't depend on the test's cwd
     // being a real git repo. Returns canned data for the two
-    // composing calls readHeadCommit makes.
+    // composing calls readHeadCommit makes. Issue #54 slice 2c —
+    // arm-time replay-on-mount calls readHeadCommit once before
+    // iter-1 starts, then the iter-1 git commit substage calls it
+    // again. The stub uses distinct SHAs so the two emissions are
+    // distinguishable in the assertions below.
     let gitCalls = 0;
+    let revParseCalls = 0;
+    let logCalls = 0;
     const gitExec = ({ args }) => {
         gitCalls++;
         if (args[0] === "rev-parse" && args[1] === "--short") {
-            return "abc1234\n";
+            revParseCalls += 1;
+            // Arm-time HEAD before any iter has run.
+            // Iter-1 commit observation lands on the post-commit HEAD.
+            return revParseCalls === 1 ? "0000000\n" : "abc1234\n";
         }
         if (args[0] === "log") {
-            return "feat(tui): smoke\u0000Co-authored-by: Copilot <c@e>\nCo-authored-by: copilot-ralph <r@e>\n";
+            logCalls += 1;
+            return logCalls === 1
+                ? "chore: pre-loop baseline\u0000"
+                : "feat(tui): smoke\u0000Co-authored-by: Copilot <c@e>\nCo-authored-by: copilot-ralph <r@e>\n";
         }
         return null;
     };
@@ -2107,14 +2229,18 @@ test("runRalphTui smoke: full marker stream surfaces stage_plan + task_list + ta
     assert.equal(taskStart.sub, 1);
     const taskEnd = events.find((e) => e.type === "task_end");
     assert.equal(taskEnd.outcome, "ok");
-    const commitObs = events.find((e) => e.type === "commit_observed");
-    assert.equal(commitObs.sha, "abc1234");
-    assert.equal(commitObs.subject, "feat(tui): smoke");
-    assert.equal(commitObs.trailers.length, 2);
-
-    // commit_observed is exactly once (idempotent per toolCallId).
-    assert.equal(events.filter((e) => e.type === "commit_observed").length, 1,
-        "commit_observed must be idempotent per toolCallId");
+    // Two commit_observed events in order: arm-time replay then
+    // iter-1 commit substage. Pinning both proves slice 2c is wired
+    // and the iter-loop's per-toolCallId path is still idempotent.
+    const commitObsList = events.filter((e) => e.type === "commit_observed");
+    assert.equal(commitObsList.length, 2, "arm-time replay + iter-1 commit substage");
+    assert.equal(commitObsList[0].iteration, 0);
+    assert.equal(commitObsList[0].sha, "0000000");
+    assert.equal(commitObsList[0].subject, "chore: pre-loop baseline");
+    assert.equal(commitObsList[1].iteration, 1);
+    assert.equal(commitObsList[1].sha, "abc1234");
+    assert.equal(commitObsList[1].subject, "feat(tui): smoke");
+    assert.equal(commitObsList[1].trailers.length, 2);
 
     // foldEvents must build a snapshot the renderer can consume.
     const snap = foldEvents(events);
@@ -2126,10 +2252,12 @@ test("runRalphTui smoke: full marker stream surfaces stage_plan + task_list + ta
     );
     assert.deepEqual(snap.currentPlan?.stages, ["DIAG", "FIX", "TEST", "COMMIT", "PUSH", "END"]);
     assert.equal(snap.currentTaskList?.stage, "FIX");
+    // After both commit_observed emissions, snap.lastCommit reflects
+    // the most-recent (iter-1 commit), not the arm-time baseline.
     assert.equal(snap.lastCommit?.sha, "abc1234");
     assert.equal(snap.lastCommit?.subject, "feat(tui): smoke");
 
-    // The runner shelled out to git twice (rev-parse + log) for the
-    // single commit — proves the readHeadCommit path actually fired.
-    assert.equal(gitCalls, 2, "readHeadCommit composes two git commands");
+    // The runner shelled out to git four times: arm-time
+    // (rev-parse + log) + iter-1 commit (rev-parse + log).
+    assert.equal(gitCalls, 4, "arm-time + iter-1 each compose rev-parse + log");
 });


### PR DESCRIPTION
Closes #54.

`ralph-tui run` shipped three UX papercuts that made the layout look
broken when the agent was idle or working but silent. This PR fixes
all three end-to-end.

## Slice 1 — panel headings on the four top panes
`<Header>` / `<StagesRow>` / `<TasksPane>` / `<SubstagesPane>` each
now render a bold-underline heading (`Run` / `Stages` / `Tasks` /
`Activity`) as the first child inside the bordered Box, matching
the existing inside-border heading convention used by `<Timeline>`,
`<DetailPane>`, and `<LastCommit>`. `<SubstagesPane>` decouples its
heading from the active-stage marker — `Activity` is the heading
and the `▸ STAGE_NAME` body row remains in the first content
position so the substage stream still scopes visually to its
parent stage.

## Slice 2a — live Timeline excerpt
- `runner.mjs` accumulates root-agent
  `assistant.message.data.content` per-iter; when 80+ new chars
  have accumulated since the last emission, the live excerpt
  piggybacks on the next `usage_update` event (or fires its own
  `usage_update` if no token-bearing event is pending). The first
  non-empty content emits immediately so terse iters (1-79 chars)
  don't sit on `(working…)` for their whole duration.
- `events.mjs` `foldEvents` `case "usage_update"` updates
  `iterations[last].excerpt` and `snap.lastExcerpt` together,
  gated by the same `last && last.endedAt == null && iter-match`
  check so a late event can never regress either surface to a
  stale value.
- `Timeline.mjs` renders three branches:
  excerpt → `(working…)` (in-flight, no excerpt yet)
  → `(no excerpt)` (finished, no captured excerpt). Replay
  fidelity for old runs is preserved.

## Slice 2c — LastCommit replay-on-mount
- `runner.mjs` shells `git rev-parse --short HEAD` +
  `git log -1 --pretty=format:%s%(trailers:only)` once at arm
  time (right after the canonical `armed` event, carrying
  `iteration: 0`), so the LastCommit pane shows HEAD
  immediately when the cwd has any commit.
- `defaultGitExec` gained a 200 ms `spawnSync` timeout to
  protect the start path against a wedged repo (lock file,
  hung credential helper).
- When `gitExec` is null (test injection without a stub) or
  the cwd isn't a git repo, arm-time replay is silently
  skipped — no crash, no spurious event.

(Slices 2b and 3 from the issue body — Detail tokens stuck at 0,
spurious top-level-await warning — already shipped on `main` as
`56b2048` and `f9bf59b`.)

## Tests
- 13 new tests across
  `packages/tui/test/{components,events,runner}.test.mjs`
  covering all three slices.
- Three pre-existing `commit_observed` tests updated to use
  stateful `gitExec` stubs returning distinct SHAs at arm-time
  vs iter-1.
- One pre-existing terminal-sequence test relaxed to filter out
  `usage_update` events before asserting the iteration-lifecycle
  skeleton (slice 2a now emits at least one `usage_update` on
  the first content-bearing assistant.message regardless of
  token count).

`npm test` → **953/953 passing**. `npm run check` clean.
