### PR TITLE
feat(tui): elapsed HH:MM:SS wallclock counter in Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 ## Unreleased
 
 ### Features
+- TUI Header gains an `elapsed HH:MM:SS` wallclock counter on
+  the right row (after `tokens` / `premium`) so an at-a-glance
+  read of the run pane shows how long the loop has been
+  active. Live in non-terminal status (running / paused) — the
+  `<App>` component drives a 1 Hz tick that re-renders the
+  Header so seconds advance without depending on event
+  arrivals (long stages without events no longer freeze the
+  display). Frozen at the run's actual end ts in terminal
+  status (complete / aborted) so the final value is the real
+  duration of the run. `foldEvents` gains a `terminalAt:
+  number|null` field on the snapshot, set strictly from the
+  `complete` / `abort` event's own `ts`, so a late or replayed
+  event arriving after termination cannot shift the frozen
+  elapsed counter (mirrors the `ts`-pinned-not-`updatedAt`
+  pattern used by `iteration_end`). Hidden when the loop has
+  not yet armed (`startedAt` is null) and in static-mode
+  renders without an injected `now` for non-terminal status,
+  so snapshot tests and pre-iter-1 frames stay deterministic
+  rather than rendering a wallclock-derived value that drifts
+  per CI machine. The 1 Hz `setInterval` only fires in live
+  mode (when `<App>` receives an `eventStream`), `unref()`s
+  itself so it can't keep the process alive past TUI
+  unmount, and clears immediately on terminal-status
+  transition or unmount. The new `formatElapsed(ms)` helper
+  is exported from `<Header>` and computes `HH:MM:SS`
+  manually so a 30-hour self-improve run reads `30:00:00`
+  rather than wrapping at 24 hours like a `Date`-based
+  formatter would.
+
 - Issue #54 — `ralph-tui run` UX hardening across the
   three-level layout. The four top panes
   (`<Header>` / `<StagesRow>` / `<TasksPane>` /

--- a/packages/tui/src/components/App.mjs
+++ b/packages/tui/src/components/App.mjs
@@ -38,6 +38,13 @@ const h = React.createElement;
  */
 export default function App({ eventStream, events: initial = [], runId, onUserAbort }) {
     const [events, setEvents] = useState(initial);
+    // `now` is read by <Header> to render the live elapsed clock. We
+    // only tick it in live mode (eventStream present) so static-mode
+    // renders (existing tests + snapshot fixtures) stay deterministic
+    // and don't leak intervals across test runs. The tick stops once
+    // the loop reaches a terminal status — at that point <Header>
+    // freezes elapsed at `snapshot.terminalAt` anyway.
+    const [now, setNow] = useState(() => Date.now());
     const { exit } = useApp();
 
     useInput((input, key) => {
@@ -94,8 +101,22 @@ export default function App({ eventStream, events: initial = [], runId, onUserAb
     const snapshot = foldEvents(events);
     if (runId && !snapshot.runId) snapshot.runId = runId;
 
+    // 1 Hz tick to keep the Header's elapsed counter live. Live mode
+    // only — static renders (tests, fixtures) don't tick. Stops at
+    // terminal status so a finished run doesn't keep re-rendering.
+    const isLive = !!eventStream;
+    const tickActive = isLive
+        && snapshot.status !== "complete"
+        && snapshot.status !== "aborted";
+    useEffect(() => {
+        if (!tickActive) return undefined;
+        const id = setInterval(() => setNow(Date.now()), 1000);
+        if (typeof id?.unref === "function") id.unref();
+        return () => clearInterval(id);
+    }, [tickActive]);
+
     return h(Box, { flexDirection: "column" },
-        h(Header, { snapshot }),
+        h(Header, { snapshot, now: isLive ? now : undefined }),
         h(StagesRow, { snapshot }),
         h(TasksPane, { snapshot }),
         h(SubstagesPane, { snapshot }),

--- a/packages/tui/src/components/Header.mjs
+++ b/packages/tui/src/components/Header.mjs
@@ -29,6 +29,25 @@ const h = React.createElement;
 // the user's perspective.
 const RUNAWAY_GUARD_CEILING = 1000;
 
+const TERMINAL_STATUSES = new Set(["complete", "aborted"]);
+
+/** Format a positive ms duration as `HH:MM:SS`, manually computed so
+ *  hours grow past 24 without wrap (a 30-hour self-improve run should
+ *  read `30:00:00`, not `06:00:00` from a `Date`-based formatter).
+ *  Returns `null` when input is non-finite or negative so the Header
+ *  can collapse the row when there's no credible elapsed window
+ *  (e.g. pre-`armed`, or a replayed event whose ts predates start).
+ *  Pure / exported for unit tests. */
+export function formatElapsed(ms) {
+    if (!Number.isFinite(ms) || ms < 0) return null;
+    const totalSec = Math.floor(ms / 1000);
+    const hours = Math.floor(totalSec / 3600);
+    const mins = Math.floor((totalSec % 3600) / 60);
+    const secs = totalSec % 60;
+    const pad = (n) => String(n).padStart(2, "0");
+    return `${pad(hours)}:${pad(mins)}:${pad(secs)}`;
+}
+
 const STATUS_COLOR = {
     idle: "gray",
     running: "cyan",
@@ -74,7 +93,7 @@ function backlogField(value) {
     return value === null || value === undefined ? "?" : String(value);
 }
 
-export default function Header({ snapshot }) {
+export default function Header({ snapshot, now }) {
     const status = snapshot?.status ?? "idle";
     const label = snapshot?.label ?? "(unknown)";
     const runId = snapshot?.runId ?? "(no run)";
@@ -89,6 +108,29 @@ export default function Header({ snapshot }) {
     const closedByLoop = snapshot?.closedByLoop ?? 0;
 
     const maxLabel = max === RUNAWAY_GUARD_CEILING ? "∞" : String(max);
+
+    // Elapsed wallclock since the loop armed. Frozen at the terminal
+    // event's own ts (`snapshot.terminalAt`, set by foldEvents on
+    // `complete` / `abort`) for terminal statuses; otherwise tracks
+    // the caller-supplied `now` so <App>'s 1 Hz tick keeps the value
+    // live during running/paused. Hidden when `startedAt` is null
+    // (pre-iter-1), when the computed window is non-finite/negative,
+    // or when no `now` is supplied for a non-terminal status (the
+    // static-render path — keeps snapshot tests deterministic by
+    // refusing to fall back to wallclock).
+    const startedAt = snapshot?.startedAt;
+    const terminalAt = snapshot?.terminalAt;
+    let elapsedMs = null;
+    if (Number.isFinite(startedAt)) {
+        let end = null;
+        if (TERMINAL_STATUSES.has(status) && Number.isFinite(terminalAt)) {
+            end = terminalAt;
+        } else if (Number.isFinite(now)) {
+            end = now;
+        }
+        if (end !== null) elapsedMs = end - startedAt;
+    }
+    const elapsedLabel = formatElapsed(elapsedMs);
 
     const left = h(Box, { flexDirection: "row" },
         h(Text, { color: STATUS_COLOR[status] ?? "white", bold: true }, STATUS_LABEL[status] ?? String(status).toUpperCase()),
@@ -115,6 +157,16 @@ export default function Header({ snapshot }) {
                 h(Text, null, "   "),
                 h(Text, { dimColor: true }, "premium "),
                 h(Text, null, String(premiumRequests)),
+              )
+            : null,
+        // Elapsed wallclock counter — only rendered once the loop
+        // has armed (startedAt is finite) so single-shot static
+        // renders without an `armed` event don't display 00:00:00.
+        elapsedLabel
+            ? h(Box, { flexDirection: "row" },
+                h(Text, null, "   "),
+                h(Text, { dimColor: true }, "elapsed "),
+                h(Text, null, elapsedLabel),
               )
             : null,
     );

--- a/packages/tui/src/events.mjs
+++ b/packages/tui/src/events.mjs
@@ -570,6 +570,7 @@ export function foldEvents(events) {
      *   lastExcerpt: string|null,
      *   startedAt: number|null,
      *   updatedAt: number|null,
+     *   terminalAt: number|null,
      *   iterations: Array<{iteration:number, startedAt:number, endedAt:number|null, excerpt:string|null}>,
      *   activeStage: {stage:number, name:string, startedAt:number}|null,
      *   recentStages: Array<{stage:number, name:string, startedAt:number, endedAt:number|null, durationMs:number|null, outcome:string|null}>,
@@ -604,6 +605,14 @@ export function foldEvents(events) {
         lastExcerpt: null,
         startedAt: null,
         updatedAt: null,
+        // TUI elapsed-clock display: pin the wallclock ts of the
+        // `complete` / `abort` event so the Header's elapsed
+        // counter freezes at the run's actual end ts rather than
+        // tracking `updatedAt` (which would shift if a late /
+        // replayed event arrived after termination). Stays null
+        // until a terminal event fires; resets on `armed` for
+        // multi-run replays.
+        terminalAt: null,
         iterations: [],
         activeStage: null,
         recentStages: [],
@@ -662,6 +671,7 @@ export function foldEvents(events) {
                 snap.premiumRequests = null;
                 snap.lastExcerpt = null;
                 snap.startedAt = ev.ts;
+                snap.terminalAt = null;
                 snap.iterations = [];
                 snap.activeStage = null;
                 snap.recentStages = [];
@@ -771,10 +781,12 @@ export function foldEvents(events) {
             case "complete":
                 snap.status = "complete";
                 snap.reason = ev.reason ?? snap.reason;
+                if (Number.isFinite(ev.ts)) snap.terminalAt = ev.ts;
                 break;
             case "abort":
                 snap.status = "aborted";
                 snap.reason = ev.reason ?? snap.reason;
+                if (Number.isFinite(ev.ts)) snap.terminalAt = ev.ts;
                 break;
             case "stage_start": {
                 if (!Number.isFinite(ev.stage)) break;

--- a/packages/tui/test/components.test.mjs
+++ b/packages/tui/test/components.test.mjs
@@ -9,13 +9,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-let render, React, App, Header, Timeline, DetailPane, Controls, truncateTimeline;
+let render, React, App, Header, Timeline, DetailPane, Controls, truncateTimeline, formatElapsed;
 let inkAvailable = false;
 try {
     ({ render } = await import("ink-testing-library"));
     React = (await import("react")).default;
     App = (await import("../src/components/App.mjs")).default;
-    Header = (await import("../src/components/Header.mjs")).default;
+    const HeaderMod = await import("../src/components/Header.mjs");
+    Header = HeaderMod.default;
+    formatElapsed = HeaderMod.formatElapsed;
     const TimelineMod = await import("../src/components/Timeline.mjs");
     Timeline = TimelineMod.default;
     truncateTimeline = TimelineMod.truncate;
@@ -118,6 +120,117 @@ test("Header: hides premium counter when premiumRequests is null", { skip }, () 
     };
     const out = render(React.createElement(Header, { snapshot })).lastFrame();
     assert.doesNotMatch(out, /premium/);
+});
+
+// ─── Issue: elapsed wallclock counter ─────────────────────────────
+// The Header's right row appends `elapsed HH:MM:SS` after the
+// tokens (and premium) counters when `snapshot.startedAt` is finite
+// AND a clock endpoint is available — caller-supplied `now` while
+// the loop runs, or `snapshot.terminalAt` after `complete` /
+// `abort`. Hidden otherwise so static-render snapshots don't drift
+// across CI machines and pre-`armed` states stay compact.
+
+test("Header: shows elapsed HH:MM:SS for a running loop using injected now", { skip }, () => {
+    const snapshot = {
+        status: "running", label: "self_improve",
+        runId: "self_improve-100", iteration: 1, maxIterations: 1000,
+        tokens: { input: 0, output: 0 },
+        startedAt: 1_000_000,           // armed at t=1_000_000 ms
+        updatedAt: 1_500_000,
+        terminalAt: null,
+    };
+    const now = 1_000_000 + ((14 * 60 + 32) * 1000); // +14m32s
+    const out = render(React.createElement(Header, { snapshot, now })).lastFrame();
+    assert.match(out, /elapsed\s+00:14:32/);
+});
+
+test("Header: elapsed freezes at terminalAt for complete status (ignores now)", { skip }, () => {
+    const snapshot = {
+        status: "complete", label: "self_improve",
+        runId: "self_improve-100", iteration: 5, maxIterations: 5,
+        tokens: { input: 1, output: 2 },
+        startedAt: 1_000_000,
+        updatedAt: 9_999_999_999,       // late event, do NOT use this
+        terminalAt: 1_000_000 + 5_000,  // run finished after 5s
+    };
+    const now = 1_000_000 + ((14 * 60 + 32) * 1000);
+    const out = render(React.createElement(Header, { snapshot, now })).lastFrame();
+    assert.match(out, /elapsed\s+00:00:05/);
+    assert.doesNotMatch(out, /14:32/);
+});
+
+test("Header: elapsed freezes at terminalAt for aborted status", { skip }, () => {
+    const snapshot = {
+        status: "aborted", label: "ralph_loop",
+        runId: "ralph_loop-200", iteration: 2, maxIterations: 100,
+        tokens: { input: 0, output: 0 },
+        startedAt: 1_000_000, updatedAt: 1_002_000,
+        terminalAt: 1_000_000 + 90_000, // 1m30s run
+    };
+    const now = 1_000_000 + 999_999_999; // any now value, ignored
+    const out = render(React.createElement(Header, { snapshot, now })).lastFrame();
+    assert.match(out, /elapsed\s+00:01:30/);
+});
+
+test("Header: elapsed hidden when startedAt is null (pre-armed)", { skip }, () => {
+    const snapshot = {
+        status: "idle", label: "(unknown)", runId: "(no run)",
+        iteration: 0, maxIterations: 100,
+        tokens: { input: 0, output: 0 },
+        startedAt: null, updatedAt: null, terminalAt: null,
+    };
+    const out = render(React.createElement(Header, { snapshot, now: 12345 })).lastFrame();
+    assert.doesNotMatch(out, /elapsed/);
+});
+
+test("Header: elapsed hidden in static-mode (no `now`) for non-terminal status", { skip }, () => {
+    // Static renders (e.g. snapshot tests, fixtures) deliberately
+    // pass no `now` — Header must NOT fall back to `Date.now()`
+    // because that would make the rendered frame change every
+    // millisecond and break deterministic test pinning.
+    const snapshot = {
+        status: "running", label: "ralph_loop", runId: "ralph_loop-300",
+        iteration: 1, maxIterations: 10, tokens: { input: 0, output: 0 },
+        startedAt: 1_000_000, updatedAt: 1_500_000, terminalAt: null,
+    };
+    const out = render(React.createElement(Header, { snapshot })).lastFrame();
+    assert.doesNotMatch(out, /elapsed/);
+});
+
+test("Header: elapsed visible without `now` once status is terminal (uses terminalAt)", { skip }, () => {
+    // Terminal status pins the elapsed value to `terminalAt -
+    // startedAt`, so even a static-mode render (no `now`) must
+    // show the frozen elapsed once the loop is done.
+    const snapshot = {
+        status: "complete", label: "self_improve", runId: "self_improve-400",
+        iteration: 3, maxIterations: 3, tokens: { input: 0, output: 0 },
+        startedAt: 1_000_000, updatedAt: 1_007_000,
+        terminalAt: 1_000_000 + 7_000,
+    };
+    const out = render(React.createElement(Header, { snapshot })).lastFrame();
+    assert.match(out, /elapsed\s+00:00:07/);
+});
+
+test("Header.formatElapsed: pads with zeroes and grows past 24 hours without wrap", { skip }, () => {
+    // Long self-improve runs can chew through several days; the
+    // elapsed counter must NOT wrap at 24h (a `Date`-based
+    // formatter would). Pin manual H/M/S so a 30h run reads
+    // `30:00:00`, not `06:00:00`.
+    assert.equal(formatElapsed(0), "00:00:00");
+    assert.equal(formatElapsed(999), "00:00:00");           // sub-second floors
+    assert.equal(formatElapsed(1_000), "00:00:01");
+    assert.equal(formatElapsed(60_000), "00:01:00");
+    assert.equal(formatElapsed((14 * 60 + 32) * 1000), "00:14:32");
+    assert.equal(formatElapsed(60 * 60 * 1000), "01:00:00");
+    assert.equal(formatElapsed(30 * 60 * 60 * 1000), "30:00:00"); // 30h, no wrap
+});
+
+test("Header.formatElapsed: returns null for non-finite or negative input", { skip }, () => {
+    assert.equal(formatElapsed(null), null);
+    assert.equal(formatElapsed(undefined), null);
+    assert.equal(formatElapsed(NaN), null);
+    assert.equal(formatElapsed(Infinity), null);
+    assert.equal(formatElapsed(-1), null);
 });
 
 test("DetailPane: renders 'premium req N' row when set", { skip }, () => {

--- a/packages/tui/test/events.test.mjs
+++ b/packages/tui/test/events.test.mjs
@@ -200,6 +200,68 @@ test("foldEvents: a fresh `armed` resets iterations array (replay-with-multiple-
     assert.equal(snap.iterations[0].iteration, 1);
 });
 
+// ─── terminalAt: pins the run's end-of-life timestamp ────────────
+// `terminalAt` is set strictly from the `complete` / `abort` event's
+// own `ts`, not from generic `updatedAt` (which would shift if a
+// late/replayed event arrived after termination). The TUI's Header
+// reads this field to freeze the elapsed-clock display at the
+// run's actual end ts.
+
+test("foldEvents: complete sets terminalAt to the event's ts", () => {
+    const snap = foldEvents([
+        { type: "armed", ts: 100, runId: "r", label: "self_improve" },
+        { type: "iteration_start", ts: 110, runId: "r", iteration: 1 },
+        { type: "complete", ts: 200, runId: "r", reason: "completion_promise" },
+    ]);
+    assert.equal(snap.status, "complete");
+    assert.equal(snap.terminalAt, 200);
+});
+
+test("foldEvents: abort sets terminalAt to the event's ts", () => {
+    const snap = foldEvents([
+        { type: "armed", ts: 1, runId: "r", label: "grow_project" },
+        { type: "abort", ts: 50, runId: "r", reason: "user_quit" },
+    ]);
+    assert.equal(snap.status, "aborted");
+    assert.equal(snap.terminalAt, 50);
+});
+
+test("foldEvents: terminalAt is null pre-termination", () => {
+    const snap = foldEvents([
+        { type: "armed", ts: 1, runId: "r", label: "ralph_loop" },
+        { type: "iteration_start", ts: 2, runId: "r", iteration: 1 },
+    ]);
+    assert.equal(snap.terminalAt, null);
+});
+
+test("foldEvents: a fresh `armed` resets terminalAt for the new run", () => {
+    const snap = foldEvents([
+        { type: "armed", ts: 1, runId: "r1", label: "ralph_loop" },
+        { type: "complete", ts: 2, runId: "r1", reason: "promise" },
+        { type: "armed", ts: 3, runId: "r2", label: "self_improve" },
+    ]);
+    assert.equal(snap.runId, "r2");
+    assert.equal(snap.terminalAt, null,
+        "fresh armed must wipe the previous run's terminalAt");
+});
+
+test("foldEvents: terminalAt is NOT shifted by a late post-termination event", () => {
+    // Replay / out-of-band scenario: a stray event arrives with a
+    // `ts` greater than the terminal event's `ts`. `updatedAt` will
+    // (correctly) advance, but `terminalAt` must stay pinned to the
+    // moment the run actually ended so the Header's elapsed counter
+    // doesn't appear to keep ticking after `complete`.
+    const snap = foldEvents([
+        { type: "armed", ts: 1, runId: "r", label: "self_improve" },
+        { type: "complete", ts: 100, runId: "r", reason: "promise" },
+        { type: "usage_update", ts: 9_999_999, runId: "r", iteration: 1, tokens: { input: 1, output: 1 } },
+    ]);
+    assert.equal(snap.terminalAt, 100,
+        "terminalAt stays pinned to the complete event's ts even when later events arrive");
+    assert.equal(snap.updatedAt, 9_999_999,
+        "updatedAt still tracks the latest event observed (sanity)");
+});
+
 test("foldEvents: rejects non-array input", () => {
     assert.throws(() => foldEvents(null), /must be an array/);
 });


### PR DESCRIPTION
Adds a live elapsed-time counter to the TUI `<Header>`'s right
row (after `tokens` / `premium`) so an at-a-glance read of the
run pane shows how long the loop has been active.

## Behaviour

- **Live in non-terminal status** (running / paused) — `<App>`
  drives a 1 Hz `setInterval` that updates a `now` state
  passed to `<Header>`, so seconds advance without depending
  on event arrivals (long stages without events no longer
  freeze the display).
- **Frozen at the run's actual end ts** in terminal status
  (complete / aborted) so the final value is the real
  duration of the run.
- **Hidden** when `startedAt` is null (loop not yet armed)
  and in static-mode renders without an injected `now` for
  non-terminal status, so snapshot tests and pre-iter-1
  frames stay deterministic.
- **Paused keeps ticking** — wallclock semantics, not
  work-time.
- The 1 Hz tick is **live-mode only** (gated on
  `eventStream`), `unref()`s itself so it can't keep the
  process alive past TUI unmount, and clears immediately on
  terminal-status transition or unmount.

## Implementation

- `foldEvents()` gains a `terminalAt: number|null` field on
  the snapshot, set strictly from the `complete` / `abort`
  event's own `ts`, so a late or replayed post-termination
  event cannot shift the frozen elapsed counter (mirrors the
  `ts`-pinned-not-`updatedAt` pattern used by
  `iteration_end`). Reset on a fresh `armed`.
- New `formatElapsed(ms)` helper exported from `<Header>`
  computes `HH:MM:SS` manually, so a 30-hour self-improve
  run reads `30:00:00` rather than wrapping at 24h like a
  `Date`-based formatter would. Returns `null` for
  non-finite or negative input.

## Tests

Adds 13 regression tests; full suite 966/966 passing locally.
