### PR TITLE
docs(github): rebrand workflow + Copilot instructions to autopilot (refs #49)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Copilot Instructions for copilot-ralph-extension
+# Copilot Instructions for autopilot
 
 This is the canonical filename GitHub Copilot (and other AI coding
 assistants that load `.github/copilot-instructions.md` automatically)
@@ -25,10 +25,11 @@ the single source of truth:
   `.github/workflows/release.yml` enforces the match.
 - **AI-authored commits** must include both
   `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`
-  and (unless `RALPH_NO_ATTRIBUTION=1` is set in the environment)
+  and (unless `AUTOPILOT_NO_ATTRIBUTION=1` is set in the environment)
   `Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>`
   trailers so loop-driven commits are passively searchable across
-  public GitHub.
+  public GitHub. Legacy `RALPH_*` env vars (e.g. `RALPH_NO_ATTRIBUTION`)
+  still work via fallback for one release.
 - **Tests**: the project is pure-stdlib Node; run them with `npm test`.
   No build, no lint, no transpiler — `node --test test/*.test.mjs
   packages/*/test/*.test.mjs` covers everything.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,6 @@
 name: Deploy docs site
 
-# Tracked in issue #2: https://github.com/kloba/copilot-ralph-extension/issues/2
+# Tracked in issue #2: https://github.com/kloba/autopilot/issues/2
 # Deploys the MkDocs Material site under /docs/ to the gh-pages branch
 # whenever the docs/, mkdocs.yml, or this workflow itself change on main.
 


### PR DESCRIPTION
## Summary

Unit 8/11 of #49 — flips remaining GitHub-config references away from `copilot-ralph-extension` toward `autopilot`.

- `.github/workflows/docs.yml`: tracking-issue comment URL flipped from `kloba/copilot-ralph-extension` to `kloba/autopilot` (Decision D).
- `.github/copilot-instructions.md`:
  - Title now reads "Copilot Instructions for autopilot".
  - `RALPH_NO_ATTRIBUTION` env var renamed to `AUTOPILOT_NO_ATTRIBUTION`.
  - Added a one-line note that legacy `RALPH_*` env vars still work via fallback for one release (consistent with the upstream `feat/rename-autopilot` env policy).
- The literal commit trailer `Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>` is preserved verbatim — it's the bot account name and the trailer string callers grep for on public GitHub.

The other items in the unit-8 spec (`ralph_loop`, `ralph-tui`, install paths, `RALPH_EVENTS_DIR`, etc.) didn't appear in either scoped file, so no edits were needed for them.

## Test plan

- [x] `npm install --no-audit --no-fund` clean
- [x] `npm test` — 921 pass / 53 skipped / 1 fail; the failure (`bin where: prints default runs root`) reproduces on base `feat/rename-autopilot` and is unrelated to this PR's scope.
- [x] `npm run check` clean (`Syntax-checked 22 .mjs files.`)
- [x] `grep -nE "ralph|copilot-ralph-extension|RALPH_" .github/copilot-instructions.md .github/workflows/docs.yml` — only the intentionally-preserved trailer literal and the legacy-fallback note remain.

Refs #49.