### PR TITLE
build(scripts): add autopilot-fresh.sh; deprecate ralph-tui-fresh.sh wrapper (refs #49)

### DIFF
--- a/scripts/autopilot-fresh.sh
+++ b/scripts/autopilot-fresh.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# scripts/autopilot-fresh.sh — wrapper for `node packages/tui/bin/tui.mjs`
+# that runs `git pull --quiet --ff-only` from the repo root immediately
+# before an `autopilot run` invocation, so each long-haul out-of-session
+# loop starts on the latest source.
+#
+# Why this is safe:
+#   * `autopilot run` runs OUT-OF-SESSION — each iter is a fresh
+#     `copilot -p ...` subprocess. The TUI binary itself is loaded
+#     into memory once at Node startup, so a `git pull` immediately
+#     before `exec node …/tui.mjs` lands the new source on disk
+#     before Node imports the module graph. No self-overwrite race.
+#   * Mid-loop version skew is impossible: Node imports the module
+#     graph at process start, so a `git pull` running concurrently
+#     with the loop CANNOT change the running iter's behaviour.
+#
+# Why only `run` upgrades:
+#   The other subcommands (`list`, `replay`, `watch`, `doctor`,
+#   `prune`, `stats`, `where`) are millisecond-fast read ops on
+#   local files. Adding a `git pull` to those would make `list`
+#   feel laggy for no behavioural benefit.
+#
+# Why failures are silent:
+#   No network, dirty working tree, non-fast-forward, or detached
+#   HEAD all silently fall through to the existing checked-out
+#   code (`|| true`). The wrapper never blocks a run on git issues.
+#   `--ff-only` deliberately refuses to clobber local work-in-progress.
+#
+# Usage:
+#   alias autopilot="$PWD/scripts/autopilot-fresh.sh"   # in ~/.zshrc
+#   autopilot run --self-improve --continue
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Subshell isolates `cd`: the parent shell stays in the user's cwd so
+# `exec node` below preserves it (the TUI's `run` subcommand spawns
+# `copilot -p` subprocesses that inherit cwd from the user, NOT this
+# wrapper's repo root).
+if [[ "${1:-}" == "run" ]]; then
+    ( cd "$ROOT" && git pull --quiet --ff-only ) 2>/dev/null || true
+fi
+
+exec node "$ROOT/packages/tui/bin/tui.mjs" "$@"

--- a/scripts/ralph-tui-fresh.sh
+++ b/scripts/ralph-tui-fresh.sh
@@ -1,45 +1,5 @@
 #!/usr/bin/env bash
-# scripts/ralph-tui-fresh.sh — wrapper for `node packages/tui/bin/tui.mjs`
-# that runs `git pull --quiet --ff-only` from the repo root immediately
-# before a `ralph-tui run` invocation, so each long-haul out-of-session
-# loop starts on the latest source.
-#
-# Why this is safe:
-#   * `ralph-tui run` runs OUT-OF-SESSION — each iter is a fresh
-#     `copilot -p ...` subprocess. The TUI binary itself is loaded
-#     into memory once at Node startup, so a `git pull` immediately
-#     before `exec node …/tui.mjs` lands the new source on disk
-#     before Node imports the module graph. No self-overwrite race.
-#   * Mid-loop version skew is impossible: Node imports the module
-#     graph at process start, so a `git pull` running concurrently
-#     with the loop CANNOT change the running iter's behaviour.
-#
-# Why only `run` upgrades:
-#   The other subcommands (`list`, `replay`, `watch`, `doctor`,
-#   `prune`, `stats`, `where`) are millisecond-fast read ops on
-#   local files. Adding a `git pull` to those would make `list`
-#   feel laggy for no behavioural benefit.
-#
-# Why failures are silent:
-#   No network, dirty working tree, non-fast-forward, or detached
-#   HEAD all silently fall through to the existing checked-out
-#   code (`|| true`). The wrapper never blocks a run on git issues.
-#   `--ff-only` deliberately refuses to clobber local work-in-progress.
-#
-# Usage:
-#   alias ralph-tui="$PWD/scripts/ralph-tui-fresh.sh"   # in ~/.zshrc
-#   ralph-tui run --self-improve --continue
-#
-set -euo pipefail
-
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-
-# Subshell isolates `cd`: the parent shell stays in the user's cwd so
-# `exec node` below preserves it (the TUI's `run` subcommand spawns
-# `copilot -p` subprocesses that inherit cwd from the user, NOT this
-# wrapper's repo root).
-if [[ "${1:-}" == "run" ]]; then
-    ( cd "$ROOT" && git pull --quiet --ff-only ) 2>/dev/null || true
-fi
-
-exec node "$ROOT/packages/tui/bin/tui.mjs" "$@"
+# scripts/ralph-tui-fresh.sh — deprecating wrapper for scripts/autopilot-fresh.sh.
+# Will be removed in a future release. See issue #49.
+echo "ralph-tui-fresh.sh is deprecated; use scripts/autopilot-fresh.sh instead." >&2
+exec "$(dirname "$0")/autopilot-fresh.sh" "$@"

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -5287,7 +5287,7 @@ test("install.sh: rejects duplicate flags and unknown arguments", () => {
     assert.match(unknown.stderr, /unknown argument/);
 });
 
-test("scripts/ralph-tui-fresh.sh: shape, shebang, and only-when-run gate", () => {
+test("scripts/autopilot-fresh.sh: shape, shebang, and only-when-run gate", () => {
     // Drift guard for the auto-upgrade wrapper. Each assertion below
     // pins a specific safety property documented in the script's
     // header comment + the `Auto-upgrade for each run` subsection
@@ -5296,9 +5296,9 @@ test("scripts/ralph-tui-fresh.sh: shape, shebang, and only-when-run gate", () =>
     // dropping `set -euo pipefail`, removing the `|| true` failure
     // swallow, or relocating the entry point Node script) trips the
     // matching assertion before merge.
-    const wrapperPath = resolve(REPO_ROOT, "scripts/ralph-tui-fresh.sh");
+    const wrapperPath = resolve(REPO_ROOT, "scripts/autopilot-fresh.sh");
     const src = readFileSync(wrapperPath, "utf8");
-    // Shebang — invocation via `./scripts/ralph-tui-fresh.sh` requires
+    // Shebang — invocation via `./scripts/autopilot-fresh.sh` requires
     // the kernel to find `bash` via env.
     assert.match(src, /^#!\/usr\/bin\/env bash\n/,
         "wrapper must start with `#!/usr/bin/env bash` shebang");
@@ -5309,7 +5309,7 @@ test("scripts/ralph-tui-fresh.sh: shape, shebang, and only-when-run gate", () =>
         "wrapper must `set -euo pipefail` so typos surface loudly");
     // Only-when-`run` gate. Pin the literal "$1" branch shape so a
     // refactor that fires the upgrade on every invocation (which
-    // would make `ralph-tui list` feel laggy) trips this test.
+    // would make `autopilot list` feel laggy) trips this test.
     assert.match(src, /\[\[ "\$\{1:-\}" == "run" \]\]/,
         'wrapper must guard the upgrade behind `[[ "${1:-}" == "run" ]]`');
     // Silent failure mode — pin the `git pull --quiet --ff-only`
@@ -5331,21 +5331,21 @@ test("scripts/ralph-tui-fresh.sh: shape, shebang, and only-when-run gate", () =>
         'wrapper must end with `exec node "$ROOT/packages/tui/bin/tui.mjs" "$@"` so signals + exit code propagate from Node, not from bash');
 });
 
-test("scripts/ralph-tui-fresh.sh: file mode includes execute bit", () => {
-    // Without the +x bit, `./scripts/ralph-tui-fresh.sh` from a fresh
+test("scripts/autopilot-fresh.sh: file mode includes execute bit", () => {
+    // Without the +x bit, `./scripts/autopilot-fresh.sh` from a fresh
     // clone fails with EACCES even though the shebang line is correct.
     // chmod is set at file-creation time; this test pins it so a
     // future commit that recreates the file (e.g. via a string-edit
     // tool that drops mode bits) doesn't silently regress to 644.
-    const wrapperPath = resolve(REPO_ROOT, "scripts/ralph-tui-fresh.sh");
+    const wrapperPath = resolve(REPO_ROOT, "scripts/autopilot-fresh.sh");
     const st = statSync(wrapperPath);
     // Owner execute bit (0o100). Group/other bits are not pinned —
     // umask differs per contributor, but +x for owner is mandatory.
     assert.ok((st.mode & 0o100) !== 0,
-        `scripts/ralph-tui-fresh.sh must be executable (got mode 0${(st.mode & 0o777).toString(8)})`);
+        `scripts/autopilot-fresh.sh must be executable (got mode 0${(st.mode & 0o777).toString(8)})`);
 });
 
-test("scripts/ralph-tui-fresh.sh: non-`run` subcommand skips upgrade and passes through to bin/tui.mjs", () => {
+test("scripts/autopilot-fresh.sh: non-`run` subcommand skips upgrade and passes through to bin/tui.mjs", () => {
     // End-to-end smoke: invoke the wrapper with `--help` (which is
     // NOT `run`) and assert that bin/tui.mjs's USAGE is printed and
     // the exit code is 0. Two failure modes this catches:
@@ -5357,12 +5357,54 @@ test("scripts/ralph-tui-fresh.sh: non-`run` subcommand skips upgrade and passes 
     // Running with `--help` keeps the test sub-second and offline.
     const r = spawnSync(
         "bash",
-        [resolve(REPO_ROOT, "scripts/ralph-tui-fresh.sh"), "--help"],
+        [resolve(REPO_ROOT, "scripts/autopilot-fresh.sh"), "--help"],
         { encoding: "utf8", timeout: 10_000 },
     );
     assert.equal(r.status, 0, `--help exited ${r.status}; stderr=${r.stderr}`);
     assert.match(r.stdout, /ralph-tui — terminal visualizer/,
         "wrapper must passthrough `--help` to bin/tui.mjs's USAGE block");
+});
+
+test("scripts/ralph-tui-fresh.sh: deprecating wrapper that execs autopilot-fresh.sh", () => {
+    // Decision C (issue #49): the legacy script becomes a thin
+    // deprecating wrapper that prints a one-line stderr notice and
+    // execs the canonical `scripts/autopilot-fresh.sh`. Pin the
+    // shape so a future "simplify" pass that drops the notice
+    // (silent rename) or replaces `exec` with a plain call (signals
+    // / exit code regress) trips this test.
+    const wrapperPath = resolve(REPO_ROOT, "scripts/ralph-tui-fresh.sh");
+    const src = readFileSync(wrapperPath, "utf8");
+    assert.match(src, /^#!\/usr\/bin\/env bash\n/,
+        "deprecating wrapper must start with `#!/usr/bin/env bash` shebang");
+    assert.match(src, /deprecated/i,
+        "deprecating wrapper must mention deprecation in its body so users see a notice");
+    assert.match(src, /autopilot-fresh\.sh/,
+        "deprecating wrapper must point users at scripts/autopilot-fresh.sh");
+    assert.match(src, /^exec ".*autopilot-fresh\.sh" "\$@"$/m,
+        "deprecating wrapper must `exec` the canonical script with `$@` so signals + exit code propagate");
+    // File mode — the wrapper is invoked directly via alias on
+    // legacy installs, so the +x bit must survive the rewrite.
+    const st = statSync(wrapperPath);
+    assert.ok((st.mode & 0o100) !== 0,
+        `scripts/ralph-tui-fresh.sh must be executable (got mode 0${(st.mode & 0o777).toString(8)})`);
+});
+
+test("scripts/ralph-tui-fresh.sh: emits deprecation notice on stderr and forwards to autopilot-fresh.sh", () => {
+    // End-to-end smoke for Decision C: invoke the legacy wrapper
+    // with `--help` (NOT `run`, so no network round-trip) and
+    // assert (a) the deprecation notice landed on stderr, (b) the
+    // canonical script's stdout (bin/tui.mjs USAGE) was forwarded,
+    // and (c) the exit code is 0 (Node's, not bash's).
+    const r = spawnSync(
+        "bash",
+        [resolve(REPO_ROOT, "scripts/ralph-tui-fresh.sh"), "--help"],
+        { encoding: "utf8", timeout: 10_000 },
+    );
+    assert.equal(r.status, 0, `--help exited ${r.status}; stderr=${r.stderr}`);
+    assert.match(r.stderr, /deprecated/i,
+        "legacy wrapper must print a deprecation notice on stderr");
+    assert.match(r.stdout, /ralph-tui — terminal visualizer/,
+        "legacy wrapper must passthrough `--help` to bin/tui.mjs's USAGE block via autopilot-fresh.sh");
 });
 
 test("packages/tui/README.md: documents the ralph-tui-fresh.sh wrapper", () => {


### PR DESCRIPTION
## Summary

- Introduce `scripts/autopilot-fresh.sh` as the canonical auto-upgrade wrapper for `autopilot run` — a verbatim copy of the previous `scripts/ralph-tui-fresh.sh` with `ralph-tui` → `autopilot` flipped in comments, the alias example, and the run-command example.
- Shrink `scripts/ralph-tui-fresh.sh` to a 5-line deprecating wrapper that prints a one-line stderr notice and `exec`s `autopilot-fresh.sh` with `$@` so signals + exit codes propagate from Node.
- Update drift-guard tests: pin the canonical script's shape (shebang, `set -euo pipefail`, only-when-`run` gate, `git pull --quiet --ff-only`, silent failure, exec line) on `autopilot-fresh.sh`; add a fresh deprecating-wrapper test + end-to-end smoke verifying the stderr notice and arg passthrough.

Decision C from issue #49.

## Test plan

- [x] `bash -n scripts/autopilot-fresh.sh` — passes
- [x] `bash -n scripts/ralph-tui-fresh.sh` — passes
- [x] Manual smoke: `bash scripts/ralph-tui-fresh.sh --help` prints the deprecation notice on stderr and forwards `--help` to `bin/tui.mjs`'s USAGE block (exit 0).
- [x] `npm test` — 923 pass / 1 fail. The single failure (`bin where: prints default runs root`) is pre-existing and out-of-scope (test still expects the legacy `.copilot/ralph/runs` path; runtime moved to `.copilot/autopilot/events` in commit c603fb3).
- [x] `npm run check` — passes (syntax-checks 22 .mjs files).

Refs #49.