### PR TITLE
feat(tui): show app version in Header top-right corner (closes #59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 ## Unreleased
 
 ### Features
+- Issue #59 — TUI Header gains a dim `v<X.Y.Z>` version pip
+  pinned to the right edge of the heading row so an
+  at-a-glance read of the run pane shows which build is
+  active. Reads `packages/tui/package.json` via a new shared
+  helper `readTuiVersion()` extracted to
+  `packages/tui/src/version.mjs` (also re-exported from
+  `bin/tui.mjs` so the existing `--version` flag and `doctor`
+  output keep their previous behaviour). Visible from launch,
+  including pre-iter-1 / idle status. `<Header>` accepts an
+  optional `appVersion` string prop; when absent or empty,
+  the pip is hidden and the heading row collapses to the
+  pre-issue-59 single-text layout, so snapshot tests and
+  pre-existing callers stay deterministic. `<App>` forwards
+  the prop through; `run-ui.mjs` and `watch.mjs` pass
+  `readTuiVersion()` at mount time. `readTuiVersion()`
+  returns the literal `"unknown"` on read/parse failure
+  rather than throwing, and `<Header>` will render
+  `vunknown` over a blank pip when that fallback fires —
+  more informative than silence when something went wrong.
+
 - TUI Header gains an `elapsed HH:MM:SS` wallclock counter on
   the right row (after `tokens` / `premium`) so an at-a-glance
   read of the run pane shows how long the loop has been

--- a/packages/tui/bin/tui.mjs
+++ b/packages/tui/bin/tui.mjs
@@ -47,7 +47,7 @@ import process from "node:process";
 import fs from "node:fs";
 import nodePath from "node:path";
 import readline from "node:readline";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { pathToFileURL } from "node:url";
 
 import { readRunIndex, resolveRunsRoot, resolveRunEventsPath, parseDuration, pruneRuns, aggregateRuns } from "../src/writer.mjs";
 import { readEventsFile, tailEventsFile } from "../src/tail.mjs";
@@ -510,19 +510,14 @@ export function cmdStats() {
     return 0;
 }
 
-export function readTuiVersion() {
-    try {
-        const pkgPath = nodePath.resolve(
-            nodePath.dirname(fileURLToPath(import.meta.url)),
-            "..",
-            "package.json",
-        );
-        const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
-        return pkg.version || "unknown";
-    } catch {
-        return "unknown";
-    }
-}
+// Re-exported from the canonical `src/version.mjs` so the existing
+// `--version` flag and `doctor` lines keep working unchanged. The
+// shared module also feeds the live TUI Header (issue #59). We
+// import the symbol AND re-export it so internal call sites in
+// this module (the `--version` flag handler + `doctor` line) keep
+// the bare-identifier reference they had pre-extraction.
+import { readTuiVersion } from "../src/version.mjs";
+export { readTuiVersion };
 
 export function cmdWhere() {
     process.stdout.write(resolveRunsRoot() + "\n");

--- a/packages/tui/src/components/App.mjs
+++ b/packages/tui/src/components/App.mjs
@@ -27,6 +27,12 @@ const h = React.createElement;
  *        snapshot tests.
  * @param {object[]} [props.events]   Initial / static event list.
  * @param {string} [props.runId]      Display label for the header.
+ * @param {string} [props.appVersion] Optional package version string
+ *        (e.g. `"0.1.0"`). When supplied, forwarded to <Header> so it
+ *        renders a dim `v<value>` pip in the top-right of the heading
+ *        row (issue #59). Snapshot tests + pre-issue-59 callers omit
+ *        the prop, in which case the pip is hidden and the heading
+ *        row stays single-text (existing layout).
  * @param {(reason: string) => void} [props.onUserAbort] Optional
  *        callback fired when the user requests to abort via Ctrl-C
  *        or `q`. When provided (issue #48 slice 8 — `ralph-tui run`
@@ -36,7 +42,7 @@ const h = React.createElement;
  *        TUI tears down. Read-only callers (`ralph-tui watch`)
  *        omit it; the App still exits but no driver action occurs.
  */
-export default function App({ eventStream, events: initial = [], runId, onUserAbort }) {
+export default function App({ eventStream, events: initial = [], runId, appVersion, onUserAbort }) {
     const [events, setEvents] = useState(initial);
     // `now` is read by <Header> to render the live elapsed clock. We
     // only tick it in live mode (eventStream present) so static-mode
@@ -116,7 +122,7 @@ export default function App({ eventStream, events: initial = [], runId, onUserAb
     }, [tickActive]);
 
     return h(Box, { flexDirection: "column" },
-        h(Header, { snapshot, now: isLive ? now : undefined }),
+        h(Header, { snapshot, now: isLive ? now : undefined, appVersion }),
         h(StagesRow, { snapshot }),
         h(TasksPane, { snapshot }),
         h(SubstagesPane, { snapshot }),

--- a/packages/tui/src/components/Header.mjs
+++ b/packages/tui/src/components/Header.mjs
@@ -14,6 +14,14 @@
 // work items the loop has already closed (`closedByLoop`) so the
 // user sees forward motion as the backlog drains.
 //
+// Issue #59: optional `appVersion` prop renders a dim `v<X.Y.Z>`
+// pip in the heading row's right edge — at-a-glance read of which
+// build is running, useful when filing issues or confirming an
+// update took effect. Component stays purely presentational; the
+// caller (run-ui.mjs / watch.mjs) is responsible for resolving the
+// version string from `src/version.mjs`. Hidden when the prop is
+// absent so snapshot tests stay deterministic.
+//
 // Pure presentational component. Uses React.createElement directly so
 // the file loads in plain Node ESM (no JSX/TypeScript build step).
 
@@ -93,7 +101,7 @@ function backlogField(value) {
     return value === null || value === undefined ? "?" : String(value);
 }
 
-export default function Header({ snapshot, now }) {
+export default function Header({ snapshot, now, appVersion }) {
     const status = snapshot?.status ?? "idle";
     const label = snapshot?.label ?? "(unknown)";
     const runId = snapshot?.runId ?? "(no run)";
@@ -219,7 +227,22 @@ export default function Header({ snapshot, now }) {
     // The status badge (RUN / DONE / PAUSE) lives in the topRow
     // right of the heading, so the heading is the user-facing pane
     // label rather than a duplicate of the status.
-    const heading = h(Text, { bold: true, underline: true }, "Run");
+    //
+    // Issue #59: when `appVersion` is supplied, the heading row
+    // becomes a flex row with the version pip pinned to the right
+    // edge. The pip renders as a dim `v<value>` so it doesn't
+    // compete visually with the active heading text. Absent /
+    // empty prop ⇒ no pip, and the row collapses to a single
+    // bold-underline "Run" text node (existing behaviour for
+    // pre-issue-59 callers + snapshot tests).
+    const versionPip = (typeof appVersion === "string" && appVersion.length > 0)
+        ? h(Text, { dimColor: true }, "v" + appVersion)
+        : null;
+    const headingText = h(Text, { bold: true, underline: true }, "Run");
+    const heading = versionPip
+        ? h(Box, { flexDirection: "row", justifyContent: "space-between" },
+            headingText, versionPip)
+        : headingText;
 
     return h(Box, {
         borderStyle: "round",

--- a/packages/tui/src/run-ui.mjs
+++ b/packages/tui/src/run-ui.mjs
@@ -26,6 +26,7 @@
 import process from "node:process";
 
 import { tailEventsFile } from "./tail.mjs";
+import { readTuiVersion } from "./version.mjs";
 
 /**
  * @param {Object} args
@@ -56,6 +57,7 @@ export async function mountRunUi({ runId, eventsPath, onUserAbort }) {
             runId,
             events: [],
             eventStream,
+            appVersion: readTuiVersion(),
             onUserAbort,
         }),
         { exitOnCtrlC: false, patchConsole: false },

--- a/packages/tui/src/version.mjs
+++ b/packages/tui/src/version.mjs
@@ -1,0 +1,30 @@
+// Single source of truth for the package version string used both by
+// `ralph-tui --version` (in `bin/tui.mjs`) and the live TUI Header
+// (issue #59 — "show active app version in top-right corner"). Reads
+// `packages/tui/package.json` once per call from disk; the file is
+// small and call sites are limited (CLI startup + Ink mount), so we
+// don't bother caching.
+//
+// Returns the literal string `"unknown"` on any read/parse failure
+// (e.g. the package.json was deleted, has bad JSON, or the resolved
+// path escapes the package). Callers that surface this to the user
+// MUST be prepared for `"unknown"` rather than throwing — the Header
+// in particular still wants to render `vunknown` over a crash.
+
+import fs from "node:fs";
+import nodePath from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function readTuiVersion() {
+    try {
+        const pkgPath = nodePath.resolve(
+            nodePath.dirname(fileURLToPath(import.meta.url)),
+            "..",
+            "package.json",
+        );
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+        return pkg.version || "unknown";
+    } catch {
+        return "unknown";
+    }
+}

--- a/packages/tui/src/watch.mjs
+++ b/packages/tui/src/watch.mjs
@@ -8,6 +8,7 @@
 import process from "node:process";
 
 import { tailEventsFile, readEventsFile } from "./tail.mjs";
+import { readTuiVersion } from "./version.mjs";
 
 /**
  * @param {Object} args
@@ -37,6 +38,7 @@ export async function runInteractive({ runId, eventsPath }) {
             runId,
             events: initial,
             eventStream,
+            appVersion: readTuiVersion(),
         }),
     );
     await waitUntilExit();

--- a/packages/tui/test/bin.test.mjs
+++ b/packages/tui/test/bin.test.mjs
@@ -300,6 +300,26 @@ test("bin --help: mentions --version", () => {
     assert.match(r.stdout, /--version/);
 });
 
+// ─── version.mjs (issue #59) ─────────────────────────────────────
+// Direct unit test for the shared module; bin/tui.mjs re-exports
+// from src/version.mjs so a regression in the shared module
+// surfaces both via this import-from-src test AND the existing
+// `bin --version` integration test above.
+
+test("version.mjs: readTuiVersion returns package.json version string", async () => {
+    const { readTuiVersion } = await import("../src/version.mjs");
+    const pkg = JSON.parse(readFileSync2(resolve(REPO_ROOT, "package.json"), "utf8"));
+    assert.equal(readTuiVersion(), pkg.version);
+});
+
+test("version.mjs: bin/tui.mjs re-export matches src/version.mjs", async () => {
+    const fromBin = (await import("../bin/tui.mjs")).readTuiVersion;
+    const fromSrc = (await import("../src/version.mjs")).readTuiVersion;
+    assert.equal(typeof fromBin, "function");
+    assert.equal(typeof fromSrc, "function");
+    assert.equal(fromBin(), fromSrc());
+});
+
 function seedThreeRuns(dir) {
     writeFileSync(join(dir, "index.jsonl"),
         JSON.stringify({ type: "armed", ts: 1000, runId: "ralph_loop-1000", label: "ralph_loop", maxIterations: 5, minIterations: 1 }) + "\n"

--- a/packages/tui/test/components.test.mjs
+++ b/packages/tui/test/components.test.mjs
@@ -233,6 +233,86 @@ test("Header.formatElapsed: returns null for non-finite or negative input", { sk
     assert.equal(formatElapsed(-1), null);
 });
 
+// ─── appVersion pip rendering (issue #59) ────────────────────────
+// The Header's heading row renders a dim `v<X.Y.Z>` pip pinned to
+// the right edge when the `appVersion` prop is supplied. Hidden
+// otherwise so snapshot tests + pre-issue-59 callers stay
+// deterministic.
+
+test("Header: renders dim version pip when appVersion is supplied", { skip }, () => {
+    const snapshot = {
+        status: "idle",
+        label: "ralph_loop",
+        runId: "ralph_loop-1",
+        iteration: 0,
+        maxIterations: 10,
+        tokens: { input: 0, output: 0 },
+    };
+    const out = render(React.createElement(Header, { snapshot, appVersion: "1.2.3" })).lastFrame();
+    assert.match(out, /v1\.2\.3/);
+    // The heading text and version pip both still render — neither
+    // collapses the other.
+    assert.match(out, /Run/);
+});
+
+test("Header: hides version pip when appVersion is omitted", { skip }, () => {
+    const snapshot = {
+        status: "running",
+        label: "ralph_loop",
+        runId: "ralph_loop-2",
+        iteration: 1,
+        maxIterations: 10,
+        tokens: { input: 0, output: 0 },
+    };
+    const out = render(React.createElement(Header, { snapshot })).lastFrame();
+    // Asserting no `v` followed by a digit in the heading line — the
+    // existing label / runId can contain digits but not the `vN`
+    // pattern. Use a tight regex anchored to `v\d`.
+    assert.doesNotMatch(out, /v\d/);
+});
+
+test("Header: hides version pip when appVersion is empty string", { skip }, () => {
+    // Defensive: a future caller might pass `""` if version lookup
+    // fails. Header should hide rather than render `v` with no
+    // value (which would look broken).
+    const snapshot = {
+        status: "idle",
+        label: "ralph_loop",
+        runId: "ralph_loop-3",
+        iteration: 0,
+        maxIterations: 10,
+        tokens: { input: 0, output: 0 },
+    };
+    const out = render(React.createElement(Header, { snapshot, appVersion: "" })).lastFrame();
+    assert.doesNotMatch(out, /v\d/);
+});
+
+test("Header: renders 'unknown' version pip when readTuiVersion's fallback is passed through", { skip }, () => {
+    // version.mjs returns the literal string "unknown" on any
+    // read/parse failure. Header should still render that — `vunknown`
+    // is more informative than nothing when something went wrong.
+    const snapshot = {
+        status: "idle",
+        label: "ralph_loop",
+        runId: "ralph_loop-4",
+        iteration: 0,
+        maxIterations: 10,
+        tokens: { input: 0, output: 0 },
+    };
+    const out = render(React.createElement(Header, { snapshot, appVersion: "unknown" })).lastFrame();
+    assert.match(out, /vunknown/);
+});
+
+test("App: forwards appVersion prop through to Header pip", { skip }, () => {
+    const events = [
+        { type: "armed", runId: "r1", at: 1, label: "ralph_loop", maxIterations: 10 },
+    ];
+    const out = render(React.createElement(App, {
+        events, runId: "r1", appVersion: "9.8.7",
+    })).lastFrame();
+    assert.match(out, /v9\.8\.7/);
+});
+
 test("DetailPane: renders 'premium req N' row when set", { skip }, () => {
     const snapshot = {
         tokens: { input: 0, output: 415 },


### PR DESCRIPTION
Closes #59.

Adds a dim `v<X.Y.Z>` pip pinned to the right edge of the Header's heading row so an at-a-glance read of the run pane shows which build is active.

## Layout

```
╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Run                                                                                       v0.1.0 │
│ RUN   ralph_loop  rl-1                                                    iter 3/10   tokens 300 │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
```

## What ships

- New shared module `packages/tui/src/version.mjs` with `readTuiVersion()`. `bin/tui.mjs` re-exports it so existing `--version` and `doctor` paths keep working.
- `<Header>` accepts an optional `appVersion` string prop; renders dim `v<value>` pip in the heading row's right edge via `flex-row` + `justifyContent: "space-between"`. Hidden when prop is absent or empty so snapshot tests and pre-existing callers stay deterministic.
- `<App>` forwards the prop through.
- `run-ui.mjs` (`ralph-tui run`) and `watch.mjs` (`ralph-tui watch`) call `readTuiVersion()` at mount time. Visible from launch in both surfaces.

## Tests

- 5 new `<Header>` rendering tests: visible / hidden / empty-string / fallback / App passthrough.
- 2 new `version.mjs` unit tests: direct read + bin re-export parity.
- Existing `bin --version`, `bin -V`, and `bin doctor` tests still pass via the re-export.
- Full suite **976/976** green.
