### PR TITLE
docs(site)!: rebrand docs/ pages to autopilot (refs #49)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,12 +21,12 @@ The trade-off is documented in the README's comparison table; see [What's differ
 extension/
 ├── extension.mjs   # SDK glue — joinSession + createRalphController() + register tools/hooks
 ├── handler.mjs     # The entire controller: state machine, validation, tool defs, baked prompts
-└── events-emit.mjs # Zero-dep JSONL event emitter (writes ~/.copilot/ralph/runs/<runId>/events.jsonl)
+└── events-emit.mjs # Zero-dep JSONL event emitter (writes ~/.copilot/autopilot/runs/<runId>/events.jsonl)
 test/
 ├── extension.test.mjs       # node:test suite — controller against a fake session
 ├── events-emit.test.mjs     # Unit tests for the JSONL emitter helpers
 └── handler-events.test.mjs  # Integration tests covering controller↔emitter wiring
-packages/tui/       # Stand-alone TUI consumer (`ralph-tui`) — see packages/tui/README.md
+packages/tui/       # Stand-alone TUI consumer (`autopilot`) — see packages/tui/README.md
 install.sh          # User- or project-scoped install into ~/.copilot/extensions or .github/extensions
 ```
 
@@ -45,8 +45,8 @@ While a loop is running, `state.active` holds the canonical loop state. Field-by
 - `prompt` / `completionPromise` / `abortPromise` — the strings re-fed each iter and the substrings that terminate the loop.
 - `prev` / `streak` / `stagnationLimit` — byte-identical-response detector that aborts a stuck loop.
 - `pendingFire` / `fireInFlight` / `observedMessageThisFire` — per-iteration dispatch guards. The first idle (the one that *armed* the loop) consumes `pendingFire` to fire iter 1; the in-flight markers prevent stale-idle bloat from cancelled tool calls or sub-agents.
-- `paused` / `pauseReason` / `pausedAt` / `totalPausedMs` — pause-state fields (issue [#3](https://github.com/kloba/copilot-ralph-extension/issues/3)). When `paused === true`, `onIdle` short-circuits before firing the next iteration so the user can chat freely without consuming iterations. `ap_resume` re-arms by zeroing the streak detector (manual intervention almost always changes context) and folding `pausedFor` into `totalPausedMs` for accurate elapsed-time reporting in `ap_status`.
-- Adaptive-budget fields (issue [#4](https://github.com/kloba/copilot-ralph-extension/issues/4)): `adaptiveBudget`, `adaptiveExtension`, `adaptiveMaxTotal`, `originalMax`, `adaptiveContentHashes`, `adaptiveExtensionHistory`.
+- `paused` / `pauseReason` / `pausedAt` / `totalPausedMs` — pause-state fields (issue [#3](https://github.com/kloba/autopilot/issues/3)). When `paused === true`, `onIdle` short-circuits before firing the next iteration so the user can chat freely without consuming iterations. `ap_resume` re-arms by zeroing the streak detector (manual intervention almost always changes context) and folding `pausedFor` into `totalPausedMs` for accurate elapsed-time reporting in `ap_status`.
+- Adaptive-budget fields (issue [#4](https://github.com/kloba/autopilot/issues/4)): `adaptiveBudget`, `adaptiveExtension`, `adaptiveMaxTotal`, `originalMax`, `adaptiveContentHashes`, `adaptiveExtensionHistory`.
 
 When the loop finishes, `state.active` becomes `null` and the immutable `state.lastResult` (a deep-frozen `RalphResult`) holds the post-mortem.
 
@@ -66,8 +66,8 @@ The baked prompts include hard-coded `COMPLETE` / `ABORT_…` tokens and `min_it
 |---|---|---|
 | `ap_loop` | Generic re-fed-prompt loop | One loop at a time. Returns immediately after arming. Driven by `session.idle`. |
 | `ap_stop` | Cancel the active loop | Returns failure if no loop is active. Optional `reason` string is recorded as `note` on the result. |
-| `ap_status` | Live structured snapshot of the active loop | Issue [#5](https://github.com/kloba/copilot-ralph-extension/issues/5) — read-only; safe to call mid-loop. |
-| `ap_pause` | Pause the active loop without losing state | Issue [#3](https://github.com/kloba/copilot-ralph-extension/issues/3). Idempotent; `onIdle` short-circuits while `paused === true`. Returns failure if no loop is active. |
+| `ap_status` | Live structured snapshot of the active loop | Issue [#5](https://github.com/kloba/autopilot/issues/5) — read-only; safe to call mid-loop. |
+| `ap_pause` | Pause the active loop without losing state | Issue [#3](https://github.com/kloba/autopilot/issues/3). Idempotent; `onIdle` short-circuits while `paused === true`. Returns failure if no loop is active. |
 | `ap_resume` | Resume a paused loop | Returns failure if no loop is active or the loop is not paused. Stagnation streak is reset on resume. |
 | `self_improve` | Baked SDLC self-improvement prompt | Wraps `armLoop` with `PROMPT_SELF_IMPROVE`. Honors `focus` for narrowing scope. |
 | `grow_project` | Baked backlog-grooming + execution loop | Wraps `armLoop` with `PROMPT_GROW_PROJECT`. Drives `gh` CLI calls. |
@@ -80,11 +80,11 @@ All tools share the `success(message, extra)` / `failure(message, extra)` envelo
 - **`abort_promise`** (optional, no default) — same mechanism, but finishes with `reason: "abort_promise"`. Used by `grow_project` (`ABORT_NO_BACKLOG`) to bail when there's nothing to do.
 - Both promises are **only honored once `i >= min_iterations`** to avoid premature termination from the agent merely describing the protocol on iter 1. Stagnation, max-iterations, and adaptive-budget terminators have their own thresholds and do not respect `min_iterations`.
 
-## Adaptive iteration budget (issue [#4](https://github.com/kloba/copilot-ralph-extension/issues/4))
+## Adaptive iteration budget (issue [#4](https://github.com/kloba/autopilot/issues/4))
 
 Opt-in. When the loop reaches `max_iterations`, `evaluateAdaptiveSignals(a, gitExec)` returns a non-null reason iff *either* `git diff --shortstat HEAD` or `git status --porcelain` reports working-tree changes, *or* the rolling 3-iteration content-hash window contains ≥ 2 distinct hashes. A positive signal grants `adaptive_extension` more iterations, capped at `adaptive_max_total`. Stagnation / completion / abort still win unconditionally because they're checked earlier in `onIdle`.
 
-## Token tracking (issue [#7](https://github.com/kloba/copilot-ralph-extension/issues/7))
+## Token tracking (issue [#7](https://github.com/kloba/autopilot/issues/7))
 
 `assistant.message` events from the root agent are routed through two helpers in `handler.mjs`: `extractUsage(ev)` reads `data.usage.{input_tokens, output_tokens, model}` (or the flat `data.usage_input_tokens`/`usage_output_tokens`/`usage_model` form used by the SDK's events table); `creditUsage(a, usage)` accumulates the result onto `a.tokens.input` / `a.tokens.output`, appends a per-iteration breakdown to `byIteration` (`{iter, input, output, model}`), and folds per-model totals into `byModel`. Sub-agent events are filtered upstream by `isSubAgentEvent`, so token credit covers root-agent usage only.
 
@@ -97,14 +97,14 @@ Two thresholds are derived from the running `tokens.input` total against `MODEL_
 
 The `max_tokens` cap (set at arm time) is checked at the end of each iteration in `onIdle`; the running total — input + output — is compared against the cap, and the loop finishes with `reason: "max_tokens"` once it crosses. Because pause-time and rejected events do not credit, this cap is never tripped by chat-time activity or malformed events.
 
-## Caffeinate integration (issue [#8](https://github.com/kloba/copilot-ralph-extension/issues/8))
+## Caffeinate integration (issue [#8](https://github.com/kloba/autopilot/issues/8))
 
-Opt-in via `RALPH_CAFFEINATE=1`. On macOS, `armLoop` spawns `caffeinate -i [-d] -w <pid>` to inhibit display/system sleep for the duration of the loop. `finish()` (and every error path) kills the caffeinate process. Tests inject a `spawnFn` stub via `createRalphController({ caffeinate: { spawnFn } })`.
+Opt-in via `AUTOPILOT_CAFFEINATE=1`. On macOS, `armLoop` spawns `caffeinate -i [-d] -w <pid>` to inhibit display/system sleep for the duration of the loop. `finish()` (and every error path) kills the caffeinate process. Tests inject a `spawnFn` stub via `createRalphController({ caffeinate: { spawnFn } })`.
 
 ## Test architecture
 
 - `node:test` runner; no third-party test deps.
 - `makeFakeSession()` returns a `{ on, emit, send, log }` object that mimics the SDK's event bus.
 - `runTurn(session, content)` drives one iteration: emits `assistant.message` then `session.idle`.
-- DI on the controller (`createRalphController({ caffeinate, git, adaptive, events })`) lets tests stub external effects (process spawn, git exec, JSONL event emit) without monkey-patching. The `events` slot is the issue [#22](https://github.com/kloba/copilot-ralph-extension/issues/22) JSONL emitter wiring — accepts `true` (default emitter), `{ env, fs }` (default emitter w/ overrides), or `{ factory }` (custom emitter built per-arm); see the inline JSDoc above `armLoop` for the full contract.
+- DI on the controller (`createRalphController({ caffeinate, git, adaptive, events })`) lets tests stub external effects (process spawn, git exec, JSONL event emit) without monkey-patching. The `events` slot is the issue [#22](https://github.com/kloba/autopilot/issues/22) JSONL emitter wiring — accepts `true` (default emitter), `{ env, fs }` (default emitter w/ overrides), or `{ factory }` (custom emitter built per-arm); see the inline JSDoc above `armLoop` for the full contract.
 - Several **shape-pin tests** lock down field counts and key sets on `state.active`, the success-envelope, the parsed-args object, and the tool-array order. These exist specifically to catch refactors that silently leak internal scratch into the LLM-facing surface.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing
 
-Thanks for your interest in `copilot-ralph-extension`! This page is the entry point for contributors. End-user docs live in the [README](../README.md).
+Thanks for your interest in `autopilot`! This page is the entry point for contributors. End-user docs live in the [README](../README.md).
 
 ## Local development setup
 
 ```bash
-git clone https://github.com/kloba/copilot-ralph-extension.git
-cd copilot-ralph-extension
+git clone https://github.com/kloba/autopilot.git
+cd autopilot
 npm test    # runs the node:test suite under test/ (no install needed — zero runtime deps)
 ```
 
@@ -17,7 +17,7 @@ The repository has **zero npm runtime dependencies** and only Node ≥ 20's buil
 For day-to-day iteration, prefer a **project-scoped** install so your `git checkout` is the live source the CLI loads:
 
 ```bash
-./install.sh --project   # installs into .github/extensions/ralph in this repo
+./install.sh --project   # installs into .github/extensions/autopilot in this repo
 ```
 
 After editing `extension/handler.mjs`, run `extensions_reload` from inside Copilot CLI (or restart the CLI) — new tool definitions are picked up immediately.
@@ -25,7 +25,7 @@ After editing `extension/handler.mjs`, run `extensions_reload` from inside Copil
 For a user-scoped install (loads the same extension across all your repos):
 
 ```bash
-./install.sh             # default: ~/.copilot/extensions/ralph
+./install.sh             # default: ~/.copilot/extensions/autopilot
 ./install.sh --dry-run   # show what would be copied without writing
 ```
 
@@ -46,7 +46,7 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 Co-authored-by: copilot-ralph <noreply+copilot-ralph@github.com>
 ```
 
-The first attributes the underlying Copilot model; the second attributes the loop that executed the iteration. Order matters — GitHub surfaces the first co-author more prominently. See the [README "Commit attribution" section](../README.md#commit-attribution) and [CHANGELOG](../CHANGELOG.md) for full rationale and opt-out (`RALPH_NO_ATTRIBUTION=1`).
+The first attributes the underlying Copilot model; the second attributes the loop that executed the iteration. Order matters — GitHub surfaces the first co-author more prominently. See the [README "Commit attribution" section](../README.md#commit-attribution) and [CHANGELOG](../CHANGELOG.md) for full rationale and opt-out (`AUTOPILOT_NO_ATTRIBUTION=1`).
 
 ## Pull request expectations
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,8 +1,8 @@
 # Releasing
 
-`copilot-ralph-extension` ships as a small set of `.mjs` files copied into `~/.copilot/extensions/ralph` (or `.github/extensions/ralph` for project-scoped installs). There is **no npm publish**; releases are tagged commits on `main` plus an annotated GitHub Release page.
+`autopilot` ships as a small set of `.mjs` files copied into `~/.copilot/extensions/autopilot` (or `.github/extensions/autopilot` for project-scoped installs). There is **no npm publish**; releases are tagged commits on `main` plus an annotated GitHub Release page.
 
-A formal tag-driven release-automation workflow now ships at [`.github/workflows/release.yml`](../.github/workflows/release.yml) (see issue [#10](https://github.com/kloba/copilot-ralph-extension/issues/10) for the rationale). Pushing a `vX.Y.Z` tag verifies `package.json` matches the tag, asserts a matching `CHANGELOG.md` section exists, runs `npm test`, and creates the GitHub Release with every `extension/*.mjs` attached as an asset. The manual checklist below is the fallback when the workflow is unavailable or you need to cut a release out-of-band.
+A formal tag-driven release-automation workflow now ships at [`.github/workflows/release.yml`](../.github/workflows/release.yml) (see issue [#10](https://github.com/kloba/autopilot/issues/10) for the rationale). Pushing a `vX.Y.Z` tag verifies `package.json` matches the tag, asserts a matching `CHANGELOG.md` section exists, runs `npm test`, and creates the GitHub Release with every `extension/*.mjs` attached as an asset. The manual checklist below is the fallback when the workflow is unavailable or you need to cut a release out-of-band.
 
 ## Manual release checklist
 
@@ -49,18 +49,18 @@ Once a release exists with assets attached, end users can pin a specific revisio
 
 ```bash
 # Project-scoped pin
-mkdir -p .github/extensions/ralph
+mkdir -p .github/extensions/autopilot
 # Order matters: leaf modules first, entry point (extension.mjs) LAST —
 # mirrors install.sh's FILES array and README Option A/B/D. If
 # `/extensions reload` fires mid-download, this guarantees the SDK
 # never sees a new `extension.mjs` importing missing/old siblings.
 for f in events-emit.mjs prompts.mjs handler.mjs extension.mjs; do
-  curl -L -o ".github/extensions/ralph/$f" \
-    "https://github.com/kloba/copilot-ralph-extension/releases/download/vX.Y.Z/$f"
+  curl -L -o ".github/extensions/autopilot/$f" \
+    "https://github.com/kloba/autopilot/releases/download/vX.Y.Z/$f"
 done
 ```
 
-For the user-scoped equivalent, swap `.github/extensions/ralph` for `~/.copilot/extensions/ralph`.
+For the user-scoped equivalent, swap `.github/extensions/autopilot` for `~/.copilot/extensions/autopilot`.
 
 ## Hotfix branches
 

--- a/docs/cli-stack.md
+++ b/docs/cli-stack.md
@@ -2,7 +2,7 @@
 
 > Stack-verification reference for `packages/tui/` (issue #22).
 >
-> The ralph TUI is built on the same proven trio used by today's leading
+> The autopilot TUI is built on the same proven trio used by today's leading
 > agentic-CLI tools: **Ink** (React for terminal UIs), **Yoga**
 > (Facebook's Flexbox engine that Ink uses for layout), and **Commander**
 > (the de-facto Node.js CLI argument parser). This document captures
@@ -72,7 +72,7 @@ the extension's webview stays consistent with the CLI.
 
 Commander has been the dominant Node CLI parser since 2011 and is
 what tools like ESLint, Vue CLI, and `pnpm` ship with. The reasons
-for picking it for `ralph-tui`:
+for picking it for `autopilot`:
 
 * **Subcommand ergonomics.** `program.command("replay <runId>")` and
   `program.command("watch [runId]")` map 1:1 to our `cmd` switch.
@@ -120,7 +120,7 @@ at Yoga as the layout backend.
 
 The TUI's full dependency closure resolves to ~3 MB of `node_modules/`
 when installed (Ink + React + Yoga's WASM + Commander). That cost is
-paid only by users who run `ralph-tui watch` interactively. The
+paid only by users who run `autopilot watch` interactively. The
 *event emitter* in the core extension stays stdlib-only, so an
 extension install via `install.sh` adds zero new packages.
 
@@ -130,5 +130,5 @@ extension install via `install.sh` adds zero new packages.
   Live TUI walkthrough + asciinema recipe.
 * [packages/tui/package.json](../packages/tui/package.json) — current
   pinned versions.
-* [Issue #22](https://github.com/kloba/copilot-ralph-extension/issues/22) —
+* [Issue #22](https://github.com/kloba/autopilot/issues/22) —
   TUI design discussion.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,7 +1,7 @@
 # Concepts
 
 !!! note "Stub page (issue #2)"
-    Scaffold only — to be expanded in follow-ups. See the [README](https://github.com/kloba/copilot-ralph-extension#readme) until this page is filled in.
+    Scaffold only — to be expanded in follow-ups. See the [README](https://github.com/kloba/autopilot#readme) until this page is filled in.
 
 Topics planned:
 
@@ -116,7 +116,7 @@ window pressure climb in real time.
 ### What you observe
 
 - **Live cumulative totals** — `ap_status.tokens` (added in
-  issue [#7](https://github.com/kloba/copilot-ralph-extension/issues/7))
+  issue [#7](https://github.com/kloba/autopilot/issues/7))
   exposes `{ input, output, total, max_tokens }` on the active
   snapshot. Counts start at zero and grow with every credited
   iteration. `max_tokens` echoes the configured cap, or is `null`
@@ -197,7 +197,7 @@ Slot-by-slot:
   `paused_for_ms` from the structured snapshot if you need
   active-only time.
 - `, tokens {X}/{Y}` — appears **only when** `max_tokens` was armed
-  (issue [#7](https://github.com/kloba/copilot-ralph-extension/issues/7)).
+  (issue [#7](https://github.com/kloba/autopilot/issues/7)).
   `X` is the cumulative input+output total credited so far; `Y` is
   the configured cap. Loops without a cap omit this segment so
   consumers do not see a misleading `tokens X/null`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,20 +2,20 @@
 
 Short answers to the questions that come up most often when running
 Ralph in anger. Most of these point at a deeper section in the
-[README](https://github.com/kloba/copilot-ralph-extension#readme) or
+[README](https://github.com/kloba/autopilot#readme) or
 at [`docs/concepts.md`](concepts.md) — keep this page narrow and
 link out rather than duplicating prose.
 
 ## Setup
 
-### Why doesn't `/extensions` list `ralph` after install?
+### Why doesn't `/extensions` list `autopilot` after install?
 
 The Copilot CLI loads extensions at startup (and on `/extensions
 reload`). Confirm every shipped `.mjs` is present in the install
 target:
 
-- User-scoped: `~/.copilot/extensions/ralph/` — visible from any cwd.
-- Project-scoped: `<git-root>/.github/extensions/ralph/` — only
+- User-scoped: `~/.copilot/extensions/autopilot/` — visible from any cwd.
+- Project-scoped: `<git-root>/.github/extensions/autopilot/` — only
   visible when you launch Copilot CLI from inside that repo.
 
 Currently shipped files are `extension.mjs`, `handler.mjs`, and
@@ -28,7 +28,7 @@ to the source via `cmp -s`.
 ### How do I install a specific tagged release?
 
 See README → [Option D — Pin a specific tagged
-release](https://github.com/kloba/copilot-ralph-extension#option-d--pin-a-specific-tagged-release).
+release](https://github.com/kloba/autopilot#option-d--pin-a-specific-tagged-release).
 Tags are immutable; release tarballs are SHA-pinned by GitHub,
 so a pinned install never silently shifts under you.
 
@@ -62,7 +62,7 @@ against the assistant's accumulated turn output — if the agent quotes
 the trigger phrase mid-thought (e.g. *"I'll mark this COMPLETE when
 done"*), the loop finishes. Pick a phrase the agent is unlikely to
 mention casually; `RALPH_DONE_42` and similar unusual tokens work
-well. See README → [Limitations](https://github.com/kloba/copilot-ralph-extension#limitations).
+well. See README → [Limitations](https://github.com/kloba/autopilot#limitations).
 
 ### Why does my loop never finish?
 
@@ -108,17 +108,18 @@ state-machine writeup.
 
 ### Where does a running loop's event log live?
 
-By default: `~/.copilot/ralph/runs/<runId>/events.jsonl`. Override
-the runs root with the `RALPH_EVENTS_DIR` environment variable. The
+By default: `~/.copilot/autopilot/runs/<runId>/events.jsonl`. Override
+the runs root with the `AUTOPILOT_EVENTS_DIR` environment variable
+(legacy `RALPH_EVENTS_DIR` is still honored as a fallback). The
 `<runId>` shape is `${label}-${startedAt}` — sortable,
 filesystem-safe, and surfaced in the `armed` event so the TUI can
 locate it.
 
 ### How do I tail a running loop's events?
 
-Use the bundled TUI: `npx ralph-tui watch <runId>` to follow events
-live, or `ralph-tui list` to see runs the index knows about. See
-README → [Inspecting a running loop](https://github.com/kloba/copilot-ralph-extension#inspecting-a-running-loop-ap_status-tool)
+Use the bundled TUI: `npx autopilot watch <runId>` to follow events
+live, or `autopilot list` to see runs the index knows about. See
+README → [Inspecting a running loop](https://github.com/kloba/autopilot#inspecting-a-running-loop-ap_status-tool)
 for the snapshot tool that returns a structured live snapshot
 without leaving the chat.
 
@@ -154,11 +155,11 @@ trailers — one for the `Copilot` GitHub identity, one for the
 dedicated `copilot-ralph` bot account. The dual-trailer convention
 is baked into the SDLC prompts (`self_improve`, `grow_project`)
 and appended as a rider to the user-supplied prompt for
-`ap_loop`. See README → [Commit attribution](https://github.com/kloba/copilot-ralph-extension#commit-attribution).
+`ap_loop`. See README → [Commit attribution](https://github.com/kloba/autopilot#commit-attribution).
 
 ### How do I opt out of the second `copilot-ralph` trailer?
 
-Set `RALPH_NO_ATTRIBUTION=1` in the environment before arming the
+Set `AUTOPILOT_NO_ATTRIBUTION=1` in the environment before arming the
 loop. The opt-out suppresses **only** the second
 `copilot-ralph` trailer; the first `Copilot` trailer always ships.
 Note that the opt-out is honored by the prompt, not enforced by
@@ -169,6 +170,6 @@ it), the trailer can still appear. Audit afterwards with
 ## Anything else?
 
 If your question isn't answered here, open an issue or skim the
-[README](https://github.com/kloba/copilot-ralph-extension#readme)
+[README](https://github.com/kloba/autopilot#readme)
 Troubleshooting and Limitations sections — they cover the
 long-tail edge cases this page intentionally elides.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 An autonomous iterative loop for the GitHub Copilot CLI.
 
 !!! warning "Stub documentation site"
-    This site is the v0 scaffold for [issue #2](https://github.com/kloba/copilot-ralph-extension/issues/2). The pages below mirror the planned navigation but are intentionally short — they will be filled in by follow-up PRs.
+    This site is the v0 scaffold for [issue #2](https://github.com/kloba/autopilot/issues/2). The pages below mirror the planned navigation but are intentionally short — they will be filled in by follow-up PRs.
 
 ## What is this?
 
@@ -17,6 +17,6 @@ The loop is the simplest possible form of agentic autonomy: one prompt, repeated
 
 ## Repository
 
-- [Source on GitHub](https://github.com/kloba/copilot-ralph-extension)
-- [Issue tracker](https://github.com/kloba/copilot-ralph-extension/issues)
-- [Releases](https://github.com/kloba/copilot-ralph-extension/releases)
+- [Source on GitHub](https://github.com/kloba/autopilot)
+- [Issue tracker](https://github.com/kloba/autopilot/issues)
+- [Releases](https://github.com/kloba/autopilot/releases)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,8 +6,8 @@
 ## Install
 
 ```bash
-git clone https://github.com/kloba/copilot-ralph-extension
-cd copilot-ralph-extension
+git clone https://github.com/kloba/autopilot
+cd autopilot
 ./install.sh
 ```
 
@@ -23,4 +23,4 @@ Stop early:
 ap_stop({ reason: "changed plan" })
 ```
 
-See the project [README](https://github.com/kloba/copilot-ralph-extension#readme) for the full reference until these pages are filled in.
+See the project [README](https://github.com/kloba/autopilot#readme) for the full reference until these pages are filled in.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,7 +1,7 @@
 # Recipes
 
 !!! note "Stub page (issue #2)"
-    Scaffold only — to be expanded in follow-ups. See the [README](https://github.com/kloba/copilot-ralph-extension#readme) until this page is filled in.
+    Scaffold only — to be expanded in follow-ups. See the [README](https://github.com/kloba/autopilot#readme) until this page is filled in.
 
 Planned recipes:
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -6,5 +6,5 @@
 This page will eventually feature:
 
 - Recorded demos of long Ralph runs
-- Live dashboard screenshots (see [issue #6](https://github.com/kloba/copilot-ralph-extension/issues/6))
+- Live dashboard screenshots (see [issue #6](https://github.com/kloba/autopilot/issues/6))
 - Real-world projects built or maintained by Ralph

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -6853,7 +6853,7 @@ test("docs/faq.md is no longer the stub and answers core operational questions",
     // Headline questions that MUST be present (regression guard against
     // future "simplify" PRs that drop sections wholesale).
     const requiredHeadings = [
-        /Why doesn't `\/extensions` list `ralph` after install\?/,
+        /Why doesn't `\/extensions` list `autopilot` after install\?/,
         /Why does arming fail with .*already armed/,
         /Why did my loop stop after exactly one iteration\?/,
         /Why does my loop never finish\?/,
@@ -6878,8 +6878,8 @@ test("docs/faq.md is no longer the stub and answers core operational questions",
     assert.match(faq, /pause[\s\S]{0,80}idempotent/i);
     assert.match(faq, /resume[\s\S]{0,40}\*\*not\*\* idempotent/i);
     // (c) The default runs root path — used by the events emitter.
-    assert.match(faq, /~\/\.copilot\/ralph\/runs/);
-    assert.match(faq, /RALPH_EVENTS_DIR/);
+    assert.match(faq, /~\/\.copilot\/autopilot\/runs/);
+    assert.match(faq, /AUTOPILOT_EVENTS_DIR/);
 });
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Stage-0 dropped the project branding from these docs pages but left the
**identifier** references behind. This PR flips the remaining
`copilot-ralph-extension`, `ralph-tui`, `ralph_*`, `RALPH_*`, and
`~/.copilot/ralph*` references to their `autopilot` equivalents across
the 10 user-facing docs/ pages (unit 10/11 of issue #49).

The drift-guard in `test/extension.test.mjs` that pinned the old FAQ
heading and the `~/.copilot/ralph/runs` + `RALPH_EVENTS_DIR` claims is
updated in lockstep so it now pins the rebranded autopilot strings.

## Preserved verbatim (per stage-0 rules)

- `Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>` trailer literal in `docs/CONTRIBUTING.md`.
- `docs/ARCHITECTURE.md` credit link to anthropics/claude-code's `ralph-wiggum` plugin.
- `docs/index.md` "Why a loop?" Anthropic-plugin reference.
- `copilot-ralph` bot-account identity in `docs/faq.md` commit-attribution section.
- `copilot-ralph-mode` third-party shell-wrapper reference in `docs/ARCHITECTURE.md`.
- `createRalphController()` / `RalphResult` JS identifiers — they still live in `extension/handler.mjs`.

The `faq.md` events-emitter section now points at `AUTOPILOT_EVENTS_DIR`
with a parenthetical noting that legacy `RALPH_EVENTS_DIR` is still
honored as a fallback.

## Test plan

- [x] `npm install --no-audit --no-fund`
- [x] `npm test` — 921 pass, 1 unrelated failure (`bin where: prints default runs root` in `packages/tui/test/bin.test.mjs`) that was already failing on `feat/rename-autopilot` HEAD before this PR
- [x] `npm run check` — Syntax-checked 22 .mjs files

Refs #49.