### PR TITLE
feat(tui-runner)!: prefer AUTOPILOT_* env + autopilot-* runId prefixes (refs #49)

### DIFF
--- a/packages/tui/src/runner.mjs
+++ b/packages/tui/src/runner.mjs
@@ -1,5 +1,5 @@
-// `ralph-tui run` driver — out-of-session sibling of the in-extension
-// ralph_loop / self_improve / grow_project tools.
+// autopilot run driver — out-of-session sibling of the in-extension
+// ap_loop / self_improve / grow_project tools.
 //
 // Why a separate driver? Because the in-extension loop runs as part of
 // the user's current Copilot session — so the LLM context grows
@@ -7,7 +7,7 @@
 // in-session loop (the user sees every iter inline, and pause/resume
 // mid-session lets the user chat with the agent), but it also creates
 // a context-rot failure mode where late iterations are dominated by
-// early-iteration noise. The `ralph-tui run` driver runs each
+// early-iteration noise. The autopilot run driver runs each
 // iteration as a fresh `copilot -p ...` subprocess so:
 //
 //   --continue   resume the same Copilot session every iter (parity
@@ -28,7 +28,7 @@
 //     iter 1 and reused via `--resume=<sessionId>` for iter 2+ when
 //     the driver is in --continue mode.
 //
-// Pause/resume/stop are out-of-band: a sibling `ralph-tui run --pause
+// Pause/resume/stop are out-of-band: a sibling `autopilot run --pause
 // <runId>` flips a flag in the run's state.json (CAS-protected via
 // lockfile so concurrent pause+stop don't lose updates), and the
 // driver re-reads state at each iter boundary. The current child
@@ -38,8 +38,8 @@
 
 import { spawn as nodeSpawn, spawnSync as nodeSpawnSync } from "node:child_process";
 import { homedir } from "node:os";
-import { mkdirSync, readFileSync, writeFileSync, renameSync, existsSync, rmSync, appendFileSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync, renameSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 
 import {
@@ -72,7 +72,7 @@ export { PROMPT_SELF_IMPROVE, PROMPT_GROW_PROJECT, COMPLETION_PROMISE, BAKED_ABO
 // would be rejected by handler.mjs is also rejected here.
 export const MAX_FOCUS_CHARS = 2000;
 
-// Cap on the user-supplied --prompt string for ralph_loop-style runs.
+// Cap on the user-supplied --prompt string for ap_loop-style runs.
 // Mirrors the in-extension MAX_PROMPT_CHARS.
 export const MAX_PROMPT_CHARS = 65536;
 
@@ -94,34 +94,58 @@ const MAX_LOCK_RETRIES = 200; // 5s worst-case
 
 // ─── State-file CAS ────────────────────────────────────────────────
 
-// Print a one-line stderr deprecation notice the FIRST time a given
-// migration trigger fires, then drop a sentinel line under
-// ~/.copilot/autopilot/. Mirror of the helpers in
-// extension/events-emit.mjs and packages/tui/src/writer.mjs — the
-// three surfaces share a sentinel so a user only sees each notice
-// once across all three call sites.
-function emitDeprecationOnce({ key, message, sentinelPath, fs, stderr }) {
+// Per-process dedupe flags for the env-var deprecation notices. The
+// runner is a long-lived process (the loop runs many iters), so we
+// only want each `RALPH_TUI_*` deprecation message printed once per
+// invocation. Cross-process suppression isn't needed for the env-var
+// path: a user who keeps using the legacy env var will re-set it on
+// every shell session and the one-line warning is cheap. Stored as a
+// Set so the test suite can clear it via `_resetDeprecationFlagsForTest`.
+const _envNoticesShown = new Set();
+
+function noteEnvDeprecation(varName, stderr) {
+    if (_envNoticesShown.has(varName)) return;
+    _envNoticesShown.add(varName);
     try {
-        const content = fs.readFileSync(sentinelPath, "utf8");
-        if (content.split("\n").some((l) => l === key)) return;
-    } catch { /* sentinel missing or unreadable */ }
-    try {
-        stderr.write(message);
-        fs.mkdirSync(dirname(sentinelPath), { recursive: true });
-        fs.appendFileSync(sentinelPath, key + "\n");
+        stderr.write(
+            `[autopilot] note: env $${varName} is deprecated, please use $${varName.replace(/^RALPH_TUI_/, "AUTOPILOT_")} (still honored)\n`,
+        );
     } catch { /* best-effort */ }
 }
 
-/** Resolve the state-files root, preferring $AUTOPILOT_RUNS_DIR, falling back
- *  to $RALPH_TUI_RUNS_DIR (deprecated), then to ~/.copilot/autopilot/runs. */
+/** Test-only: reset the per-process env-var deprecation flags.
+ *  Used by the test suite to assert one-shot semantics across
+ *  multiple `resolveStateRoot` / `resolveCopilotBin` invocations
+ *  within a single test process. Not part of the public API. */
+export function _resetDeprecationFlagsForTest() {
+    _envNoticesShown.clear();
+}
+
+/** Resolve the state-files root for autopilot run-driver state files
+ *  (state.json, lockfiles, etc.). This is intentionally SEPARATE from
+ *  the events root resolved by writer.mjs / events-emit.mjs:
+ *  events go to `~/.copilot/autopilot/runs`, runner state goes to
+ *  `~/.copilot/autopilot-tui/runs`. The two roots are decoupled so an
+ *  operator can wipe TUI runner state without nuking the canonical
+ *  events.jsonl history.
+ *
+ *  Resolution order:
+ *    1. `$AUTOPILOT_RUNS_DIR` (primary, no notice).
+ *    2. `$RALPH_TUI_RUNS_DIR` (legacy, one-line stderr notice — the
+ *       per-process dedupe means a long-running loop only logs once).
+ *    3. Default `~/.copilot/autopilot-tui/runs`. If that path doesn't
+ *       exist yet but `~/.copilot/ralph-tui/runs` does, return the
+ *       legacy default and emit a one-line stderr migration notice
+ *       gated by the sentinel `<NEW_ROOT>/.migrated-from-ralph-tui`.
+ *       The sentinel itself is written by `initState` after the first
+ *       successful mkdir of the new root, so the next process flips
+ *       silent automatically. */
 export function resolveStateRoot({
     env = process.env,
-    fs: fsArg = { readFileSync, existsSync, mkdirSync, appendFileSync },
+    fs: fsArg = { existsSync },
     stderr: stderrArg = process.stderr,
     sentinelPath: sentinelPathArg,
 } = {}) {
-    const sentinelPath = sentinelPathArg ?? join(homedir(), ".copilot", "autopilot", ".migration-notice-shown");
-
     // Primary: $AUTOPILOT_RUNS_DIR
     const newOverride = env?.AUTOPILOT_RUNS_DIR;
     if (typeof newOverride === "string" && newOverride.trim()) return newOverride.trim();
@@ -129,19 +153,14 @@ export function resolveStateRoot({
     // Legacy fallback: $RALPH_TUI_RUNS_DIR (deprecated)
     const legacyOverride = env?.RALPH_TUI_RUNS_DIR;
     if (typeof legacyOverride === "string" && legacyOverride.trim()) {
-        emitDeprecationOnce({
-            key: "env:RALPH_TUI_RUNS_DIR",
-            message: "[autopilot] note: env $RALPH_TUI_RUNS_DIR is deprecated, please use $AUTOPILOT_RUNS_DIR (still honored)\n",
-            sentinelPath,
-            fs: fsArg,
-            stderr: stderrArg,
-        });
+        noteEnvDeprecation("RALPH_TUI_RUNS_DIR", stderrArg);
         return legacyOverride.trim();
     }
 
-    // Default paths
-    const newDefault = join(homedir(), ".copilot", "autopilot", "runs");
+    // Default paths.
+    const newDefault = join(homedir(), ".copilot", "autopilot-tui", "runs");
     const oldDefault = join(homedir(), ".copilot", "ralph-tui", "runs");
+    const sentinelPath = sentinelPathArg ?? join(newDefault, ".migrated-from-ralph-tui");
 
     let newExists = false;
     let oldExists = false;
@@ -149,41 +168,38 @@ export function resolveStateRoot({
     try { oldExists = fsArg.existsSync(oldDefault); } catch { /* swallow */ }
 
     if (!newExists && oldExists) {
-        emitDeprecationOnce({
-            key: `path:${oldDefault}`,
-            message: `[autopilot] note: reading from legacy ~/.copilot/ralph-tui/runs (default is now ~/.copilot/autopilot/runs)\n`,
-            sentinelPath,
-            fs: fsArg,
-            stderr: stderrArg,
-        });
+        // Sentinel-gated one-shot migration notice. The sentinel is
+        // dropped by `initState` after the first successful mkdir of
+        // the new root; once present, this branch suppresses the
+        // notice.
+        let sentinelExists = false;
+        try { sentinelExists = fsArg.existsSync(sentinelPath); } catch { /* swallow */ }
+        if (!sentinelExists) {
+            try {
+                stderrArg.write(
+                    "[autopilot] note: reading from legacy ~/.copilot/ralph-tui/runs (default is now ~/.copilot/autopilot-tui/runs)\n",
+                );
+            } catch { /* best-effort */ }
+        }
         return oldDefault;
     }
 
     return newDefault;
 }
 
-/** Resolve the copilot binary path, preferring $AUTOPILOT_COPILOT_BIN, falling
- *  back to $RALPH_TUI_COPILOT_BIN (deprecated), then "copilot". */
+/** Resolve the copilot binary path, preferring $AUTOPILOT_COPILOT_BIN,
+ *  falling back to $RALPH_TUI_COPILOT_BIN (deprecated, one-line stderr
+ *  notice with per-process dedupe), then to "copilot" on PATH. */
 export function resolveCopilotBin({
     env = process.env,
-    fs: fsArg = { readFileSync, existsSync, mkdirSync, appendFileSync },
     stderr: stderrArg = process.stderr,
-    sentinelPath: sentinelPathArg,
 } = {}) {
-    const sentinelPath = sentinelPathArg ?? join(homedir(), ".copilot", "autopilot", ".migration-notice-shown");
-
     const newOverride = env?.AUTOPILOT_COPILOT_BIN;
     if (typeof newOverride === "string" && newOverride.trim()) return newOverride.trim();
 
     const legacyOverride = env?.RALPH_TUI_COPILOT_BIN;
     if (typeof legacyOverride === "string" && legacyOverride.trim()) {
-        emitDeprecationOnce({
-            key: "env:RALPH_TUI_COPILOT_BIN",
-            message: "[autopilot] note: env $RALPH_TUI_COPILOT_BIN is deprecated, please use $AUTOPILOT_COPILOT_BIN (still honored)\n",
-            sentinelPath,
-            fs: fsArg,
-            stderr: stderrArg,
-        });
+        noteEnvDeprecation("RALPH_TUI_COPILOT_BIN", stderrArg);
         return legacyOverride.trim();
     }
 
@@ -258,11 +274,43 @@ export function updateState(runId, mutator, env = process.env) {
     }
 }
 
-/** Initial state-file write; creates the run directory.  */
+/** Initial state-file write; creates the run directory.
+ *
+ *  Side effect: when `resolveStateRoot` returned the legacy
+ *  `~/.copilot/ralph-tui/runs` path due to first-run migration, this
+ *  function also creates the new default root
+ *  (`~/.copilot/autopilot-tui/runs`) and drops a
+ *  `.migrated-from-ralph-tui` sentinel into it. The sentinel
+ *  suppresses the migration notice on subsequent invocations, even if
+ *  the runner keeps writing state to the legacy path (compatibility
+ *  with existing runIds is preserved — we simply stop nagging the
+ *  user once they've seen the message once). */
 function initState(runId, initial, env = process.env) {
-    const statePath = resolveStatePath(runId, env);
-    const dir = join(resolveStateRoot({ env }), runId);
+    const root = resolveStateRoot({ env });
+    const statePath = join(root, runId, "state.json");
+    const dir = join(root, runId);
     mkdirSync(dir, { recursive: true });
+
+    // First-run migration: when we returned the legacy path AND the
+    // env-var overrides aren't in play, drop the sentinel into the new
+    // default so future calls flip silent. We re-derive the paths
+    // here rather than threading them out of `resolveStateRoot` so
+    // the resolver stays a pure read; this initState is the only
+    // mkdir-side-effect site so the write naturally fits here.
+    if (
+        !env?.AUTOPILOT_RUNS_DIR
+        && !env?.RALPH_TUI_RUNS_DIR
+        && root === join(homedir(), ".copilot", "ralph-tui", "runs")
+    ) {
+        const newDefault = join(homedir(), ".copilot", "autopilot-tui", "runs");
+        const sentinelPath = join(newDefault, ".migrated-from-ralph-tui");
+        try {
+            mkdirSync(newDefault, { recursive: true });
+            writeFileSync(sentinelPath, "");
+        } catch { /* best-effort — a missing sentinel just means the next
+                     process re-emits the one-line notice */ }
+    }
+
     const lockPath = acquireLock(statePath);
     try {
         const seed = { version: 1, ...initial };
@@ -350,9 +398,9 @@ export function composePrompt({ mode, prompt, focus }) {
 
 /** Mode → label used by the event emitter and the run directory name. */
 function labelForMode(mode) {
-    if (mode === "self-improve") return "ralph-tui-self-improve";
-    if (mode === "grow-project") return "ralph-tui-grow-project";
-    if (mode === "prompt") return "ralph-tui-prompt";
+    if (mode === "self-improve") return "autopilot-self-improve";
+    if (mode === "grow-project") return "autopilot-grow-project";
+    if (mode === "prompt") return "autopilot-prompt";
     throw new TypeError(`labelForMode: unknown mode "${mode}"`);
 }
 
@@ -1012,8 +1060,10 @@ export function runOneIteration({
     env = process.env,
     extraArgs = [],
     onLine, // optional callback per parsed event (for live feedback)
+    stderr = process.stderr, // injected for tests that capture
+                              // resolveCopilotBin's deprecation notice
 }) {
-    const bin = copilotBin ?? resolveCopilotBin({ env });
+    const bin = copilotBin ?? resolveCopilotBin({ env, stderr });
     const args = ["-p", prompt, "--allow-all-tools", "--output-format", "json"];
     if (resumeSessionId) args.push(`--resume=${resumeSessionId}`);
     else if (sessionName) args.push("-n", sessionName);
@@ -1106,7 +1156,7 @@ export function runOneIteration({
  *   spawn               Inject for tests.
  *   copilotBin          Inject for tests. Falls back to
  *                       $AUTOPILOT_COPILOT_BIN, then $RALPH_TUI_COPILOT_BIN
- *                       (legacy), then "copilot".
+ *                       (deprecated), then "copilot".
  *   env, fs, now        Inject for tests.
  *   eventEmitter        Inject for tests; otherwise createEventEmitter
  *                       is invoked.
@@ -1190,7 +1240,7 @@ export async function runRalphTui(opts) {
         totalPausedMs: 0,
     }, env);
 
-    // Emit the canonical `armed` event so `ralph-tui list/stats`
+    // Emit the canonical `armed` event so `autopilot list/stats`
     // pick up this run.
     emitter.write({
         type: "armed",
@@ -1699,11 +1749,12 @@ export async function runRalphTui(opts) {
                 cwd,
                 env,
                 onLine,
+                stderr,
             });
         } catch (err) {
             terminationReason = "error";
             terminationNote = err?.message ?? String(err);
-            stderr.write?.(`ralph-tui run: subprocess error: ${terminationNote}\n`);
+            stderr.write?.(`autopilot run: subprocess error: ${terminationNote}\n`);
             // Even on subprocess error, fold in any iter-live usage
             // counters (the child may have emitted some
             // assistant.message events before crashing) so the final
@@ -1833,7 +1884,7 @@ export async function runRalphTui(opts) {
         if (result.exitCode !== 0) {
             terminationReason = "subprocess_failed";
             terminationNote = `copilot exited with code ${result.exitCode}: ${result.stderr.slice(0, 500)}`;
-            stderr.write?.(`ralph-tui run: ${terminationNote}\n`);
+            stderr.write?.(`autopilot run: ${terminationNote}\n`);
             break;
         }
 

--- a/packages/tui/test/runner.test.mjs
+++ b/packages/tui/test/runner.test.mjs
@@ -1,10 +1,10 @@
-// Tests for `ralph-tui run` driver (packages/tui/src/runner.mjs).
+// Tests for autopilot run driver (packages/tui/src/runner.mjs).
 //
 // Strategy:
 //   - Pure helpers (validateFocus, composePrompt, reduceCopilotEvents)
 //     get straightforward unit tests.
 //   - State-file CAS (initState/updateState/pauseRun/resumeRun/stopRun)
-//     gets isolated tmp-dir tests via $RALPH_TUI_RUNS_DIR.
+//     gets isolated tmp-dir tests via $AUTOPILOT_RUNS_DIR.
 //   - End-to-end loop tests use a Node-script "fake copilot" shim that
 //     emits scripted JSONL on stdout. The shim is parameterised by a
 //     SCRIPT env var (path to a JSON file describing the iter's
@@ -34,6 +34,7 @@ import {
     statusRun,
     runRalphTui,
     runOneIteration,
+    _resetDeprecationFlagsForTest,
     PROMPT_SELF_IMPROVE,
     PROMPT_GROW_PROJECT,
     COMPLETION_PROMISE,
@@ -48,7 +49,7 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "
 const FAKE_COPILOT = resolve(dirname(fileURLToPath(import.meta.url)), "fixtures", "fake-copilot.mjs");
 
 function tmp() {
-    return mkdtempSync(join(tmpdir(), "ralph-tui-runner-"));
+    return mkdtempSync(join(tmpdir(), "autopilot-tui-runner-"));
 }
 
 function makeEnv(extra = {}) {
@@ -59,30 +60,17 @@ function makeEnv(extra = {}) {
     };
 }
 
-// Stage 3 (issue #49): resolveStateRoot / resolveCopilotBin now perform
-// sentinel-gated stderr deprecation notices when legacy
-// $RALPH_TUI_RUNS_DIR / $RALPH_TUI_COPILOT_BIN are used. Tests inject
-// a fake fs (no sentinel, accepts mkdir/append silently) and a fake
-// stderr (captures into messages[]). The sentinelPath points at a fake
-// location so deprecation writes never touch the real ~/.copilot.
-function makeFakeFs({ sentinel = "", existingPaths = new Set() } = {}) {
-    let written = "";
-    const fake = {
-        readFileSync: (p) => {
-            if (p === fake._sentinelPath) return sentinel + written;
-            const e = new Error("ENOENT");
-            e.code = "ENOENT";
-            throw e;
-        },
-        appendFileSync: (p, data) => {
-            if (p === fake._sentinelPath) written += data;
-        },
-        mkdirSync: () => {},
+// Issue #49: resolveStateRoot / resolveCopilotBin now perform
+// per-process-deduped stderr deprecation notices when legacy
+// $RALPH_TUI_RUNS_DIR / $RALPH_TUI_COPILOT_BIN are used, and a
+// sentinel-gated migration notice when the legacy default path
+// `~/.copilot/ralph-tui/runs` is read. Tests inject a fake fs
+// (configurable existingPaths set) and a fake stderr so deprecation
+// writes never touch the real ~/.copilot.
+function makeFakeFs({ existingPaths = new Set() } = {}) {
+    return {
         existsSync: (p) => existingPaths.has(p),
     };
-    fake._sentinelPath = "/fake/sentinel";
-    fake.writtenSentinel = () => written;
-    return fake;
 }
 
 function makeFakeStderr() {
@@ -232,80 +220,93 @@ test("resolveStateRoot: honors $AUTOPILOT_RUNS_DIR (primary)", () => {
 });
 
 test("resolveStateRoot: honors $RALPH_TUI_RUNS_DIR (legacy, with notice)", () => {
+    _resetDeprecationFlagsForTest();
     const fs = makeFakeFs();
     const stderr = makeFakeStderr();
     assert.equal(
-        resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/tmp/x" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/tmp/x" }, fs, stderr }),
         "/tmp/x",
     );
     assert.equal(stderr.messages.length, 1);
     assert.match(stderr.messages[0], /RALPH_TUI_RUNS_DIR is deprecated/);
 });
 
-test("resolveStateRoot: defaults under ~/.copilot/autopilot/runs", () => {
+test("resolveStateRoot: defaults under ~/.copilot/autopilot-tui/runs", () => {
+    _resetDeprecationFlagsForTest();
     const fs = makeFakeFs();
     const stderr = makeFakeStderr();
-    const r = resolveStateRoot({ env: {}, fs, stderr, sentinelPath: "/fake/sentinel" });
-    assert.match(r, /\.copilot\/autopilot\/runs$/);
+    const r = resolveStateRoot({ env: {}, fs, stderr });
+    assert.match(r, /\.copilot\/autopilot-tui\/runs$/);
     assert.equal(stderr.messages.length, 0);
 });
 
 test("resolveStateRoot: AUTOPILOT primary wins over RALPH_TUI legacy (no notice)", () => {
+    _resetDeprecationFlagsForTest();
     const fs = makeFakeFs();
     const stderr = makeFakeStderr();
     assert.equal(
         resolveStateRoot({
             env: { AUTOPILOT_RUNS_DIR: "/ap", RALPH_TUI_RUNS_DIR: "/legacy" },
-            fs, stderr, sentinelPath: "/fake/sentinel",
+            fs, stderr,
         }),
         "/ap",
     );
     assert.equal(stderr.messages.length, 0);
 });
 
-test("resolveStateRoot: legacy default path is honoured with deprecation notice", () => {
+test("resolveStateRoot: legacy default path is honoured with migration notice", () => {
+    _resetDeprecationFlagsForTest();
     const legacyDefault = join(homedir(), ".copilot", "ralph-tui", "runs");
     const fs = makeFakeFs({ existingPaths: new Set([legacyDefault]) });
     const stderr = makeFakeStderr();
     assert.equal(
-        resolveStateRoot({ env: {}, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        resolveStateRoot({ env: {}, fs, stderr }),
         legacyDefault,
     );
     assert.equal(stderr.messages.length, 1);
-    assert.match(stderr.messages[0], /reading from legacy/);
+    assert.match(stderr.messages[0], /reading from legacy ~\/\.copilot\/ralph-tui\/runs/);
+    assert.match(stderr.messages[0], /default is now ~\/\.copilot\/autopilot-tui\/runs/);
+});
+
+test("resolveStateRoot: sentinel `.migrated-from-ralph-tui` suppresses the migration notice", () => {
+    _resetDeprecationFlagsForTest();
+    const newDefault = join(homedir(), ".copilot", "autopilot-tui", "runs");
+    const legacyDefault = join(homedir(), ".copilot", "ralph-tui", "runs");
+    const sentinelPath = join(newDefault, ".migrated-from-ralph-tui");
+    // Sentinel exists (under the new root), legacy path also exists,
+    // new root itself does NOT exist yet — the migration branch fires
+    // but the sentinel must suppress the notice.
+    const fs = makeFakeFs({ existingPaths: new Set([legacyDefault, sentinelPath]) });
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveStateRoot({ env: {}, fs, stderr }),
+        legacyDefault,
+        "still returns legacy path so existing runIds keep working",
+    );
+    assert.equal(stderr.messages.length, 0, "sentinel suppresses the notice");
 });
 
 test("resolveStateRoot: when both default paths exist, primary wins (no notice)", () => {
-    const newDefault = join(homedir(), ".copilot", "autopilot", "runs");
+    _resetDeprecationFlagsForTest();
+    const newDefault = join(homedir(), ".copilot", "autopilot-tui", "runs");
     const oldDefault = join(homedir(), ".copilot", "ralph-tui", "runs");
     const fs = makeFakeFs({ existingPaths: new Set([newDefault, oldDefault]) });
     const stderr = makeFakeStderr();
     assert.equal(
-        resolveStateRoot({ env: {}, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        resolveStateRoot({ env: {}, fs, stderr }),
         newDefault,
     );
     assert.equal(stderr.messages.length, 0);
 });
 
-test("resolveStateRoot: deprecation notice is one-shot per process (sentinel-gated)", () => {
+test("resolveStateRoot: deprecation notice is one-shot per process (module-level dedupe)", () => {
+    _resetDeprecationFlagsForTest();
     const fs = makeFakeFs();
     const stderr = makeFakeStderr();
-    const sentinelPath = "/fake/sentinel";
-    resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/x" }, fs, stderr, sentinelPath });
-    resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/x" }, fs, stderr, sentinelPath });
-    resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/x" }, fs, stderr, sentinelPath });
+    resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/x" }, fs, stderr });
+    resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/x" }, fs, stderr });
+    resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/x" }, fs, stderr });
     assert.equal(stderr.messages.length, 1);
-    assert.match(fs.writtenSentinel(), /RALPH_TUI_RUNS_DIR/);
-});
-
-test("resolveStateRoot: pre-existing sentinel suppresses the notice", () => {
-    const fs = makeFakeFs({ sentinel: "env:RALPH_TUI_RUNS_DIR\n" });
-    const stderr = makeFakeStderr();
-    assert.equal(
-        resolveStateRoot({ env: { RALPH_TUI_RUNS_DIR: "/tmp/x" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
-        "/tmp/x",
-    );
-    assert.equal(stderr.messages.length, 0);
 });
 
 // resolveCopilotBin (issue #49) — same DI shape as resolveStateRoot
@@ -314,24 +315,45 @@ test("resolveCopilotBin: defaults to 'copilot'", () => {
 });
 
 test("resolveCopilotBin: honours $AUTOPILOT_COPILOT_BIN (primary, no notice)", () => {
-    const fs = makeFakeFs();
+    _resetDeprecationFlagsForTest();
     const stderr = makeFakeStderr();
     assert.equal(
-        resolveCopilotBin({ env: { AUTOPILOT_COPILOT_BIN: "/usr/local/bin/copilot" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        resolveCopilotBin({ env: { AUTOPILOT_COPILOT_BIN: "/usr/local/bin/copilot" }, stderr }),
         "/usr/local/bin/copilot",
     );
     assert.equal(stderr.messages.length, 0);
 });
 
 test("resolveCopilotBin: honours $RALPH_TUI_COPILOT_BIN (legacy, with notice)", () => {
-    const fs = makeFakeFs();
+    _resetDeprecationFlagsForTest();
     const stderr = makeFakeStderr();
     assert.equal(
-        resolveCopilotBin({ env: { RALPH_TUI_COPILOT_BIN: "/usr/local/bin/copilot-old" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        resolveCopilotBin({ env: { RALPH_TUI_COPILOT_BIN: "/usr/local/bin/copilot-old" }, stderr }),
         "/usr/local/bin/copilot-old",
     );
     assert.equal(stderr.messages.length, 1);
     assert.match(stderr.messages[0], /RALPH_TUI_COPILOT_BIN is deprecated/);
+});
+
+test("resolveCopilotBin: AUTOPILOT primary wins over RALPH_TUI legacy (no notice)", () => {
+    _resetDeprecationFlagsForTest();
+    const stderr = makeFakeStderr();
+    assert.equal(
+        resolveCopilotBin({
+            env: { AUTOPILOT_COPILOT_BIN: "/ap-bin", RALPH_TUI_COPILOT_BIN: "/legacy-bin" },
+            stderr,
+        }),
+        "/ap-bin",
+    );
+    assert.equal(stderr.messages.length, 0);
+});
+
+test("resolveCopilotBin: deprecation notice is one-shot per process (module-level dedupe)", () => {
+    _resetDeprecationFlagsForTest();
+    const stderr = makeFakeStderr();
+    resolveCopilotBin({ env: { RALPH_TUI_COPILOT_BIN: "/x" }, stderr });
+    resolveCopilotBin({ env: { RALPH_TUI_COPILOT_BIN: "/x" }, stderr });
+    assert.equal(stderr.messages.length, 1);
 });
 
 test("resolveStatePath: joins root + runId + state.json", () => {
@@ -697,6 +719,219 @@ test("runRalphTui: subprocess exit code != 0 ends loop with subprocess_failed", 
         spawn,
     });
     assert.equal(result.terminationReason, "subprocess_failed");
+});
+
+// Issue #49: stderr error prefix flipped from `ralph-tui run:` to
+// `autopilot run:` to match the new binary name. Two emit sites: the
+// subprocess-error path and the non-zero exit path.
+test("runRalphTui: subprocess exit code != 0 prints `autopilot run:` stderr prefix", async () => {
+    const stderr = makeFakeStderr();
+    const spawn = makeMockSpawn([
+        { stdout: "", stderr: "auth error\n", exitCode: 7 },
+    ]);
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        stderr,
+    });
+    assert.ok(
+        stderr.messages.some((m) => m.startsWith("autopilot run:")),
+        `expected an "autopilot run:" stderr line, got ${JSON.stringify(stderr.messages)}`,
+    );
+    // Negative — we must NOT still emit the legacy prefix.
+    assert.ok(
+        !stderr.messages.some((m) => m.startsWith("ralph-tui run:")),
+        "legacy `ralph-tui run:` prefix must be gone",
+    );
+});
+
+test("runRalphTui: subprocess error path prints `autopilot run:` stderr prefix", async () => {
+    const stderr = makeFakeStderr();
+    const spawn = function () {
+        // Throw synchronously from spawn — simulates a missing
+        // copilot binary, which trips the catch path.
+        throw new Error("ENOENT: copilot not found");
+    };
+    const result = await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        stderr,
+    });
+    assert.equal(result.terminationReason, "error");
+    assert.ok(
+        stderr.messages.some((m) => m.startsWith("autopilot run: subprocess error:")),
+        `expected "autopilot run: subprocess error:" prefix, got ${JSON.stringify(stderr.messages)}`,
+    );
+});
+
+// Issue #49 decision E (BREAKING): runId mode prefixes flipped from
+// `ralph-tui-*` to `autopilot-*` with no shim. Pin all three modes so a
+// future regression that re-introduces the legacy prefix fails loudly.
+test("runRalphTui: --self-improve emits runId / label with `autopilot-self-improve` prefix", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "stub-ignored",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    const spawn = makeMockSpawn([
+        {
+            stdout: [
+                JSON.stringify({ type: "assistant.message", data: { content: "COMPLETE" } }),
+                JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+            ].join("\n") + "\n",
+            exitCode: 0,
+        },
+    ]);
+    let realRunId = null;
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+        onRunId: (id) => { realRunId = id; },
+    });
+    // The injected eventEmitter has its own stub runId so the loop
+    // uses that for state-file paths; the label flowed through every
+    // event is still derived from `mode` via labelForMode.
+    const armed = events.find((e) => e.type === "armed");
+    assert.equal(armed.label, "autopilot-self-improve");
+    assert.ok(!armed.label.startsWith("ralph-tui-"), "must NOT carry the legacy `ralph-tui-` prefix");
+});
+
+test("runRalphTui: --grow-project emits label with `autopilot-grow-project` prefix", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "stub", eventsPath: "/dev/null",
+        write: (ev) => events.push(ev), close: () => {},
+    };
+    const spawn = makeMockSpawn([
+        {
+            stdout: [
+                JSON.stringify({ type: "assistant.message", data: { content: BAKED_BACKLOG_ABORT_TOKEN } }),
+                JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+            ].join("\n") + "\n",
+            exitCode: 0,
+        },
+    ]);
+    await runRalphTui({
+        mode: "grow-project",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+    });
+    assert.equal(events.find((e) => e.type === "armed").label, "autopilot-grow-project");
+});
+
+test("runRalphTui: --prompt emits label with `autopilot-prompt` prefix", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "stub", eventsPath: "/dev/null",
+        write: (ev) => events.push(ev), close: () => {},
+    };
+    const spawn = makeMockSpawn([
+        {
+            stdout: [
+                JSON.stringify({ type: "assistant.message", data: { content: "done COMPLETE" } }),
+                JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+            ].join("\n") + "\n",
+            exitCode: 0,
+        },
+    ]);
+    await runRalphTui({
+        mode: "prompt",
+        contextMode: "fresh",
+        prompt: "do a thing",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+    });
+    assert.equal(events.find((e) => e.type === "armed").label, "autopilot-prompt");
+});
+
+// Issue #49: runOneIteration must honour $AUTOPILOT_COPILOT_BIN as the
+// primary copilot-binary override (with $RALPH_TUI_COPILOT_BIN as a
+// legacy fallback). Pin the default-resolution path against runRalphTui
+// — the args passed to spawn carry the runner's choice as `bin`.
+test("runRalphTui: spawns with $AUTOPILOT_COPILOT_BIN when set", async () => {
+    const sawBin = [];
+    const spawn = function (bin, _args, _opts) {
+        sawBin.push(bin);
+        const handlers = { stdout: [], close: [] };
+        const child = {
+            stdout: { on: (ev, fn) => handlers.stdout.push(fn), pipe: () => {} },
+            stderr: { on: () => {}, pipe: () => {} },
+            on: (ev, fn) => { if (ev === "close") handlers.close.push(fn); },
+            kill: () => {},
+        };
+        setImmediate(() => {
+            for (const fn of handlers.stdout) fn(Buffer.from(JSON.stringify({
+                type: "assistant.message", data: { content: "COMPLETE" },
+            }) + "\n" + JSON.stringify({
+                type: "result", success: true, result: { sessionId: "s" },
+            }) + "\n"));
+            for (const fn of handlers.close) fn(0);
+        });
+        return child;
+    };
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: { ...makeEnv(), AUTOPILOT_COPILOT_BIN: "/usr/local/bin/cop-v2" },
+        spawn,
+    });
+    assert.equal(sawBin[0], "/usr/local/bin/cop-v2");
+});
+
+test("runRalphTui: falls back to $RALPH_TUI_COPILOT_BIN when AUTOPILOT_COPILOT_BIN is unset", async () => {
+    _resetDeprecationFlagsForTest();
+    const stderr = makeFakeStderr();
+    const sawBin = [];
+    const spawn = function (bin) {
+        sawBin.push(bin);
+        const handlers = { stdout: [], close: [] };
+        const child = {
+            stdout: { on: (ev, fn) => handlers.stdout.push(fn), pipe: () => {} },
+            stderr: { on: () => {}, pipe: () => {} },
+            on: (ev, fn) => { if (ev === "close") handlers.close.push(fn); },
+            kill: () => {},
+        };
+        setImmediate(() => {
+            for (const fn of handlers.stdout) fn(Buffer.from(JSON.stringify({
+                type: "assistant.message", data: { content: "COMPLETE" },
+            }) + "\n" + JSON.stringify({
+                type: "result", success: true, result: { sessionId: "s" },
+            }) + "\n"));
+            for (const fn of handlers.close) fn(0);
+        });
+        return child;
+    };
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: { ...makeEnv(), RALPH_TUI_COPILOT_BIN: "/legacy/copilot" },
+        spawn,
+        stderr,
+    });
+    assert.equal(sawBin[0], "/legacy/copilot");
+    assert.ok(
+        stderr.messages.some((m) => m.includes("RALPH_TUI_COPILOT_BIN is deprecated")),
+        "deprecation notice must fire when the legacy env var is the only override",
+    );
 });
 
 test("runRalphTui: stopRun mid-loop ends with terminationReason=stopped", async () => {


### PR DESCRIPTION
## Summary

- Default state-files root now `~/.copilot/autopilot-tui/runs` (kept separate from events root); first-run reads still fall back to `~/.copilot/ralph-tui/runs` gated by a `<NEW_ROOT>/.migrated-from-ralph-tui` sentinel
- `$AUTOPILOT_RUNS_DIR` / `$AUTOPILOT_COPILOT_BIN` are now primary, with `$RALPH_TUI_*` honoured as a deprecated fallback (one-line stderr notice, per-process dedupe)
- BREAKING (per decision E): runId labels flip from `ralph-tui-*` to `autopilot-*`; stderr error prefixes flip from `ralph-tui run:` to `autopilot run:`
- File-header / comments naming `ralph-tui` or `ralph_loop` flip to `autopilot` / `ap_loop`; internal `runRalphTui` symbol stays per the convention

## Test plan

- [x] `npm test` for `packages/tui/test/runner.test.mjs` — 127/127 pass
- [x] `npm run check` clean
- [x] One pre-existing failure in `packages/tui/test/bin.test.mjs` (`bin where: prints default runs root`) is on the base branch and outside this PR's scope

Refs #49.