### PR TITLE
feat(tui)!: prefer AUTOPILOT_EVENTS_DIR + ~/.copilot/autopilot/runs in TUI writer (refs #49)

### DIFF
--- a/packages/tui/src/writer.mjs
+++ b/packages/tui/src/writer.mjs
@@ -1,10 +1,32 @@
-// JSONL event writer for the ralph TUI (issue #22).
+// JSONL event writer for the autopilot TUI (issue #22).
 //
 // The loop handler in extension/handler.mjs imports createEventWriter() and
 // calls writer.emit(ev) at iteration boundaries. The writer keeps a single
 // append-mode file descriptor open per run and maintains a sibling
-// `runs/index.jsonl` so `ralph-tui list` can enumerate past runs without
+// `runs/index.jsonl` so `autopilot list` can enumerate past runs without
 // scanning every per-run directory.
+//
+// Path / env-var resolution (issue #49 rename — Decisions A + B):
+//   - Preferred env var:  AUTOPILOT_EVENTS_DIR.
+//   - Legacy fallback:    RALPH_EVENTS_DIR (still honored, one-line
+//                         stderr deprecation on first read per process).
+//   - Preferred default:  ~/.copilot/autopilot/runs.
+//   - Legacy default:     ~/.copilot/ralph/runs (read-only; honored only
+//                         when the new default does not yet exist on disk
+//                         AND the legacy default does, so an upgrading
+//                         user keeps seeing their past runs without
+//                         data movement). One-line stderr migration
+//                         notice gated by a sentinel file under the new
+//                         root (`<NEW_ROOT>/.migrated-from-ralph`) so the
+//                         notice never reprints once writes have started
+//                         landing on the new path.
+//   - On the first write to the new root, mkdir -p the new root and drop
+//     the sentinel so subsequent reads stay quiet.
+//   - The TUI writer here MUST resolve to the same path the extension's
+//     event emitter resolves to (extension/events-emit.mjs). The two
+//     surfaces share a single contract — same env-var precedence, same
+//     defaults, same legacy fallback — so a single emitted run is
+//     guaranteed to be readable by `autopilot list / stats`.
 //
 // Design constraints:
 //   - Zero runtime deps (Node stdlib only) — the core extension's bundle
@@ -24,33 +46,35 @@ import osDefault from "node:os";
 
 import { MAX_EVENT_LINE_BYTES, makeRunId, serializeEvent } from "./events.mjs";
 
-// Print a one-line stderr deprecation notice the FIRST time a given
-// migration trigger fires, then drop a sentinel line under
-// ~/.copilot/autopilot/ so subsequent runs (in this or any later
-// process) stay silent. Mirror of the helper in
-// extension/events-emit.mjs — the two surfaces resolve from the same
-// sentinel so a single legacy default-path read silences both.
-function emitDeprecationOnce({ key, message, sentinelPath, fs, stderr }) {
-    try {
-        const content = fs.readFileSync(sentinelPath, "utf8");
-        if (content.split("\n").some((l) => l === key)) return;
-    } catch { /* sentinel missing or unreadable */ }
-    try {
-        stderr.write(message);
-        fs.mkdirSync(pathDefault.dirname(sentinelPath), { recursive: true });
-        fs.appendFileSync(sentinelPath, key + "\n");
-    } catch { /* best-effort */ }
+// Sentinel filename for Decision A's path-migration gate. Sits at
+// `<NEW_ROOT>/.migrated-from-ralph` so its presence means "we've
+// already told this user the new default exists, don't reprint".
+const MIGRATION_SENTINEL = ".migrated-from-ralph";
+
+/** Compute the canonical new-default events-root path for a given home. */
+function newDefaultRoot(home, path) {
+    return path.join(home, ".copilot", "autopilot", "runs");
 }
+
+// Process-level dedup for the $RALPH_EVENTS_DIR deprecation notice
+// (Decision B). Purely advisory — no disk sentinel; a second
+// invocation in the same process stays quiet. Tests re-arm via
+// `__test__.resetLegacyEnvNoticeForTests`.
+let legacyEnvNoticePrintedThisProcess = false;
 
 /**
  * Resolve the on-disk root for autopilot TUI run metadata.
  *
  *   $AUTOPILOT_EVENTS_DIR if set (absolute path expected; surfaced verbatim
  *   so users can pin a tmp dir in CI).
- *   else $RALPH_EVENTS_DIR if set (deprecated; one-time stderr notice).
- *   else `${HOME}/.copilot/autopilot/events` (new default).
- *   If new default doesn't exist but `${HOME}/.copilot/ralph/runs` does,
- *   falls back to the old path with a deprecation notice.
+ *   else $RALPH_EVENTS_DIR if set (deprecated; one-line stderr notice the
+ *   first time the fallback fires per process).
+ *   else `${HOME}/.copilot/autopilot/runs` (new default).
+ *   If the new default does not yet exist but `${HOME}/.copilot/ralph/runs`
+ *   does, returns the legacy path AND prints a one-line stderr migration
+ *   notice. The notice is gated by `<NEW_ROOT>/.migrated-from-ralph` so
+ *   it never reprints once the new root has been touched (see
+ *   `dropMigrationSentinel` — fired from createEventWriter on first write).
  */
 export function resolveRunsRoot({
     env = process.env,
@@ -61,27 +85,27 @@ export function resolveRunsRoot({
     sentinelPath: sentinelPathArg,
 } = {}) {
     const home = os.homedir();
-    const sentinelPath = sentinelPathArg ?? path.join(home, ".copilot", "autopilot", ".migration-notice-shown");
 
     // Primary: $AUTOPILOT_EVENTS_DIR
     const newOverride = env.AUTOPILOT_EVENTS_DIR;
     if (typeof newOverride === "string" && newOverride.length > 0) return newOverride;
 
-    // Legacy fallback: $RALPH_EVENTS_DIR (deprecated)
+    // Legacy fallback: $RALPH_EVENTS_DIR (deprecated; process-deduped notice)
     const legacyOverride = env.RALPH_EVENTS_DIR;
     if (typeof legacyOverride === "string" && legacyOverride.length > 0) {
-        emitDeprecationOnce({
-            key: "env:RALPH_EVENTS_DIR",
-            message: "[autopilot] note: env $RALPH_EVENTS_DIR is deprecated, please use $AUTOPILOT_EVENTS_DIR (still honored)\n",
-            sentinelPath,
-            fs,
-            stderr,
-        });
+        if (!legacyEnvNoticePrintedThisProcess) {
+            legacyEnvNoticePrintedThisProcess = true;
+            try {
+                stderr.write(
+                    "tui-writer: $RALPH_EVENTS_DIR is deprecated; please set $AUTOPILOT_EVENTS_DIR (still honored)\n",
+                );
+            } catch { /* swallow — advisory only */ }
+        }
         return legacyOverride;
     }
 
     // Default paths
-    const newDefault = path.join(home, ".copilot", "autopilot", "events");
+    const newDefault = newDefaultRoot(home, path);
     const oldDefault = path.join(home, ".copilot", "ralph", "runs");
 
     let newExists = false;
@@ -90,17 +114,34 @@ export function resolveRunsRoot({
     try { oldExists = fs.existsSync(oldDefault); } catch { /* swallow */ }
 
     if (!newExists && oldExists) {
-        emitDeprecationOnce({
-            key: `path:${oldDefault}`,
-            message: `[autopilot] note: reading from legacy ~/.copilot/ralph/runs (default is now ~/.copilot/autopilot/events)\n`,
-            sentinelPath,
-            fs,
-            stderr,
-        });
+        const sentinelPath = sentinelPathArg ?? path.join(newDefault, MIGRATION_SENTINEL);
+        let sentinelExists = false;
+        try { sentinelExists = fs.existsSync(sentinelPath); } catch { /* swallow */ }
+        if (!sentinelExists) {
+            try {
+                stderr.write(
+                    "tui-writer: reading runs from legacy ~/.copilot/ralph/runs; "
+                    + "will migrate writes to ~/.copilot/autopilot/runs on next emit\n",
+                );
+            } catch { /* swallow — advisory only */ }
+        }
         return oldDefault;
     }
 
     return newDefault;
+}
+
+// Best-effort sentinel drop on first write to the new root. Failures
+// are swallowed: losing the sentinel just means a re-print of the
+// migration notice on the next process — annoying, not broken.
+// `appendFileSync` with empty content is idempotent (creates the
+// file if missing, leaves it untouched if already present), so no
+// pre-check is needed.
+function dropMigrationSentinel({ root, fs, path }) {
+    try {
+        fs.mkdirSync(root, { recursive: true });
+        fs.appendFileSync(path.join(root, MIGRATION_SENTINEL), "");
+    } catch { /* swallow */ }
 }
 
 /**
@@ -229,16 +270,16 @@ export function createEventWriter({
     if (typeof runId !== "string" || !runId) {
         throw new TypeError("createEventWriter: runId must be a non-empty string");
     }
-    // Defensive symmetry with `resolveRunEventsPath` (line 47) and
-    // `pruneRuns` (line 361): production runIds come from `makeRunId`
-    // and only contain `[A-Za-z0-9_-]`, but createEventWriter is the
-    // primary write surface — letting a runId with `..` or `/` through
-    // here would let a future caller (or hostile test fixture) escape
-    // the runs sandbox via `path.join(root, runId, …)`. Guarding here
-    // keeps the read + write + delete paths in lockstep.
+    // Defensive symmetry with `resolveRunEventsPath` and `pruneRuns`:
+    // production runIds come from `makeRunId` and only contain
+    // `[A-Za-z0-9_-]`, but createEventWriter is the primary write
+    // surface — letting a runId with `..` or `/` through here would let
+    // a future caller (or hostile test fixture) escape the runs
+    // sandbox via `path.join(root, runId, …)`. Guarding here keeps the
+    // read + write + delete paths in lockstep.
     assertSafeRunId("createEventWriter", runId);
 
-    const root = resolveRunsRoot({ env, os, path });
+    const root = resolveRunsRoot({ env, os, path, fs });
     const runDir = path.join(root, runId);
     const eventsPath = path.join(runDir, "events.jsonl");
     const indexPath = path.join(root, "index.jsonl");
@@ -255,6 +296,15 @@ export function createEventWriter({
         onError(err);
     }
 
+    // Drop the migration sentinel on the first write to the new
+    // default root so subsequent resolveRunsRoot calls (this or any
+    // future process) stay quiet. We only do this when `root` IS the
+    // canonical new default — env-pinned or legacy paths have no
+    // semantic sentinel.
+    if (root === newDefaultRoot(os.homedir(), path)) {
+        dropMigrationSentinel({ root, fs, path });
+    }
+
     const writeLine = (line) => {
         if (closed) return;
         try {
@@ -265,7 +315,7 @@ export function createEventWriter({
     };
 
     const recordIndex = (ev) => {
-        // index.jsonl carries one line per `armed` event so `ralph-tui list`
+        // index.jsonl carries one line per `armed` event so `autopilot list`
         // can enumerate runs in reverse-chronological order without
         // recursing into every run dir. Replays do NOT add a row — only the
         // initial arm marks a run's existence.
@@ -335,12 +385,12 @@ export function createEventWriter({
 /**
  * Read the run index (created lazily by createEventWriter on first
  * `armed` event) and return the parsed entries newest-first. Used by
- * `ralph-tui list` and tests.
+ * `autopilot list` and tests.
  *
  * Missing index file → empty list (a fresh machine with no past runs).
  */
 export function readRunIndex({ fs = fsDefault, path = pathDefault, os = osDefault, env = process.env } = {}) {
-    const indexPath = path.join(resolveRunsRoot({ env, os, path }), "index.jsonl");
+    const indexPath = path.join(resolveRunsRoot({ env, os, path, fs }), "index.jsonl");
     let raw;
     try {
         raw = fs.readFileSync(indexPath, "utf8");
@@ -361,8 +411,13 @@ export { makeRunId };
 // iterator. Not part of the public surface (no `export` on the
 // declaration above) so consumers cannot couple to it; the
 // `__test__` bag is the project-wide convention for "tests can
-// reach in but library users should not".
-export const __test__ = { iterJsonlRows };
+// reach in but library users should not". Also exposes a
+// reset hook for the process-deduped legacy-env-var notice so
+// the test suite can re-arm it between cases.
+export const __test__ = {
+    iterJsonlRows,
+    resetLegacyEnvNoticeForTests() { legacyEnvNoticePrintedThisProcess = false; },
+};
 
 /**
  * Aggregate stats across all recorded runs. Returns:
@@ -379,7 +434,7 @@ export function aggregateRuns({
     env = process.env,
 } = {}) {
     const entries = readRunIndex({ fs, path, os, env });
-    const root = resolveRunsRoot({ env, os, path });
+    const root = resolveRunsRoot({ env, os, path, fs });
     const byTool = {};
     const byReason = {};
     const iterCounts = [];
@@ -397,7 +452,7 @@ export function aggregateRuns({
             // a huge numeric literal (e.g. `1e500`) parses as Infinity in
             // JS — without `Number.isFinite` it would propagate to
             // `iters.max = Infinity` and `iters.mean = NaN`/Infinity,
-            // silently breaking `ralph-tui stats`. The writer never emits
+            // silently breaking `autopilot stats`. The writer never emits
             // Infinity (JSON.stringify(Infinity) = "null"), so this only
             // bites for hand-edited rows; treat them like the other
             // malformed cases above and skip the iteration value.
@@ -416,7 +471,7 @@ export function aggregateRuns({
     // throws "Maximum call stack size exceeded" once iterCounts grows
     // past ~150k entries (Node's argument-count limit). A long-lived
     // user with daily self_improve runs would eventually hit that
-    // ceiling and `ralph-tui stats` would silently crash. Reduce
+    // ceiling and `autopilot stats` would silently crash. Reduce
     // handles arbitrary array sizes in O(n) without the spread.
     const max = iterCounts.length
         ? iterCounts.reduce((a, b) => (a > b ? a : b), 0)
@@ -469,7 +524,7 @@ export function pruneRuns({
     if (typeof olderThanMs !== "number" || !Number.isFinite(olderThanMs) || olderThanMs < 0) {
         throw new TypeError("pruneRuns: olderThanMs must be a non-negative number");
     }
-    const root = resolveRunsRoot({ env, os, path });
+    const root = resolveRunsRoot({ env, os, path, fs });
     const indexPath = path.join(root, "index.jsonl");
     const cutoff = now() - olderThanMs;
     const removed = [];

--- a/packages/tui/test/writer.test.mjs
+++ b/packages/tui/test/writer.test.mjs
@@ -11,11 +11,12 @@ import {
     resolveRunsRoot,
     aggregateRuns,
     pruneRuns,
+    __test__ as writerInternals,
 } from "../src/writer.mjs";
 import { makeRunId } from "../src/events.mjs";
 
 function mkTmp() {
-    return fs.mkdtempSync(path.join(os.tmpdir(), "ralph-tui-writer-"));
+    return fs.mkdtempSync(path.join(os.tmpdir(), "autopilot-tui-writer-"));
 }
 
 function readLines(filePath) {
@@ -26,31 +27,32 @@ function readLines(filePath) {
         .map((l) => JSON.parse(l));
 }
 
-// Stage 3 (issue #49): writer.mjs's resolveRunsRoot now performs
-// sentinel-gated stderr deprecation notices when legacy
-// $AUTOPILOT_EVENTS_DIR or the legacy ~/.copilot/ralph/runs default
-// path is used. Tests inject a fake fs (which has no sentinel and
-// accepts mkdir/append silently) and a fake stderr (capturing
-// writes into an array). The sentinelPath points at a fake
-// location so deprecation writes never touch the real ~/.copilot.
-function makeFakeFs({ sentinel = "", existingPaths = new Set() } = {}) {
-    let written = "";
-    const fake = {
-        readFileSync: (p) => {
-            if (p === fake._sentinelPath) return sentinel + written;
-            const e = new Error("ENOENT");
-            e.code = "ENOENT";
-            throw e;
-        },
-        appendFileSync: (p, data) => {
-            if (p === fake._sentinelPath) written += data;
-        },
-        mkdirSync: () => {},
-        existsSync: (p) => existingPaths.has(p),
+// Issue #49 — Decisions A + B for the events-root resolver:
+//
+//  * Decision A (paths). New default `~/.copilot/autopilot/runs`. If
+//    the new default does not yet exist but the legacy
+//    `~/.copilot/ralph/runs` does, we read from the legacy path AND
+//    print a one-line stderr migration notice gated by a sentinel
+//    file under the new root (`<NEW_ROOT>/.migrated-from-ralph`). On
+//    the first write to the new root we mkdir -p it and drop the
+//    sentinel so subsequent processes stay quiet.
+//
+//  * Decision B (env vars). Prefer `AUTOPILOT_EVENTS_DIR`; fall back
+//    to legacy `RALPH_EVENTS_DIR` with a one-line stderr
+//    deprecation, deduped per-process (in-memory, not on disk —
+//    advisory only).
+//
+// Tests inject a fake fs (no real disk touched), a fake stderr
+// (writes captured into an array), and where appropriate an explicit
+// sentinelPath so resolution never reaches a real ~/.copilot.
+function makeFakeFs({ existingPaths = new Set() } = {}) {
+    const paths = new Set(existingPaths);
+    return {
+        appendFileSync: (p) => { paths.add(p); },
+        mkdirSync: (p) => { paths.add(p); },
+        existsSync: (p) => paths.has(p),
+        _addPath: (p) => { paths.add(p); },
     };
-    fake._sentinelPath = "/fake/sentinel";
-    fake.writtenSentinel = () => written;
-    return fake;
 }
 
 function makeFakeStderr() {
@@ -61,88 +63,136 @@ function makeFakeStderr() {
     };
 }
 
+// Re-arm the process-deduped legacy-env-var notice between tests so
+// resolution-order doesn't bleed state from one case to another. The
+// path-fallback notice is sentinel-gated (per fake fs), not
+// process-deduped, so it doesn't need this hook.
+function resetEnvNotice() {
+    writerInternals.resetLegacyEnvNoticeForTests();
+}
+
 test("resolveRunsRoot honours $AUTOPILOT_EVENTS_DIR (primary)", () => {
+    resetEnvNotice();
     assert.equal(resolveRunsRoot({ env: { AUTOPILOT_EVENTS_DIR: "/tmp/x" } }), "/tmp/x");
 });
 
 test("resolveRunsRoot honours $RALPH_EVENTS_DIR (legacy, with notice)", () => {
-    const fs = makeFakeFs();
+    resetEnvNotice();
+    const fakeFs = makeFakeFs();
     const stderr = makeFakeStderr();
     assert.equal(
-        resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/tmp/x" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/tmp/x" }, fs: fakeFs, stderr }),
         "/tmp/x",
     );
     assert.equal(stderr.messages.length, 1);
     assert.match(stderr.messages[0], /RALPH_EVENTS_DIR is deprecated/);
 });
 
-test("resolveRunsRoot defaults to $HOME/.copilot/autopilot/events", () => {
+test("resolveRunsRoot defaults to $HOME/.copilot/autopilot/runs", () => {
+    resetEnvNotice();
     const fakeOs = { homedir: () => "/h" };
-    const fs = makeFakeFs();
+    const fakeFs = makeFakeFs();
     const stderr = makeFakeStderr();
     assert.equal(
-        resolveRunsRoot({ env: {}, os: fakeOs, fs, stderr, sentinelPath: "/fake/sentinel" }),
-        "/h/.copilot/autopilot/events",
+        resolveRunsRoot({ env: {}, os: fakeOs, fs: fakeFs, stderr }),
+        "/h/.copilot/autopilot/runs",
     );
     assert.equal(stderr.messages.length, 0);
 });
 
 test("resolveRunsRoot: AUTOPILOT primary wins over RALPH legacy (no notice)", () => {
-    const fs = makeFakeFs();
+    resetEnvNotice();
+    const fakeFs = makeFakeFs();
     const stderr = makeFakeStderr();
     assert.equal(
         resolveRunsRoot({
             env: { AUTOPILOT_EVENTS_DIR: "/ap", RALPH_EVENTS_DIR: "/legacy" },
-            fs, stderr, sentinelPath: "/fake/sentinel",
+            fs: fakeFs, stderr,
         }),
         "/ap",
     );
     assert.equal(stderr.messages.length, 0);
 });
 
-test("resolveRunsRoot: legacy default path is honoured with deprecation notice", () => {
+test("resolveRunsRoot: read-from-legacy default emits sentinel-gated migration notice", () => {
+    resetEnvNotice();
     const fakeOs = { homedir: () => "/h" };
     const legacyDefault = "/h/.copilot/ralph/runs";
-    const fs = makeFakeFs({ existingPaths: new Set([legacyDefault]) });
+    const fakeFs = makeFakeFs({ existingPaths: new Set([legacyDefault]) });
     const stderr = makeFakeStderr();
     assert.equal(
-        resolveRunsRoot({ env: {}, os: fakeOs, fs, stderr, sentinelPath: "/fake/sentinel" }),
+        resolveRunsRoot({ env: {}, os: fakeOs, fs: fakeFs, stderr }),
         legacyDefault,
     );
     assert.equal(stderr.messages.length, 1);
-    assert.match(stderr.messages[0], /reading from legacy/);
+    assert.match(stderr.messages[0], /reading runs from legacy ~\/\.copilot\/ralph\/runs/);
+    assert.match(stderr.messages[0], /will migrate writes to ~\/\.copilot\/autopilot\/runs on next emit/);
 });
 
 test("resolveRunsRoot: when both default paths exist, primary wins (no notice)", () => {
+    resetEnvNotice();
     const fakeOs = { homedir: () => "/h" };
-    const fs = makeFakeFs({ existingPaths: new Set(["/h/.copilot/autopilot/events", "/h/.copilot/ralph/runs"]) });
+    const fakeFs = makeFakeFs({
+        existingPaths: new Set(["/h/.copilot/autopilot/runs", "/h/.copilot/ralph/runs"]),
+    });
     const stderr = makeFakeStderr();
     assert.equal(
-        resolveRunsRoot({ env: {}, os: fakeOs, fs, stderr, sentinelPath: "/fake/sentinel" }),
-        "/h/.copilot/autopilot/events",
+        resolveRunsRoot({ env: {}, os: fakeOs, fs: fakeFs, stderr }),
+        "/h/.copilot/autopilot/runs",
     );
     assert.equal(stderr.messages.length, 0);
 });
 
-test("resolveRunsRoot: deprecation notice is one-shot per process (sentinel-gated)", () => {
-    const fs = makeFakeFs();
+test("resolveRunsRoot: legacy env-var notice is one-shot per process (in-memory dedup)", () => {
+    resetEnvNotice();
+    const fakeFs = makeFakeFs();
     const stderr = makeFakeStderr();
-    const sentinelPath = "/fake/sentinel";
-    resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/x" }, fs, stderr, sentinelPath });
-    resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/x" }, fs, stderr, sentinelPath });
-    resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/x" }, fs, stderr, sentinelPath });
-    assert.equal(stderr.messages.length, 1);
-    assert.match(fs.writtenSentinel(), /RALPH_EVENTS_DIR/);
+    resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/x" }, fs: fakeFs, stderr });
+    resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/x" }, fs: fakeFs, stderr });
+    resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/x" }, fs: fakeFs, stderr });
+    assert.equal(stderr.messages.length, 1, "process-level dedup: only one notice");
 });
 
-test("resolveRunsRoot: pre-existing sentinel suppresses the notice", () => {
-    const fs = makeFakeFs({ sentinel: "env:RALPH_EVENTS_DIR\n" });
+test("resolveRunsRoot: path-fallback migration notice does NOT reprint when sentinel exists", () => {
+    resetEnvNotice();
+    // Sentinel-gated: a pre-existing `<NEW_ROOT>/.migrated-from-ralph`
+    // file means a prior process already announced the migration;
+    // the notice must stay quiet on subsequent runs even when we
+    // still resolve to the legacy path. The fake fs treats path
+    // strings independently so the sentinel can register as
+    // existing without the surrounding directory.
+    const fakeOs = { homedir: () => "/h" };
+    const legacyDefault = "/h/.copilot/ralph/runs";
+    const sentinelPath = "/h/.copilot/autopilot/runs/.migrated-from-ralph";
+    const fakeFs = makeFakeFs({ existingPaths: new Set([legacyDefault, sentinelPath]) });
     const stderr = makeFakeStderr();
     assert.equal(
-        resolveRunsRoot({ env: { RALPH_EVENTS_DIR: "/tmp/x" }, fs, stderr, sentinelPath: "/fake/sentinel" }),
-        "/tmp/x",
+        resolveRunsRoot({ env: {}, os: fakeOs, fs: fakeFs, stderr }),
+        legacyDefault,
     );
-    assert.equal(stderr.messages.length, 0);
+    assert.equal(stderr.messages.length, 0,
+        "sentinel under the new root must suppress the migration notice");
+});
+
+test("resolveRunsRoot: path-fallback notice prints once across multiple calls (sentinel created on first write)", () => {
+    resetEnvNotice();
+    // Simulate the lifecycle: first resolution prints the notice.
+    // Then the writer's first emit drops the sentinel under the new
+    // root — we model that by adding the sentinel path to the fake
+    // fs's existingPaths between the two calls. The second
+    // resolution must stay silent.
+    const fakeOs = { homedir: () => "/h" };
+    const legacyDefault = "/h/.copilot/ralph/runs";
+    const sentinelPath = "/h/.copilot/autopilot/runs/.migrated-from-ralph";
+    const fakeFs = makeFakeFs({ existingPaths: new Set([legacyDefault]) });
+    const stderr = makeFakeStderr();
+    resolveRunsRoot({ env: {}, os: fakeOs, fs: fakeFs, stderr });
+    assert.equal(stderr.messages.length, 1, "first resolution prints the notice");
+    // Simulate the writer's first-emit sentinel-drop.
+    fakeFs._addPath(sentinelPath);
+    resolveRunsRoot({ env: {}, os: fakeOs, fs: fakeFs, stderr });
+    assert.equal(stderr.messages.length, 1,
+        "second resolution must NOT reprint once sentinel is on disk");
 });
 
 test("resolveRunEventsPath joins runId under the runs root", () => {
@@ -286,6 +336,46 @@ test("createEventWriter: armed getter flips after first armed emit", () => {
     assert.equal(w.armed, false);
     w.emit({ type: "armed" });
     assert.equal(w.armed, true);
+});
+
+test("createEventWriter: drops `.migrated-from-ralph` sentinel on first write to the new default root", () => {
+    // Issue #49 lifecycle: when the writer's resolved root is the new
+    // default `~/.copilot/autopilot/runs`, the very first
+    // createEventWriter() call must mkdir -p that root and touch
+    // `<NEW_ROOT>/.migrated-from-ralph` so any later resolveRunsRoot
+    // call (in this or any future process) reading from a still-
+    // populated legacy `~/.copilot/ralph/runs` does NOT reprint the
+    // migration notice. We pin the home dir to a temp scratch
+    // directory so the test never touches the real ~/.copilot.
+    const fakeHome = mkTmp();
+    const newRoot = path.join(fakeHome, ".copilot", "autopilot", "runs");
+    const sentinelPath = path.join(newRoot, ".migrated-from-ralph");
+    const fakeOs = { homedir: () => fakeHome };
+    // env is empty so resolveRunsRoot picks the default new root.
+    createEventWriter({
+        runId: "ralph_loop-1",
+        env: {},
+        os: fakeOs,
+    });
+    assert.equal(fs.existsSync(newRoot), true, "new root must be mkdir -p'd");
+    assert.equal(fs.existsSync(sentinelPath), true,
+        "sentinel `.migrated-from-ralph` must exist after first writer construction");
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+});
+
+test("createEventWriter: does NOT drop the sentinel when resolving to a non-default root", () => {
+    // When AUTOPILOT_EVENTS_DIR pins a tmp dir (e.g. CI), the writer
+    // is NOT writing to the default new root, so dropping a
+    // sentinel there would be wrong (it has no semantic meaning
+    // outside the canonical migration target). Verify that the
+    // sentinel does NOT appear under an env-pinned root.
+    const root = mkTmp();
+    createEventWriter({
+        runId: "r-no-sentinel",
+        env: { AUTOPILOT_EVENTS_DIR: root },
+    });
+    assert.equal(fs.existsSync(path.join(root, ".migrated-from-ralph")), false,
+        "no sentinel under env-pinned root — it isn't the canonical new default");
 });
 
 test("readRunIndex: empty when index.jsonl is missing", () => {
@@ -783,8 +873,6 @@ test("pruneRuns: hand-edited ts=-Infinity row does NOT prematurely delete the ru
     assert.equal(result.removed.length, 0, "ts=-Infinity row must NOT be marked for removal — finite-ts guard");
     assert.equal(fs.existsSync(liveRunDir), true, "the legitimate run dir must survive a corrupted-ts row in the index");
 });
-
-import { __test__ as writerInternals } from "../src/writer.mjs";
 
 test("iterJsonlRows: empty / non-string / null / undefined input yields nothing (defensive)", () => {
     // Iter 166 — the helper centralises the JSONL row iteration


### PR DESCRIPTION
## Summary

Aligns the TUI writer's events-root resolver with the Decision A/B
contract pinned by issue #49 — single canonical default
(`~/.copilot/autopilot/runs`), single canonical env var
(`AUTOPILOT_EVENTS_DIR`), with well-defined fallback shims for the
existing legacy surfaces (`~/.copilot/ralph/runs` /
`RALPH_EVENTS_DIR`).

- New default events-root: `~/.copilot/autopilot/runs`. Sentinel-gated
  one-line stderr migration notice (`tui-writer: reading runs from
  legacy ~/.copilot/ralph/runs; will migrate writes to
  ~/.copilot/autopilot/runs on next emit`) when the new root is empty
  but the legacy one exists. Sentinel sits at
  `<NEW_ROOT>/.migrated-from-ralph` and is dropped by
  `createEventWriter` on the first write to the canonical new root, so
  a subsequent process stays silent even if the legacy root still
  holds past runs.
- `AUTOPILOT_EVENTS_DIR` is the preferred env var; `RALPH_EVENTS_DIR`
  is still honored as a fallback with a one-line per-process stderr
  deprecation (Decision B, in-memory dedup).
- Header doc + every internal comment that named
  `~/.copilot/ralph/runs`, `RALPH_EVENTS_DIR`, or `ralph-tui
  list/stats` updated to the new tokens. Legacy references kept only
  where they describe the fallback shim.

## Test plan

- [x] `npm test` — 924 pass, 1 pre-existing failure unrelated to this
  PR (`bin where: prints default runs root` in
  `packages/tui/test/bin.test.mjs`, already failing on the base
  `feat/rename-autopilot` branch before this slice).
- [x] `npm run check` clean.
- [x] New unit-test coverage:
  - default path resolves to `~/.copilot/autopilot/runs`,
  - `AUTOPILOT_EVENTS_DIR` override,
  - `RALPH_EVENTS_DIR` deprecation-fallback (notice once per process),
  - read-from-legacy when new root absent (notice fires once, gated
    by sentinel),
  - lifecycle: notice → simulated sentinel-drop → second resolve
    silent,
  - `createEventWriter` drops `.migrated-from-ralph` on first write
    to the canonical new root,
  - `createEventWriter` does NOT drop a sentinel under env-pinned
    roots.

Refs #49.