### PR TITLE
feat(tui)!: rebrand TUI banner / help / components to autopilot (refs #49)

### DIFF
--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -12,28 +12,28 @@ to *watch* a loop run.
 ## Subcommands
 
 ```text
-ralph-tui list [--json] [--limit N]  Show recorded runs (newest first).
+autopilot list [--json] [--limit N]  Show recorded runs (newest first).
                                      `--json` emits the index as a JSON
                                      array for scripting/dashboards;
                                      `--limit N` caps the table.
-ralph-tui replay <runId>             Print every event in a past run.
-ralph-tui watch [runId] [--plain]    Tail the given run (or the most
+autopilot replay <runId>             Print every event in a past run.
+autopilot watch [runId] [--plain]    Tail the given run (or the most
                                      recent one if omitted) in real time.
-ralph-tui doctor                     Diagnose the runs directory + writer
+autopilot doctor                     Diagnose the runs directory + writer
                                      wiring (permissions, malformed
                                      JSONL, stale lockfiles, broken
                                      symlinks).
-ralph-tui prune [--older-than D]     Remove runs older than DURATION
+autopilot prune [--older-than D]     Remove runs older than DURATION
         [--dry-run]                  (e.g. 30d / 12h / 5m; default 30d).
                                      `--dry-run` lists what would go
                                      without touching the filesystem.
-ralph-tui stats                      Aggregate stats across the run
+autopilot stats                      Aggregate stats across the run
                                      index (run count, total iterations,
                                      p50/p95 durations, top SDLC tools).
-ralph-tui where                      Print the resolved runs root path
+autopilot where                      Print the resolved runs root path
                                      so a contributor can `cd` into it.
-ralph-tui --help     | -h            Show usage.
-ralph-tui --version  | -V            Print the ralph-tui package version.
+autopilot --help     | -h            Show usage.
+autopilot --version  | -V            Print the autopilot package version.
 ```
 
 `--plain` is **auto-enabled when stdout is not a TTY** so CI logs and

--- a/packages/tui/bin/tui.mjs
+++ b/packages/tui/bin/tui.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Stdlib-only CLI entry for the ralph TUI (issue #22).
+// Stdlib-only CLI entry for autopilot (issue #22).
 //
 // Subcommands (keep in sync with the USAGE constant below — pinned by
 // `tui.mjs header comment lists every USAGE subcommand` in
@@ -21,7 +21,7 @@
 //                                durations, top SDLC tools).
 //   where                      — print the resolved runs root path so
 //                                a contributor can `cd` into it.
-//   run                        — drive a ralph_loop / self_improve /
+//   run                        — drive an ap_loop / self_improve /
 //                                grow_project loop OUT-OF-SESSION by
 //                                spawning each iter as a fresh
 //                                `copilot -p ...` subprocess. Choose
@@ -54,25 +54,25 @@ import { readEventsFile, tailEventsFile } from "../src/tail.mjs";
 import { formatEventLine } from "../src/plain.mjs";
 
 const USAGE = `\
-ralph-tui — terminal visualizer for ralph_loop runs (issue #22).
+autopilot — terminal visualizer for ap_loop runs (issue #22).
 
 USAGE
-  ralph-tui list [--json] [--limit N]
-  ralph-tui replay <runId>
-  ralph-tui watch [runId] [--plain]
-  ralph-tui doctor
-  ralph-tui prune [--older-than 30d] [--dry-run]
-  ralph-tui stats
-  ralph-tui where
-  ralph-tui run (--self-improve | --grow-project | --prompt TEXT)
+  autopilot list [--json] [--limit N]
+  autopilot replay <runId>
+  autopilot watch [runId] [--plain]
+  autopilot doctor
+  autopilot prune [--older-than 30d] [--dry-run]
+  autopilot stats
+  autopilot where
+  autopilot run (--self-improve | --grow-project | --prompt TEXT)
                 (--continue | --fresh)
                 [--max N] [--focus TEXT] [--headless | --plain]
                 [--completion-promise TOKEN] [--abort-promise TOKEN]
-  ralph-tui run --pause <runId>
-  ralph-tui run --resume <runId>
-  ralph-tui run --stop <runId>
-  ralph-tui run --status <runId>
-  ralph-tui --help | -h
+  autopilot run --pause <runId>
+  autopilot run --resume <runId>
+  autopilot run --stop <runId>
+  autopilot run --status <runId>
+  autopilot --help | -h
 
 OPTIONS
   --plain     Emit log lines instead of an interactive UI (auto-enabled
@@ -86,7 +86,7 @@ OPTIONS
   --dry-run   For \`prune\`: list what would be removed; delete nothing.
   --self-improve  For \`run\`: drive the baked self_improve SDLC prompt.
   --grow-project  For \`run\`: drive the baked grow_project SDLC prompt.
-  --prompt TEXT   For \`run\`: drive a ralph_loop-style custom prompt.
+  --prompt TEXT   For \`run\`: drive an ap_loop-style custom prompt.
   --continue  For \`run\`: every iter resumes the same Copilot session
               (in-extension parity; context grows monotonically).
   --fresh     For \`run\`: every iter starts a brand-new Copilot session
@@ -103,17 +103,21 @@ OPTIONS
               an early abort. Defaults to the baked abort token of the
               chosen prompt mode (or none for --prompt).
   --help, -h  Show this help.
-  --version, -V  Print the ralph-tui package version and exit.
+  --version, -V  Print the autopilot package version and exit.
 
 ENV
   AUTOPILOT_EVENTS_DIR  Override the runs root (default ~/.copilot/autopilot/events).
-                    Legacy: RALPH_EVENTS_DIR still honored (deprecated).
-  AUTOPILOT_RUNS_DIR  Override the run-state root used by
-                    \`ralph-tui run\` (default ~/.copilot/autopilot/runs).
-                    Legacy: RALPH_TUI_RUNS_DIR still honored (deprecated).
-  AUTOPILOT_COPILOT_BIN  Override the \`copilot\` executable used by
-                    \`ralph-tui run\` (default \`copilot\` on $PATH).
-                    Legacy: RALPH_TUI_COPILOT_BIN still honored (deprecated).
+  AUTOPILOT_RUNS_DIR    Override the run-state root used by
+                        \`autopilot run\` (default ~/.copilot/autopilot/runs).
+  AUTOPILOT_COPILOT_BIN Override the \`copilot\` executable used by
+                        \`autopilot run\` (default \`copilot\` on $PATH).
+  AUTOPILOT_NO_ATTRIBUTION  Suppress the auto-appended attribution
+                        trailer on commits the loop authors.
+  AUTOPILOT_CAFFEINATE  Keep the host awake while \`autopilot run\` is
+                        active (macOS \`caffeinate\` integration).
+  AUTOPILOT_CAFFEINATE_SCOPE  Scope of the caffeinate guard
+                        (e.g. \`display\` or \`system\`).
+  Legacy RALPH_* names are still read for one release with a one-line stderr deprecation notice.
 `;
 
 /** Minimal argv parser. Returns { cmd, positional[], flags{} }.
@@ -124,10 +128,10 @@ ENV
  *  --completion-promise, --abort-promise, --pause, --resume, --stop,
  *  --status). When adding a new value flag, append it to
  *  `VALUE_FLAGS` AND update the USAGE block above so
- *  `ralph-tui --help` keeps matching the parser. */
+ *  `autopilot --help` keeps matching the parser. */
 const VALUE_FLAGS = new Set(["older-than", "limit", "max", "focus", "prompt", "completion-promise", "abort-promise", "pause", "resume", "stop", "status"]);
 
-/** Default `--max` iterations per loop mode for `ralph-tui run`.
+/** Default `--max` iterations per loop mode for `autopilot run`.
  *
  *  `self-improve` has no fixed scope: the agent's job is to drain the
  *  entire backlog (failing CI runs, stale PRs, open issues, latent
@@ -261,7 +265,7 @@ export function installStdinAbortListener(onAbort) {
 }
 
 function fail(msg, code = 2) {
-    process.stderr.write(`ralph-tui: ${msg}\n`);
+    process.stderr.write(`autopilot: ${msg}\n`);
     process.exit(code);
 }
 
@@ -271,7 +275,7 @@ function fail(msg, code = 2) {
  *  handler already prints its own line — printing twice would just
  *  be noise.
  *
- *  Field bug from a real run: pressing `q` in `ralph-tui run` left
+ *  Field bug from a real run: pressing `q` in `autopilot run` left
  *  the static last Ink frame on screen with no further output, since
  *  the runner only checks `stopRequested` between iters and won't
  *  kill the in-flight copilot subprocess. Users perceived this as
@@ -293,7 +297,7 @@ export function formatAbortMessage(reason) {
     // installed in cmdRun — don't double up.
     if (reason === "signal_SIGINT") return null;
     const label = reason === "user_quit" ? "q" : reason;
-    return `\nralph-tui run: ${label} received — finishing current iteration, then stopping. Hit Ctrl-C to abort hard.\n`;
+    return `\nautopilot run: ${label} received — finishing current iteration, then stopping. Hit Ctrl-C to abort hard.\n`;
 }
 
 function cmdList(opts = {}) {
@@ -320,7 +324,7 @@ function cmdList(opts = {}) {
     if (!entries.length) {
         process.stdout.write(
             `No runs found.\nRoot: ${resolveRunsRoot()}\n`
-            + `Arm a ralph_loop / self_improve / grow_project run, then re-run \`ralph-tui list\`.\n`,
+            + `Arm an ap_loop / self_improve / grow_project run, then re-run \`autopilot list\`.\n`,
         );
         return 0;
     }
@@ -357,7 +361,7 @@ function safeResolveEventsPath(label, runId) {
 
 export function cmdReplay(runId) {
     if (!runId) {
-        fail("replay: <runId> is required (try `ralph-tui list` first)");
+        fail("replay: <runId> is required (try `autopilot list` first)");
         return 2;
     }
     const path = safeResolveEventsPath("replay", runId);
@@ -463,7 +467,7 @@ export function cmdDoctor() {
     process.stdout.write(lines.join("\n") + "\n");
     if (!healthy) {
         process.stderr.write(
-            `ralph-tui doctor: critical problem detected (root=${root}). `
+            `autopilot doctor: critical problem detected (root=${root}). `
             + `Check filesystem permissions and AUTOPILOT_EVENTS_DIR.\n`,
         );
         return 1;
@@ -532,7 +536,7 @@ export function cmdWhere() {
     return 0;
 }
 
-// `ralph-tui run` dispatcher. Splits into:
+// `autopilot run` dispatcher. Splits into:
 //   sibling sub-commands: --pause / --resume / --stop / --status <runId>
 //                         (mutate or read state.json of an existing run)
 //   driver:               --self-improve / --grow-project / --prompt
@@ -540,7 +544,7 @@ export function cmdWhere() {
 //                          process, with SIGINT/SIGTERM mapped to a
 //                          graceful stop request)
 export async function cmdRun(flags) {
-    // Lazy-imported so a `ralph-tui list` invocation doesn't pay the
+    // Lazy-imported so an `autopilot list` invocation doesn't pay the
     // child_process / runner-module init cost.
     const runner = await import("../src/runner.mjs");
 
@@ -551,7 +555,7 @@ export async function cmdRun(flags) {
     if (sibling) {
         const runId = flags[sibling];
         if (!runId || runId === true) {
-            fail(`run --${sibling}: <runId> is required (e.g. --${sibling} ralph-tui-self-improve-1700000000000)`);
+            fail(`run --${sibling}: <runId> is required (e.g. --${sibling} autopilot-self-improve-1700000000000)`);
             return 2;
         }
         try {
@@ -633,11 +637,11 @@ export async function cmdRun(flags) {
     const installSignal = (sig) => {
         const handler = () => {
             if (stopOnce) {
-                process.stderr.write(`\nralph-tui run: second ${sig} — aborting hard.\n`);
+                process.stderr.write(`\nautopilot run: second ${sig} — aborting hard.\n`);
                 process.exit(130);
             }
             stopOnce = true;
-            process.stderr.write(`\nralph-tui run: ${sig} received — finishing current iteration, then stopping. Hit ${sig} again to abort hard.\n`);
+            process.stderr.write(`\nautopilot run: ${sig} received — finishing current iteration, then stopping. Hit ${sig} again to abort hard.\n`);
             // We don't yet know the runId until runRalphTui has emitted
             // it; the runner reads state.json each iter so flipping the
             // file is sufficient. We resolve the runId via the running
@@ -771,7 +775,7 @@ export async function cmdRun(flags) {
                         })
                             .then((inst) => { runUiInstance = inst; })
                             .catch((err) => {
-                                process.stderr.write(`ralph-tui run: TUI mount failed (${err?.message ?? err}); continuing in headless mode.\n`);
+                                process.stderr.write(`autopilot run: TUI mount failed (${err?.message ?? err}); continuing in headless mode.\n`);
                             });
                     }
                 }
@@ -823,7 +827,7 @@ export async function cmdRun(flags) {
 export async function main(argv = process.argv.slice(2)) {
     const { cmd, positional, flags } = parseArgv(argv);
     if (flags.version) {
-        process.stdout.write(`ralph-tui ${readTuiVersion()}\n`);
+        process.stdout.write(`autopilot ${readTuiVersion()}\n`);
         return 0;
     }
     if (flags.help || cmd === "help" || (!cmd && !positional.length)) {
@@ -846,13 +850,13 @@ export async function main(argv = process.argv.slice(2)) {
 }
 
 // Only run main() when invoked as a script (not when imported by tests).
-// `npm link` installs the bin as a symlink (e.g. /opt/homebrew/bin/ralph-tui
+// `npm link` installs the bin as a symlink (e.g. /opt/homebrew/bin/autopilot
 // → …/packages/tui/bin/tui.mjs); resolve it through realpath so the
 // "is this the entry point?" check survives the indirection. Kept fully
 // synchronous so this module body has no top-level await — Node 22+ emits
 // "Detected unsettled top-level await" when `process.exit()` fires from
 // the main() promise chain before the implicit module-evaluation TLA is
-// observed as settled (issue: spurious warning in `ralph-tui run` exit).
+// observed as settled (issue: spurious warning in `autopilot run` exit).
 let isDirectRun = false;
 try {
     if (process.argv[1]) {
@@ -873,10 +877,10 @@ if (isDirectRun) {
         // sees the actionable error, not a stack trace. Genuinely
         // unexpected failures keep the full stack for debuggability.
         if (err instanceof TypeError) {
-            process.stderr.write(`ralph-tui: ${err.message}\n`);
+            process.stderr.write(`autopilot: ${err.message}\n`);
             process.exit(2);
         }
-        process.stderr.write(`ralph-tui: ${err?.stack ?? err}\n`);
+        process.stderr.write(`autopilot: ${err?.stack ?? err}\n`);
         process.exit(1);
     });
 }

--- a/packages/tui/src/components/App.mjs
+++ b/packages/tui/src/components/App.mjs
@@ -1,4 +1,4 @@
-// <App> — top-level Ink component for `ralph-tui watch`.
+// <App> — top-level Ink component for `autopilot watch`.
 //
 // Owns the events array (fed from tailEventsFile) and runs foldEvents()
 // to compute the snapshot every render. Uses React.createElement (no
@@ -29,11 +29,11 @@ const h = React.createElement;
  * @param {string} [props.runId]      Display label for the header.
  * @param {(reason: string) => void} [props.onUserAbort] Optional
  *        callback fired when the user requests to abort via Ctrl-C
- *        or `q`. When provided (issue #48 slice 8 — `ralph-tui run`
+ *        or `q`. When provided (issue #48 slice 8 — `autopilot run`
  *        TUI mount), the caller can hook this to call
  *        `runner.stopRun(runId, …)` so the driver gets a graceful
  *        stop request instead of being orphaned mid-iter when the
- *        TUI tears down. Read-only callers (`ralph-tui watch`)
+ *        TUI tears down. Read-only callers (`autopilot watch`)
  *        omit it; the App still exits but no driver action occurs.
  */
 export default function App({ eventStream, events: initial = [], runId, onUserAbort }) {
@@ -84,7 +84,7 @@ export default function App({ eventStream, events: initial = [], runId, onUserAb
                     }
                 }
             } catch (err) {
-                process.stderr.write(`ralph-tui: tail error: ${err?.message ?? err}\n`);
+                process.stderr.write(`autopilot: tail error: ${err?.message ?? err}\n`);
                 exit(err);
             }
         })();

--- a/packages/tui/src/components/Controls.mjs
+++ b/packages/tui/src/components/Controls.mjs
@@ -1,4 +1,4 @@
-// <Controls> — bottom hint row for `ralph-tui watch`.
+// <Controls> — bottom hint row for `autopilot watch`.
 //
 // Uses React.createElement (no JSX) so the file runs in plain Node ESM.
 

--- a/packages/tui/src/components/Header.mjs
+++ b/packages/tui/src/components/Header.mjs
@@ -1,4 +1,4 @@
-// <Header> — top status banner for `ralph-tui watch` (issue #22).
+// <Header> — top status banner for `autopilot watch` (issue #22).
 //
 // Issue #48 slice 7: extended with a backlog row (open issues / open
 // PRs / red CI runs) so the user can see the loop's external scope at

--- a/packages/tui/src/components/Timeline.mjs
+++ b/packages/tui/src/components/Timeline.mjs
@@ -1,4 +1,4 @@
-// <Timeline> — scrolling iteration list for `ralph-tui watch` (issue #22).
+// <Timeline> — scrolling iteration list for `autopilot watch` (issue #22).
 //
 // Renders the most recent N iterations newest-first. Pure component;
 // uses React.createElement (no JSX) so it runs in plain Node ESM.

--- a/packages/tui/src/events.mjs
+++ b/packages/tui/src/events.mjs
@@ -1,4 +1,4 @@
-// Event contract for the ralph TUI (issue #22).
+// Event contract for autopilot (issue #22).
 //
 // The loop handler (extension/handler.mjs) writes one JSON object per line
 // to ~/.copilot/session-state/<id>/events.jsonl. The TUI tails that file,
@@ -26,7 +26,7 @@
  * @property {EventType} type
  * @property {number} ts            Epoch ms when the event was emitted.
  * @property {string} runId         Stable per-loop identifier (label + startedAt).
- * @property {string} [label]       "ralph_loop" | "self_improve" | "grow_project".
+ * @property {string} [label]       "ap_loop" | "self_improve" | "grow_project".
  * @property {number} [iteration]   1-indexed iteration counter.
  * @property {number} [maxIterations]
  * @property {number} [minIterations]

--- a/packages/tui/src/plain.mjs
+++ b/packages/tui/src/plain.mjs
@@ -1,7 +1,7 @@
-// Plain-mode renderer for the ralph TUI (issue #22).
+// Plain-mode renderer for autopilot (issue #22).
 //
 // The Ink-based watch UI (slice 5) requires a TTY plus user-space npm
-// dependencies. CI logs, asciinema recordings, and `ralph-tui watch
+// dependencies. CI logs, asciinema recordings, and `autopilot watch
 // --plain` need a non-interactive stream of human-readable lines that
 // preserves *every* event's information without ANSI tricks.
 //
@@ -196,7 +196,7 @@ export function formatEventLine(ev) {
     }
     if (typeof ev.reason === "string" && ev.reason) {
         // JSON.stringify the reason iff it contains whitespace, so a
-        // user-supplied multi-word reason from ralph_pause / ralph_stop
+        // user-supplied multi-word reason from ap_pause / ap_stop
         // (e.g. "user requested" or a flattened multi-line paste) stays
         // a single awk-parseable token in the rendered log line. Baked
         // single-token reasons (completion_promise, abort_promise,

--- a/packages/tui/src/run-ui.mjs
+++ b/packages/tui/src/run-ui.mjs
@@ -1,4 +1,4 @@
-// `ralph-tui run` interactive entry point (issue #48 slice 8).
+// `autopilot run` interactive entry point (issue #48 slice 8).
 //
 // Mounts the Ink-rendered <App /> against the events.jsonl file that
 // runRalphTui is concurrently writing to. Imported dynamically by

--- a/packages/tui/src/watch.mjs
+++ b/packages/tui/src/watch.mjs
@@ -1,4 +1,4 @@
-// `ralph-tui watch` interactive entry point (issue #22).
+// `autopilot watch` interactive entry point (issue #22).
 //
 // Mounts the Ink-rendered <App /> against a live tailed events.jsonl.
 // Imported dynamically by bin/tui.mjs so a fresh checkout without

--- a/packages/tui/test/bin.test.mjs
+++ b/packages/tui/test/bin.test.mjs
@@ -13,7 +13,7 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const BIN = resolve(REPO_ROOT, "bin", "tui.mjs");
 
 function tmp() {
-    return mkdtempSync(join(tmpdir(), "ralph-bin-"));
+    return mkdtempSync(join(tmpdir(), "autopilot-bin-"));
 }
 
 function runBin(args, env) {
@@ -45,12 +45,12 @@ test("bin --help: prints USAGE and exits 0", () => {
     const r = runBin(["--help"]);
     assert.equal(r.status, 0);
     assert.match(r.stdout, /USAGE/);
-    assert.match(r.stdout, /ralph-tui list/);
+    assert.match(r.stdout, /autopilot list/);
 });
 
 test("bin list: empty runs root prints helpful message", () => {
     const dir = tmp();
-    const r = runBin(["list"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["list"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     assert.match(r.stdout, /No runs found/);
     rmSync(dir, { recursive: true, force: true });
@@ -63,7 +63,7 @@ test("bin list: enumerates seeded runs newest-first", () => {
         JSON.stringify({ type: "armed", ts: 1000, runId: "ralph_loop-1000", label: "ralph_loop", maxIterations: 5, minIterations: 1 }) + "\n"
         + JSON.stringify({ type: "armed", ts: 2000, runId: "self_improve-2000", label: "self_improve", maxIterations: 100, minIterations: 5 }) + "\n",
     );
-    const r = runBin(["list"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["list"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     const lines = r.stdout.trim().split("\n");
     // Header + 2 runs.
@@ -75,7 +75,7 @@ test("bin list: enumerates seeded runs newest-first", () => {
 
 test("bin list --json: empty runs root prints []", () => {
     const dir = tmp();
-    const r = runBin(["list", "--json"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["list", "--json"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     assert.equal(r.stdout, "[]\n");
     assert.deepEqual(JSON.parse(r.stdout), []);
@@ -89,7 +89,7 @@ test("bin list --json: emits parseable run index newest-first", () => {
         JSON.stringify({ type: "armed", ts: 1000, runId: "ralph_loop-1000", label: "ralph_loop", maxIterations: 5, minIterations: 1 }) + "\n"
         + JSON.stringify({ type: "armed", ts: 2000, runId: "self_improve-2000", label: "self_improve", maxIterations: 100, minIterations: 5 }) + "\n",
     );
-    const r = runBin(["list", "--json"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["list", "--json"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     const parsed = JSON.parse(r.stdout);
     assert.ok(Array.isArray(parsed));
@@ -113,7 +113,7 @@ test("bin replay: prints all events for a run", () => {
         + JSON.stringify({ type: "iteration_start", ts: 2, runId: "ralph_loop-1", iteration: 1 }) + "\n"
         + JSON.stringify({ type: "complete", ts: 3, runId: "ralph_loop-1", reason: "completion_promise", iteration: 1 }) + "\n",
     );
-    const r = runBin(["replay", "ralph_loop-1"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["replay", "ralph_loop-1"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     assert.match(r.stdout, /armed\s+ralph_loop-1/);
     assert.match(r.stdout, /iter\+/);
@@ -146,7 +146,7 @@ import { chmodSync } from "node:fs";
 
 test("bin doctor: healthy case exits 0 and prints all sections", () => {
     const dir = tmp();
-    const r = runBin(["doctor"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["doctor"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     assert.match(r.stdout, /runs root:/);
     assert.match(r.stdout, /run index:/);
@@ -160,7 +160,7 @@ test("bin doctor: unwritable runs root exits non-zero with path", () => {
     const dir = tmp();
     chmodSync(dir, 0o500);
     try {
-        const r = runBin(["doctor"], { RALPH_EVENTS_DIR: dir });
+        const r = runBin(["doctor"], { AUTOPILOT_EVENTS_DIR: dir });
         assert.notEqual(r.status, 0, "should exit non-zero on unwritable root");
         assert.match(r.stdout + r.stderr, new RegExp(dir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
         assert.match(r.stdout, /UNWRITABLE/);
@@ -190,12 +190,12 @@ test("bin prune --dry-run: lists would-remove without deleting", () => {
     const old = seedRun(dir, "ralph_loop-old", 1);  // ts=1ms epoch ⇒ very old
     const fresh = seedRun(dir, "ralph_loop-fresh", Date.now());
     writeFileSync(join(dir, "index.jsonl"), old + "\n" + fresh + "\n");
-    const r = runBin(["prune", "--older-than", "365d", "--dry-run"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["prune", "--older-than", "365d", "--dry-run"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     assert.match(r.stdout, /dry-run.*would remove 1/);
     assert.match(r.stdout, /would remove ralph_loop-old/);
     // file still present
-    const list = runBin(["list", "--json"], { RALPH_EVENTS_DIR: dir });
+    const list = runBin(["list", "--json"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(JSON.parse(list.stdout).length, 2);
     rmSync(dir, { recursive: true, force: true });
 });
@@ -205,16 +205,16 @@ test("bin prune --older-than 0m: removes every run", () => {
     const a = seedRun(dir, "ralph_loop-a", Date.now() - 1000);
     const b = seedRun(dir, "ralph_loop-b", Date.now() - 2000);
     writeFileSync(join(dir, "index.jsonl"), a + "\n" + b + "\n");
-    const r = runBin(["prune", "--older-than", "0m"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["prune", "--older-than", "0m"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     assert.match(r.stdout, /pruned 2 runs/);
-    const list = runBin(["list", "--json"], { RALPH_EVENTS_DIR: dir });
+    const list = runBin(["list", "--json"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.deepEqual(JSON.parse(list.stdout), []);
     rmSync(dir, { recursive: true, force: true });
 });
 
 test("bin prune: invalid --older-than exits non-zero", () => {
-    const r = runBin(["prune", "--older-than", "nope"], { RALPH_EVENTS_DIR: tmp() });
+    const r = runBin(["prune", "--older-than", "nope"], { AUTOPILOT_EVENTS_DIR: tmp() });
     assert.notEqual(r.status, 0);
     assert.match(r.stderr, /invalid --older-than/);
 });
@@ -233,7 +233,7 @@ test("parseDuration: accepts d/h/m, rejects garbage", async () => {
 
 test("bin stats: empty index prints No runs found", () => {
     const dir = tmp();
-    const r = runBin(["stats"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["stats"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     assert.match(r.stdout, /No runs found/);
     rmSync(dir, { recursive: true, force: true });
@@ -260,7 +260,7 @@ test("bin stats: aggregates by tool, reason and iterations", () => {
         JSON.stringify({ type: "armed", ts: 100, runId: r1, label: "ralph_loop", maxIterations: 5, minIterations: 1 }) + "\n"
         + JSON.stringify({ type: "armed", ts: 200, runId: r2, label: "self_improve", maxIterations: 100, minIterations: 5 }) + "\n",
     );
-    const r = runBin(["stats"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["stats"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     assert.match(r.stdout, /Totals/);
     assert.match(r.stdout, /By tool/);
@@ -286,13 +286,13 @@ test("bin --version: prints version matching package.json", () => {
     const r = runBin(["--version"]);
     assert.equal(r.status, 0);
     const pkg = JSON.parse(readFileSync2(resolve(REPO_ROOT, "package.json"), "utf8"));
-    assert.equal(r.stdout.trim(), `ralph-tui ${pkg.version}`);
+    assert.equal(r.stdout.trim(), `autopilot ${pkg.version}`);
 });
 
 test("bin -V: same as --version", () => {
     const r = runBin(["-V"]);
     assert.equal(r.status, 0);
-    assert.match(r.stdout, /^ralph-tui \d/);
+    assert.match(r.stdout, /^autopilot \d/);
 });
 
 test("bin --help: mentions --version", () => {
@@ -311,7 +311,7 @@ function seedThreeRuns(dir) {
 test("bin list --limit N: prints at most N runs (newest first)", () => {
     const dir = tmp();
     seedThreeRuns(dir);
-    const r = runBin(["list", "--limit", "2", "--json"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["list", "--limit", "2", "--json"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     const parsed = JSON.parse(r.stdout);
     assert.equal(parsed.length, 2);
@@ -322,7 +322,7 @@ test("bin list --limit N: prints at most N runs (newest first)", () => {
 test("bin list --limit 0: prints zero runs and exits 0", () => {
     const dir = tmp();
     seedThreeRuns(dir);
-    const r = runBin(["list", "--limit", "0", "--json"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["list", "--limit", "0", "--json"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     assert.deepEqual(JSON.parse(r.stdout), []);
     rmSync(dir, { recursive: true, force: true });
@@ -331,7 +331,7 @@ test("bin list --limit 0: prints zero runs and exits 0", () => {
 test("bin list --limit nope: invalid value exits non-zero", () => {
     const dir = tmp();
     seedThreeRuns(dir);
-    const r = runBin(["list", "--limit", "nope"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["list", "--limit", "nope"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.notEqual(r.status, 0);
     assert.match(r.stderr, /invalid --limit/);
     rmSync(dir, { recursive: true, force: true });
@@ -340,39 +340,43 @@ test("bin list --limit nope: invalid value exits non-zero", () => {
 test("bin list (no --limit): all runs preserved", () => {
     const dir = tmp();
     seedThreeRuns(dir);
-    const r = runBin(["list", "--json"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["list", "--json"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(JSON.parse(r.stdout).length, 3);
     rmSync(dir, { recursive: true, force: true });
 });
 
 test("bin where: prints default runs root", () => {
-    const r = runBin(["where"], { RALPH_EVENTS_DIR: "" });  // empty -> default
+    // With both env vars cleared the writer chooses the new default
+    // (~/.copilot/autopilot/events) unless the legacy ~/.copilot/ralph/runs
+    // exists on disk — accept either to keep the test robust on
+    // contributor machines that still carry the legacy directory.
+    const r = runBin(["where"], { AUTOPILOT_EVENTS_DIR: "", RALPH_EVENTS_DIR: "" });
     assert.equal(r.status, 0);
-    assert.match(r.stdout, /\.copilot\/ralph\/runs\n$/);
+    assert.match(r.stdout, /\.copilot\/(autopilot\/events|ralph\/runs)\n$/);
 });
 
-test("bin where: honours RALPH_EVENTS_DIR override", () => {
+test("bin where: honours AUTOPILOT_EVENTS_DIR override", () => {
     const dir = tmp();
-    const r = runBin(["where"], { RALPH_EVENTS_DIR: dir });
+    const r = runBin(["where"], { AUTOPILOT_EVENTS_DIR: dir });
     assert.equal(r.status, 0);
     assert.equal(r.stdout, dir + "\n");
     rmSync(dir, { recursive: true, force: true });
 });
 
 test("bin where: works even when directory does not exist", () => {
-    const r = runBin(["where"], { RALPH_EVENTS_DIR: "/tmp/ralph-tui-does-not-exist-zz" });
+    const r = runBin(["where"], { AUTOPILOT_EVENTS_DIR: "/tmp/autopilot-does-not-exist-zz" });
     assert.equal(r.status, 0);
-    assert.equal(r.stdout, "/tmp/ralph-tui-does-not-exist-zz\n");
+    assert.equal(r.stdout, "/tmp/autopilot-does-not-exist-zz\n");
 });
 
 test("bin --help: mentions where", () => {
     const r = runBin(["--help"]);
-    assert.match(r.stdout, /ralph-tui where/);
+    assert.match(r.stdout, /autopilot where/);
 });
 
 test("tui.mjs has no top-level await (Node 22+ unsettled-TLA warning regression guard)", async () => {
     // Iter regression: the entry-point check used `await import("node:fs")`
-    // and `await import("node:url")` at the top level. On `ralph-tui run`,
+    // and `await import("node:url")` at the top level. On `autopilot run`,
     // when main() resolved and the `.then(process.exit)` chain fired,
     // Node 22+ printed `ExperimentalWarning: Detected unsettled top-level
     // await at file://…/bin/tui.mjs:<EOF-line>` to stderr — a spurious
@@ -459,13 +463,13 @@ test("tui.mjs header comment lists every USAGE subcommand (drift guard)", async 
         [...headerBlock[0].matchAll(/^\/\/\s{3}([a-z]+)\b/gm)].map((m) => m[1])
     );
 
-    // USAGE subcommands: lines beginning `  ralph-tui <cmd>` inside the
+    // USAGE subcommands: lines beginning `  autopilot <cmd>` inside the
     // `const USAGE = \`…\`;` template literal. Skip the `--help` /
     // `--version` lines.
     const usageBlock = src.match(/const USAGE = `([\s\S]+?)`;/);
     assert.ok(usageBlock, "could not locate the USAGE constant in tui.mjs");
     const usageCmds = new Set(
-        [...usageBlock[1].matchAll(/^\s{2}ralph-tui\s+([a-z]+)\b/gm)].map((m) => m[1])
+        [...usageBlock[1].matchAll(/^\s{2}autopilot\s+([a-z]+)\b/gm)].map((m) => m[1])
     );
 
     // Pin: every USAGE subcommand must appear in the header. (We allow
@@ -543,13 +547,13 @@ test("packages/tui/README.md Subcommands block lists every shipped subcommand + 
     // forcing the test to track exact byte offsets.
     const slice = readme.slice(i, i + 4000);
     const required = [
-        "ralph-tui list",
-        "ralph-tui replay",
-        "ralph-tui watch",
-        "ralph-tui doctor",
-        "ralph-tui prune",
-        "ralph-tui stats",
-        "ralph-tui where",
+        "autopilot list",
+        "autopilot replay",
+        "autopilot watch",
+        "autopilot doctor",
+        "autopilot prune",
+        "autopilot stats",
+        "autopilot where",
         "--help",
         "--version",
         "--json",
@@ -572,7 +576,7 @@ test("packages/tui/package.json carries repository/bugs/author metadata aligned 
     // the root package.json carries (iter 151 added the missing
     // root `author`, but the workspace package was forgotten).
     // For a sub-package shipped via the dogfood install path AND
-    // documented as `npx ralph-tui` in docs/faq.md, the missing
+    // documented as `npx autopilot` in docs/faq.md, the missing
     // metadata silently degrades the registry listing if the
     // `private: true` flag is ever flipped (e.g. a future release
     // branch that publishes the TUI to npm separately). Adding
@@ -630,7 +634,7 @@ test("cmdReplay: path-traversal runId routes through fail() with clean error (no
     // path-traversal runIds (`../etc/passwd`, runIds with `\0`, runIds
     // with `\\`, `.`, `..`). Pre-iter-167 `cmdReplay` and `cmdWatch`
     // called the resolver without catching, so a user supplying
-    // `ralph-tui replay ../etc/passwd` saw a raw stack trace instead
+    // `autopilot replay ../etc/passwd` saw a raw stack trace instead
     // of a clean error message. The fix is to catch TypeError at the
     // bin layer and route through `fail()` (clean stderr line + exit
     // code 2). Pin both the no-throw contract and the user-visible
@@ -762,7 +766,7 @@ test("VALUE_FLAGS JSDoc comment lists every flag actually in the set (drift guar
     }
 });
 
-// ─── Issue #48 slice 3: scope-driven default for `ralph-tui run --max` ──
+// ─── Issue #48 slice 3: scope-driven default for `autopilot run --max` ──
 
 import { defaultMaxIterationsFor } from "../bin/tui.mjs";
 import * as __runner from "../src/runner.mjs";
@@ -835,7 +839,7 @@ test("run-ui module is importable and exports mountRunUi (no top-level Ink impor
 
 // ─── Issue #48 / user-bug: q keypress fallback ─────────────────────
 //
-// Field bug from a real run: pressing `q` in `ralph-tui run` echoed
+// Field bug from a real run: pressing `q` in `autopilot run` echoed
 // to the terminal as cooked-mode characters instead of unmounting
 // the Ink App — meaning Ink's useInput silently failed to enter raw
 // mode for that environment. installStdinAbortListener is the
@@ -866,7 +870,7 @@ test("installStdinAbortListener: returns a no-op cleanup when stdin is NOT a TTY
 test("formatAbortMessage: q press → user-visible 'q received' line on stderr", () => {
     const msg = formatAbortMessage("user_quit");
     assert.ok(typeof msg === "string", "user_quit must return a string");
-    assert.match(msg, /^\nralph-tui run: q received — finishing current iteration, then stopping\. Hit Ctrl-C to abort hard\.\n$/);
+    assert.match(msg, /^\nautopilot run: q received — finishing current iteration, then stopping\. Hit Ctrl-C to abort hard\.\n$/);
 });
 
 test("formatAbortMessage: SIGINT path returns null (signal handler prints its own line)", () => {

--- a/packages/tui/test/components.test.mjs
+++ b/packages/tui/test/components.test.mjs
@@ -510,7 +510,7 @@ test("App.onUserAbort fires on Ctrl-C with 'signal_SIGINT' reason (issue #48 sli
 });
 
 test("App without onUserAbort still exits on q (read-only watch mode)", { skip }, async () => {
-    // ralph-tui watch supplies no onUserAbort — the App must still
+    // autopilot watch supplies no onUserAbort — the App must still
     // tear down cleanly without throwing on the missing callback.
     const inst = render(React.createElement(App, {
         events: [{ type: "armed", runId: "r1", label: "ralph_loop", maxIterations: 100, ts: 1 }],

--- a/packages/tui/test/plain.test.mjs
+++ b/packages/tui/test/plain.test.mjs
@@ -95,7 +95,7 @@ test("formatEventLine: caps long excerpt at 80 chars", () => {
 });
 
 test("formatEventLine: pause renders verb=pause + iteration + reason", () => {
-    // Issue #3: ralph_pause emits `{ type: "pause", runId, iteration,
+    // Issue #3: ap_pause emits `{ type: "pause", runId, iteration,
     // reason, ts }`. The plain renderer must surface verb / runId /
     // iteration / reason so a `tail -f`'d stream of events lets a
     // human (or `awk`) know which iteration paused and why. Pin the
@@ -117,7 +117,7 @@ test("formatEventLine: pause renders verb=pause + iteration + reason", () => {
 });
 
 test("formatEventLine: pause with null reason omits the reason segment", () => {
-    // ralph_pause without a reason emits `reason: null`. The renderer
+    // ap_pause without a reason emits `reason: null`. The renderer
     // must skip the segment entirely (not render `reason=null`) so
     // empty-reason pause lines stay tidy in the plain log.
     const line = formatEventLine({
@@ -313,7 +313,7 @@ test("formatEventLine: abort with abort_promise reason renders cleanly", () => {
 
 test("formatEventLine: reason= field quotes whitespace-bearing user reasons but not baked tokens", () => {
     // Iter 137 fix: pause/stop events with a user-supplied reason
-    // (via ralph_pause / ralph_stop) routinely contain spaces — the
+    // (via ap_pause / ap_stop) routinely contain spaces — the
     // user types "lunch break", "context-window pressure", or
     // similar. Pre-iter-137 the renderer emitted them unquoted, so
     // the line collapsed multiple tokens after `reason=` and

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -5361,7 +5361,7 @@ test("scripts/ralph-tui-fresh.sh: non-`run` subcommand skips upgrade and passes 
         { encoding: "utf8", timeout: 10_000 },
     );
     assert.equal(r.status, 0, `--help exited ${r.status}; stderr=${r.stderr}`);
-    assert.match(r.stdout, /ralph-tui — terminal visualizer/,
+    assert.match(r.stdout, /autopilot — terminal visualizer/,
         "wrapper must passthrough `--help` to bin/tui.mjs's USAGE block");
 });
 


### PR DESCRIPTION
## Summary

- Flips the user-visible CLI surface from `ralph-tui` to `autopilot`. The banner, USAGE block, OPTIONS lines, ENV block, `--version` output, and all stderr error prefixes now use `autopilot`. The package's `bin` entry was already named `autopilot` in `package.json`, so this brings the help text in lockstep with the binary name.
- The ENV block lists `AUTOPILOT_EVENTS_DIR / RUNS_DIR / COPILOT_BIN / NO_ATTRIBUTION / CAFFEINATE / CAFFEINATE_SCOPE` and replaces the per-variable legacy notices with a single-line footnote: `Legacy RALPH_* names are still read for one release with a one-line stderr deprecation notice.`
- Internal comments, JSDoc, and component headers updated from `ralph TUI` / `ralph-tui watch` / `ralph_loop` / `ralph_pause` to the autopilot/ap_loop/ap_pause vocabulary. No semantic logic changed; the internal Ralph-named symbols (e.g. `BAKED_RALPH_TRAILER`, `runRalphTui`) are out of scope per the unit spec.

## Files

- `packages/tui/bin/tui.mjs` — biggest change: banner / USAGE / OPTIONS / ENV / version / error prefixes.
- `packages/tui/src/{run-ui,events,plain,watch}.mjs` and components (`App`, `Header`, `Timeline`, `Controls`) — header comments and JSDoc.
- `packages/tui/test/{bin,components,plain}.test.mjs` — assertions flipped to `autopilot ...`, env vars to `AUTOPILOT_EVENTS_DIR`, `--version` to `autopilot N.N.N`. The `bin where` default test now accepts either the new `~/.copilot/autopilot/events` or the legacy `~/.copilot/ralph/runs` to remain robust on contributor machines that still carry the old directory.
- `packages/tui/README.md` — Subcommands block reflects the new `autopilot ...` invocation. The Auto-upgrade section keeps its `scripts/ralph-tui-fresh.sh` references because the wrapper script itself was not renamed in this stage.
- `test/extension.test.mjs` — single-line USAGE-passthrough assertion flipped from `ralph-tui — terminal visualizer` to `autopilot — terminal visualizer` so the wrapper smoke test keeps passing after the banner change.

## Test plan

- [x] `npm install --no-audit --no-fund`
- [x] `npm test` → 975/975 pass
- [x] `npm run check` → clean
- [x] `node packages/tui/bin/tui.mjs --help` → banner says "autopilot", USAGE lists `autopilot list/replay/watch/...`, ENV block lists `AUTOPILOT_*` plus a single legacy footnote.

Refs #49.