### PR TITLE
feat(handler)!: prefer AUTOPILOT_NO_ATTRIBUTION / AUTOPILOT_CAFFEINATE env vars (refs #49)

### DIFF
--- a/extension/extension.mjs
+++ b/extension/extension.mjs
@@ -1,4 +1,4 @@
-// Extension: ralph
+// Extension: autopilot
 // Hook/event-driven autonomous iterative loop for GitHub Copilot CLI.
 // Inspired by the Stop-hook re-injection pattern.
 
@@ -13,7 +13,7 @@ const controller = createRalphController({ events: true });
 // in /extensions nor any clue why. Emit stderr and rethrow.
 function fatal(stage, err) {
     const msg = err && err.message ? err.message : String(err);
-    process.stderr.write(`ralph extension: failed to ${stage}: ${msg}\n`);
+    process.stderr.write(`autopilot extension: failed to ${stage}: ${msg}\n`);
     throw err;
 }
 

--- a/extension/handler.mjs
+++ b/extension/handler.mjs
@@ -33,7 +33,7 @@ const moduleRequire = createRequire(import.meta.url);
 // which runs in CI on every push. We hard-code the literal here rather
 // than reading `package.json` at runtime because `install.sh` only ships
 // `extension.mjs handler.mjs events-emit.mjs` to `~/.copilot/extensions/
-// ralph/` — a `require("../package.json")` would crash on installed
+// autopilot/` — a `require("../package.json")` would crash on installed
 // copies. The constant is exported so a future "version check on
 // extension load" feature (issue #25) and any tooling that introspects
 // the snapshot has a single source of truth without a torn-read window
@@ -220,15 +220,21 @@ const VERB_BY_REASON = Object.freeze({
 //     load-time loop below validates both contain the literals in the
 //     correct order and document both opt-out env vars).
 //   - The __test__ exports (BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER,
-//     BAKED_ATTRIBUTION_OPT_OUT, BAKED_ATTRIBUTION_OPT_OUT_PRIMARY) used
+//     BAKED_ATTRIBUTION_OPT_OUT, BAKED_ATTRIBUTION_OPT_OUT_LEGACY) used
 //     by the canonical-source pin test.
 // Renaming any of these literals (e.g. registering the bot under a
 // different login, swapping the noreply domain) requires updating
 // every surface above.
 const BAKED_COPILOT_TRAILER = "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>";
 const BAKED_RALPH_TRAILER = "Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>";
-const BAKED_ATTRIBUTION_OPT_OUT = "RALPH_NO_ATTRIBUTION=1";
-const BAKED_ATTRIBUTION_OPT_OUT_PRIMARY = "AUTOPILOT_NO_ATTRIBUTION=1";
+// Primary opt-out env var (project-rename stage 4). The constant NAME
+// keeps the historical _OPT_OUT spelling so existing __test__ exports
+// stay stable; only its VALUE flipped from the legacy RALPH_* form.
+const BAKED_ATTRIBUTION_OPT_OUT = "AUTOPILOT_NO_ATTRIBUTION=1";
+// Legacy opt-out env var, kept as a load-time invariant so prompts
+// continue to document both spellings while existing user scripts
+// that still set RALPH_NO_ATTRIBUTION=1 keep working.
+const BAKED_ATTRIBUTION_OPT_OUT_LEGACY = "RALPH_NO_ATTRIBUTION=1";
 
 // Issue #1 (ap_loop parity): unlike self_improve / grow_project which
 // embed the COMMIT stage in their full baked SDLC prompt, ap_loop takes
@@ -245,7 +251,7 @@ const BAKED_RALPH_LOOP_RIDER = `---
 CONTROLLER REQUIREMENT — commit attribution: if this iteration produces any git commit, append BOTH Co-authored-by trailers in this exact order at the end of the commit message (separated from the body by a blank line):
   ${BAKED_COPILOT_TRAILER}
   ${BAKED_RALPH_TRAILER}
-The second trailer attributes loop-driven commits to the dedicated copilot-ralph bot account so they are passively searchable across public GitHub. If the environment variable ${BAKED_ATTRIBUTION_OPT_OUT_PRIMARY} (or legacy ${BAKED_ATTRIBUTION_OPT_OUT}) is set, omit ONLY the second copilot-ralph trailer; the first Copilot trailer always ships. If this iteration creates no commit, ignore this requirement.`;
+The second trailer attributes loop-driven commits to the dedicated copilot-ralph bot account so they are passively searchable across public GitHub. If the environment variable ${BAKED_ATTRIBUTION_OPT_OUT} (or legacy ${BAKED_ATTRIBUTION_OPT_OUT_LEGACY}) is set, omit ONLY the second copilot-ralph trailer; the first Copilot trailer always ships. If this iteration creates no commit, ignore this requirement.`;
 
 for (const [label, prompt] of [
     ["PROMPT_SELF_IMPROVE", PROMPT_SELF_IMPROVE],
@@ -264,9 +270,9 @@ for (const [label, prompt] of [
             `handler.mjs: ${label} must document the "${BAKED_ATTRIBUTION_OPT_OUT}" opt-out env var alongside the dual Co-authored-by trailers. Issue #1 attribution invariant.`,
         );
     }
-    if (!prompt.includes(BAKED_ATTRIBUTION_OPT_OUT_PRIMARY)) {
+    if (!prompt.includes(BAKED_ATTRIBUTION_OPT_OUT_LEGACY)) {
         throw new Error(
-            `handler.mjs: ${label} must document the "${BAKED_ATTRIBUTION_OPT_OUT_PRIMARY}" opt-out env var alongside the dual Co-authored-by trailers. Issue #1 attribution invariant.`,
+            `handler.mjs: ${label} must document the "${BAKED_ATTRIBUTION_OPT_OUT_LEGACY}" opt-out env var alongside the dual Co-authored-by trailers. Issue #1 attribution invariant.`,
         );
     }
 }
@@ -383,8 +389,11 @@ function pauseElapsedFromAt(pausedAt, now) {
 // the CLI — no orphaned wake-locks.
 //
 // Disabled by default. Enable via env var:
-//     RALPH_CAFFEINATE=1                 → enable, scope = idle (default)
-//     RALPH_CAFFEINATE_SCOPE=idle+display → also block display sleep
+//     AUTOPILOT_CAFFEINATE=1                 → enable, scope = idle (default)
+//     AUTOPILOT_CAFFEINATE_SCOPE=idle+display → also block display sleep
+// The legacy spellings RALPH_CAFFEINATE / RALPH_CAFFEINATE_SCOPE still
+// work as a quiet fallback; the first time either fires per process,
+// a single-line stderr deprecation notice is emitted.
 //
 // On non-darwin platforms or when the binary is missing, the helper degrades
 // to a silent no-op — never fail the loop over a power-management nicety.
@@ -392,16 +401,51 @@ function pauseElapsedFromAt(pausedAt, now) {
 const CAFFEINATE_TRUTHY = new Set(["1", "true", "yes", "on"]);
 const CAFFEINATE_SCOPES = new Set(["idle", "idle+display"]);
 
-function isCaffeinateEnabled(env) {
-    const raw = env?.RALPH_CAFFEINATE;
-    if (typeof raw !== "string") return false;
-    return CAFFEINATE_TRUTHY.has(raw.trim().toLowerCase());
+// One-shot per-process deprecation notices for legacy env-var fallbacks.
+// We deliberately keep this in-memory only (no sentinel file) because the
+// caffeinate / no-attribution surfaces are read often enough during a
+// session that disk-based dedup would add complexity without payoff —
+// the goal is to nudge the user once per CLI run, not once forever.
+const _legacyEnvNoticeFired = new Set();
+function _warnLegacyEnvOnce(legacyName, primaryName, stderr = process.stderr) {
+    if (_legacyEnvNoticeFired.has(legacyName)) return;
+    _legacyEnvNoticeFired.add(legacyName);
+    try {
+        stderr.write?.(`[autopilot] note: env $${legacyName} is deprecated, please use $${primaryName} (still honored)\n`);
+    } catch { /* best-effort */ }
+}
+// Test seam — reset the per-process notice flags so each test starts
+// from a clean slate.
+function _resetLegacyEnvNotices() { _legacyEnvNoticeFired.clear(); }
+
+// Primary $AUTOPILOT_CAFFEINATE; falls back to legacy $RALPH_CAFFEINATE
+// with a one-line stderr deprecation on first fallback firing.
+function isCaffeinateEnabled(env, stderr) {
+    const primary = env?.AUTOPILOT_CAFFEINATE;
+    if (typeof primary === "string") {
+        return CAFFEINATE_TRUTHY.has(primary.trim().toLowerCase());
+    }
+    const legacy = env?.RALPH_CAFFEINATE;
+    if (typeof legacy !== "string") return false;
+    const enabled = CAFFEINATE_TRUTHY.has(legacy.trim().toLowerCase());
+    if (enabled) _warnLegacyEnvOnce("RALPH_CAFFEINATE", "AUTOPILOT_CAFFEINATE", stderr);
+    return enabled;
 }
 
-function resolveCaffeinateScope(env) {
-    const raw = env?.RALPH_CAFFEINATE_SCOPE;
-    if (typeof raw !== "string") return "idle";
-    const v = raw.trim().toLowerCase();
+// Primary $AUTOPILOT_CAFFEINATE_SCOPE; falls back to legacy
+// $RALPH_CAFFEINATE_SCOPE with a one-line stderr deprecation on first
+// fallback firing. Bogus values collapse to "idle" the same way the
+// primary parse does — keep a typo from disabling sleep prevention.
+function resolveCaffeinateScope(env, stderr) {
+    const primary = env?.AUTOPILOT_CAFFEINATE_SCOPE;
+    if (typeof primary === "string") {
+        const v = primary.trim().toLowerCase();
+        return CAFFEINATE_SCOPES.has(v) ? v : "idle";
+    }
+    const legacy = env?.RALPH_CAFFEINATE_SCOPE;
+    if (typeof legacy !== "string") return "idle";
+    _warnLegacyEnvOnce("RALPH_CAFFEINATE_SCOPE", "AUTOPILOT_CAFFEINATE_SCOPE", stderr);
+    const v = legacy.trim().toLowerCase();
     return CAFFEINATE_SCOPES.has(v) ? v : "idle";
 }
 
@@ -421,16 +465,17 @@ function caffeinateFlagsForScope(scope) {
  * @param {Function} deps.spawnFn - child_process.spawn-compatible
  * @param {(msg: string) => void} deps.log
  * @param {string} deps.label - "ap_loop" | "self_improve" | "grow_project"
+ * @param {{ write: Function }} [deps.stderr] - sink for legacy-env deprecation notices
  * @returns {(() => void) | null}
  */
-function startCaffeinate({ env, platform, pid, spawnFn, log, label }) {
-    if (!isCaffeinateEnabled(env)) return null;
+function startCaffeinate({ env, platform, pid, spawnFn, log, label, stderr }) {
+    if (!isCaffeinateEnabled(env, stderr)) return null;
     if (platform !== "darwin") {
         log(`${label}: caffeinate skipped — platform ${platform} not supported (darwin only)`);
         return null;
     }
     if (typeof spawnFn !== "function") return null;
-    const scope = resolveCaffeinateScope(env);
+    const scope = resolveCaffeinateScope(env, stderr);
     const flags = caffeinateFlagsForScope(scope);
     const args = [flags, "-w", String(pid)];
     let child;
@@ -1115,12 +1160,15 @@ export function validateArgs(args) {
 export function createRalphController(opts = {}) {
     // Caffeinate dependency injection (issue #8). Tests pass stubs; production
     // resolves child_process.spawn lazily so the import cost is paid only when
-    // RALPH_CAFFEINATE is actually enabled.
+    // AUTOPILOT_CAFFEINATE (or legacy RALPH_CAFFEINATE) is actually enabled.
     const caffeinateDeps = {
         env: opts.caffeinate?.env ?? process.env,
         platform: opts.caffeinate?.platform ?? process.platform,
         pid: opts.caffeinate?.pid ?? process.pid,
         spawnFn: opts.caffeinate?.spawnFn ?? null,
+        // Tests inject `caffeinate.stderr = { write }` so legacy-env
+        // deprecations don't pollute the tap stream.
+        stderr: opts.caffeinate?.stderr ?? process.stderr,
     };
     // Git dependency injection (issue #5). `ap_status` calls gitExec(args)
     // synchronously; tests replace it with a stub that returns canned results.
@@ -1160,7 +1208,7 @@ export function createRalphController(opts = {}) {
     // armLoop call and attached to state.active.events. `factory` is the
     // injection seam tests use to record without touching disk.
     //   opts.events = false | undefined         → off
-    //   opts.events = true                      → on, default emitter (writes ~/.copilot/ralph/runs)
+    //   opts.events = true                      → on, default emitter (writes ~/.copilot/autopilot/events; legacy ~/.copilot/ralph/runs honored on fallback)
     //   opts.events = { factory }               → on, custom factory({label, startedAt}) → writer
     //   opts.events = { env, fs }               → on, default emitter w/ overrides
     const eventsConfig = (() => {
@@ -1663,7 +1711,7 @@ export function createRalphController(opts = {}) {
         // caffeinate is actually enabled (avoids paying the require cost
         // for every loop arm). Tests inject spawnFn directly via opts.
         let spawnFn = caffeinateDeps.spawnFn;
-        if (!spawnFn && isCaffeinateEnabled(caffeinateDeps.env) && caffeinateDeps.platform === "darwin") {
+        if (!spawnFn && isCaffeinateEnabled(caffeinateDeps.env, caffeinateDeps.stderr) && caffeinateDeps.platform === "darwin") {
             try {
                 ({ spawn: spawnFn } = moduleRequire("node:child_process"));
             } catch { /* swallow — startCaffeinate handles null spawnFn */ }
@@ -1675,6 +1723,7 @@ export function createRalphController(opts = {}) {
             spawnFn,
             log,
             label,
+            stderr: caffeinateDeps.stderr,
         });
         // Snapshot git HEAD/branch at arm-time for ap_status's
         // "files changed since loop started" diff. Best-effort — a non-git
@@ -2434,4 +2483,4 @@ export function createRalphController(opts = {}) {
     };
 }
 
-export const __test__ = { DEFAULTS, SELF_IMPROVE_DEFAULTS, GROW_PROJECT_DEFAULTS, MAX_ALLOWED_ITERATIONS, PREVIEW_CHARS, MAX_PROMPT_CHARS, MAX_PROMISE_CHARS, MAX_CONTENT_CHARS, MAX_FOCUS_CHARS, PROMPT_SELF_IMPROVE, PROMPT_GROW_PROJECT, BAKED_ABORT_TOKEN, BAKED_BACKLOG_ABORT_TOKEN, BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER, BAKED_ATTRIBUTION_OPT_OUT, BAKED_ATTRIBUTION_OPT_OUT_PRIMARY, BAKED_RALPH_LOOP_RIDER, composeRalphLoopPrompt, previewOf, evaluateAdaptiveSignals, ADAPTIVE_WINDOW, reprefixRalphLoopError, gitAheadBehind, gitUncommittedLines, classifyPorcelainLine, parseUserReason, coerceNumberField, VERSION, compareSemver, VERB_BY_REASON, isCaffeinateEnabled, resolveCaffeinateScope, caffeinateFlagsForScope, describeArgType, displayValue, pauseElapsedFromAt };
+export const __test__ = { DEFAULTS, SELF_IMPROVE_DEFAULTS, GROW_PROJECT_DEFAULTS, MAX_ALLOWED_ITERATIONS, PREVIEW_CHARS, MAX_PROMPT_CHARS, MAX_PROMISE_CHARS, MAX_CONTENT_CHARS, MAX_FOCUS_CHARS, PROMPT_SELF_IMPROVE, PROMPT_GROW_PROJECT, BAKED_ABORT_TOKEN, BAKED_BACKLOG_ABORT_TOKEN, BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER, BAKED_ATTRIBUTION_OPT_OUT, BAKED_ATTRIBUTION_OPT_OUT_LEGACY, BAKED_RALPH_LOOP_RIDER, composeRalphLoopPrompt, previewOf, evaluateAdaptiveSignals, ADAPTIVE_WINDOW, reprefixRalphLoopError, gitAheadBehind, gitUncommittedLines, classifyPorcelainLine, parseUserReason, coerceNumberField, VERSION, compareSemver, VERB_BY_REASON, isCaffeinateEnabled, resolveCaffeinateScope, caffeinateFlagsForScope, describeArgType, displayValue, pauseElapsedFromAt, _resetLegacyEnvNotices };

--- a/extension/prompts.mjs
+++ b/extension/prompts.mjs
@@ -3,12 +3,12 @@
 // module so it can be imported by:
 //
 //   - extension/handler.mjs — the in-session loop runner
-//   - packages/tui/src/runner.mjs — the out-of-session ralph-tui run
+//   - packages/tui/src/runner.mjs — the out-of-session autopilot run
 //     driver (each iter is a fresh `copilot -p ...` subprocess)
 //
 // Both runners must ship the IDENTICAL prompt body, otherwise behaviour
 // diverges between `self_improve` / `grow_project` (in-session) and
-// `ralph-tui run --self-improve` / `ralph-tui run --grow-project`
+// `autopilot run --self-improve` / `autopilot run --grow-project`
 // (out-of-session). Centralising the prompt source removes that drift
 // surface entirely.
 //

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -7,7 +7,7 @@ import { dirname, resolve, join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { createRalphController, validateArgs, __test__ } from "../extension/handler.mjs";
-const { MAX_PROMISE_CHARS, MAX_PROMPT_CHARS, MAX_ALLOWED_ITERATIONS, PREVIEW_CHARS, PROMPT_SELF_IMPROVE, PROMPT_GROW_PROJECT, BAKED_ABORT_TOKEN, BAKED_BACKLOG_ABORT_TOKEN, BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER, BAKED_ATTRIBUTION_OPT_OUT, BAKED_RALPH_LOOP_RIDER, composeRalphLoopPrompt, SELF_IMPROVE_DEFAULTS, GROW_PROJECT_DEFAULTS, MAX_FOCUS_CHARS, previewOf, evaluateAdaptiveSignals, ADAPTIVE_WINDOW, reprefixRalphLoopError, gitAheadBehind, gitUncommittedLines, parseUserReason, coerceNumberField } = __test__;
+const { MAX_PROMISE_CHARS, MAX_PROMPT_CHARS, MAX_ALLOWED_ITERATIONS, PREVIEW_CHARS, PROMPT_SELF_IMPROVE, PROMPT_GROW_PROJECT, BAKED_ABORT_TOKEN, BAKED_BACKLOG_ABORT_TOKEN, BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER, BAKED_ATTRIBUTION_OPT_OUT, BAKED_ATTRIBUTION_OPT_OUT_LEGACY, BAKED_RALPH_LOOP_RIDER, composeRalphLoopPrompt, SELF_IMPROVE_DEFAULTS, GROW_PROJECT_DEFAULTS, MAX_FOCUS_CHARS, previewOf, evaluateAdaptiveSignals, ADAPTIVE_WINDOW, reprefixRalphLoopError, gitAheadBehind, gitUncommittedLines, parseUserReason, coerceNumberField } = __test__;
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -1370,20 +1370,22 @@ test("both baked prompts retain the cwd guardrail and the trigger-phrase footgun
     }
 });
 
-test("PROMPT_SELF_IMPROVE bakes the dual Co-authored-by trailer + RALPH_NO_ATTRIBUTION opt-out (issue #1)", () => {
+test("PROMPT_SELF_IMPROVE bakes the dual Co-authored-by trailer + AUTOPILOT_NO_ATTRIBUTION opt-out (issue #1)", () => {
     // Issue #1: every loop-driven commit ships TWO Co-authored-by
     // trailers — the existing Copilot trailer for agent attribution,
     // plus a copilot-ralph bot-account trailer for passive usage
-    // analytics across public GitHub. RALPH_NO_ATTRIBUTION=1 in env
-    // suppresses ONLY the second trailer; the Copilot trailer always
-    // ships. Pin both literals so a future edit can't silently drop
-    // the bot-account trailer or invert the opt-out polarity.
+    // analytics across public GitHub. AUTOPILOT_NO_ATTRIBUTION=1
+    // (or legacy RALPH_NO_ATTRIBUTION=1) in env suppresses ONLY the
+    // second trailer; the Copilot trailer always ships. Pin both
+    // literals so a future edit can't silently drop the bot-account
+    // trailer or invert the opt-out polarity.
     const p = PROMPT_SELF_IMPROVE;
     assert.match(p, /Co-authored-by: Copilot <223556219\+Copilot@users\.noreply\.github\.com>/, "must keep the canonical Copilot trailer");
     assert.match(p, /Co-authored-by: copilot-ralph <copilot-ralph@users\.noreply\.github\.com>/, "must bake the copilot-ralph bot-account trailer (issue #1)");
-    assert.match(p, /RALPH_NO_ATTRIBUTION=1/, "must document the RALPH_NO_ATTRIBUTION=1 opt-out env var");
+    assert.match(p, /AUTOPILOT_NO_ATTRIBUTION=1/, "must document the AUTOPILOT_NO_ATTRIBUTION=1 primary opt-out env var");
+    assert.match(p, /RALPH_NO_ATTRIBUTION=1/, "must document the legacy RALPH_NO_ATTRIBUTION=1 opt-out env var (still honored)");
     // Opt-out polarity: setting the var SUPPRESSES, not enables.
-    assert.match(p, /RALPH_NO_ATTRIBUTION=1[\s\S]{0,200}\bomit\b/i, "RALPH_NO_ATTRIBUTION=1 must instruct the agent to OMIT the second trailer");
+    assert.match(p, /AUTOPILOT_NO_ATTRIBUTION=1[\s\S]{0,200}\bomit\b/i, "AUTOPILOT_NO_ATTRIBUTION=1 must instruct the agent to OMIT the second trailer");
     // Stricter polarity: must say "omit ONLY" (or equivalent) so a future
     // edit can't degrade to "omit BOTH" trailers — the Copilot trailer
     // must always ship for agent-attribution audit.
@@ -1391,22 +1393,23 @@ test("PROMPT_SELF_IMPROVE bakes the dual Co-authored-by trailer + RALPH_NO_ATTRI
     assert.match(p, /\balways\s+ship/i, "must promise the Copilot trailer always ships");
 });
 
-test("PROMPT_GROW_PROJECT bakes the dual Co-authored-by trailer + RALPH_NO_ATTRIBUTION opt-out (issue #1)", () => {
+test("PROMPT_GROW_PROJECT bakes the dual Co-authored-by trailer + AUTOPILOT_NO_ATTRIBUTION opt-out (issue #1)", () => {
     // Mirror of the PROMPT_SELF_IMPROVE pin. grow_project also commits
     // per iter and must carry the same dual-trailer + opt-out contract
     // so the two loop tools stay symmetric on the attribution surface.
     const p = PROMPT_GROW_PROJECT;
     assert.match(p, /Co-authored-by: Copilot <223556219\+Copilot@users\.noreply\.github\.com>/, "must keep the canonical Copilot trailer");
     assert.match(p, /Co-authored-by: copilot-ralph <copilot-ralph@users\.noreply\.github\.com>/, "must bake the copilot-ralph bot-account trailer (issue #1)");
-    assert.match(p, /RALPH_NO_ATTRIBUTION=1/, "must document the RALPH_NO_ATTRIBUTION=1 opt-out env var");
-    assert.match(p, /RALPH_NO_ATTRIBUTION=1[\s\S]{0,200}\bomit\b/i, "RALPH_NO_ATTRIBUTION=1 must instruct the agent to OMIT the copilot-ralph trailer");
+    assert.match(p, /AUTOPILOT_NO_ATTRIBUTION=1/, "must document the AUTOPILOT_NO_ATTRIBUTION=1 primary opt-out env var");
+    assert.match(p, /RALPH_NO_ATTRIBUTION=1/, "must document the legacy RALPH_NO_ATTRIBUTION=1 opt-out env var (still honored)");
+    assert.match(p, /AUTOPILOT_NO_ATTRIBUTION=1[\s\S]{0,200}\bomit\b/i, "AUTOPILOT_NO_ATTRIBUTION=1 must instruct the agent to OMIT the copilot-ralph trailer");
     // Stricter polarity (mirror of self_improve pin): must say "omit ONLY"
     // so a future edit can't degrade to "omit BOTH" trailers.
     assert.match(p, /\bomit\b[\s\S]{0,80}\bonly\b/i, "must instruct OMIT ONLY the copilot-ralph trailer (Copilot trailer + Closes #N always ship)");
     assert.match(p, /\balways\s+ship/i, "must promise the Copilot trailer (and Closes #N) always ship");
 });
 
-test("BAKED_RALPH_LOOP_RIDER bakes the dual Co-authored-by trailer + RALPH_NO_ATTRIBUTION opt-out (issue #1, ap_loop parity)", () => {
+test("BAKED_RALPH_LOOP_RIDER bakes the dual Co-authored-by trailer + AUTOPILOT_NO_ATTRIBUTION opt-out (issue #1, ap_loop parity)", () => {
     // ap_loop parity with self_improve / grow_project: every
     // loop-driven commit must carry the dual trailer. Because
     // ap_loop's prompt is user-supplied, the rider is appended
@@ -1416,8 +1419,9 @@ test("BAKED_RALPH_LOOP_RIDER bakes the dual Co-authored-by trailer + RALPH_NO_AT
     const r = BAKED_RALPH_LOOP_RIDER;
     assert.match(r, /Co-authored-by: Copilot <223556219\+Copilot@users\.noreply\.github\.com>/, "must keep the canonical Copilot trailer");
     assert.match(r, /Co-authored-by: copilot-ralph <copilot-ralph@users\.noreply\.github\.com>/, "must bake the copilot-ralph bot-account trailer");
-    assert.match(r, /RALPH_NO_ATTRIBUTION=1/, "must document the RALPH_NO_ATTRIBUTION=1 opt-out env var");
-    assert.match(r, /RALPH_NO_ATTRIBUTION=1[\s\S]{0,200}\bomit\b/i, "RALPH_NO_ATTRIBUTION=1 must instruct the agent to OMIT the copilot-ralph trailer");
+    assert.match(r, /AUTOPILOT_NO_ATTRIBUTION=1/, "must document the AUTOPILOT_NO_ATTRIBUTION=1 primary opt-out env var");
+    assert.match(r, /RALPH_NO_ATTRIBUTION=1/, "must document the legacy RALPH_NO_ATTRIBUTION=1 opt-out env var (still honored)");
+    assert.match(r, /AUTOPILOT_NO_ATTRIBUTION=1[\s\S]{0,200}\bomit\b/i, "AUTOPILOT_NO_ATTRIBUTION=1 must instruct the agent to OMIT the copilot-ralph trailer");
     assert.match(r, /\bomit\b[\s\S]{0,80}\bonly\b/i, "must instruct OMIT ONLY the copilot-ralph trailer");
     assert.match(r, /\balways\s+ship/i, "must promise the Copilot trailer always ships");
     // Order pin: Copilot must precede copilot-ralph (GitHub UI
@@ -1538,11 +1542,17 @@ test("BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER, BAKED_ATTRIBUTION_OPT_OUT pin 
     // CHANGELOG.
     assert.equal(BAKED_COPILOT_TRAILER, "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>");
     assert.equal(BAKED_RALPH_TRAILER, "Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>");
-    assert.equal(BAKED_ATTRIBUTION_OPT_OUT, "RALPH_NO_ATTRIBUTION=1");
+    // Project-rename stage 4: AUTOPILOT_NO_ATTRIBUTION is the
+    // primary opt-out env var; the legacy RALPH_NO_ATTRIBUTION
+    // spelling still works (and remains baked into prompt prose
+    // so existing user scripts don't drift).
+    assert.equal(BAKED_ATTRIBUTION_OPT_OUT, "AUTOPILOT_NO_ATTRIBUTION=1");
+    assert.equal(BAKED_ATTRIBUTION_OPT_OUT_LEGACY, "RALPH_NO_ATTRIBUTION=1");
     // Trailers must be distinct lines; opt-out polarity is "=1"
     // (truthy enables the suppression), not a bare flag.
     assert.notEqual(BAKED_COPILOT_TRAILER, BAKED_RALPH_TRAILER);
     assert.match(BAKED_ATTRIBUTION_OPT_OUT, /=1$/, "opt-out env var must use the =1 polarity convention");
+    assert.match(BAKED_ATTRIBUTION_OPT_OUT_LEGACY, /=1$/, "legacy opt-out env var must use the =1 polarity convention");
     // Both trailers must use the canonical GitHub noreply domain.
     // A typo like "users.noreply.gihub.com" would silently produce
     // commits whose Co-authored-by line does not link to any GitHub
@@ -1627,7 +1637,8 @@ test("the prompt actually fired through armLoop carries both Co-authored-by trai
     // the agent's actual instructions while leaving the exported
     // PROMPT_* constants untouched. Pin the SENT prompt — the
     // string the executing agent actually sees — to contain both
-    // trailer literals and the RALPH_NO_ATTRIBUTION env var
+    // trailer literals AND both opt-out env var spellings
+    // (AUTOPILOT_NO_ATTRIBUTION primary + legacy RALPH_NO_ATTRIBUTION)
     // verbatim, for both self_improve and grow_project.
     for (const name of ["self_improve", "grow_project"]) {
         const session = makeFakeSession();
@@ -1642,6 +1653,7 @@ test("the prompt actually fired through armLoop carries both Co-authored-by trai
         assert.ok(sent.includes(BAKED_COPILOT_TRAILER), `${name} sent prompt must carry the Copilot trailer`);
         assert.ok(sent.includes(BAKED_RALPH_TRAILER), `${name} sent prompt must carry the copilot-ralph trailer`);
         assert.ok(sent.includes(BAKED_ATTRIBUTION_OPT_OUT), `${name} sent prompt must mention ${BAKED_ATTRIBUTION_OPT_OUT}`);
+        assert.ok(sent.includes(BAKED_ATTRIBUTION_OPT_OUT_LEGACY), `${name} sent prompt must mention legacy ${BAKED_ATTRIBUTION_OPT_OUT_LEGACY}`);
     }
 });
 
@@ -4798,14 +4810,16 @@ test("dual Co-authored-by trailers are baked in canonical order: Copilot first, 
     }
 });
 
-test("README documents both Co-authored-by trailers and RALPH_NO_ATTRIBUTION opt-out (issue #1)", () => {
+test("README documents both Co-authored-by trailers and the opt-out env var (issue #1)", () => {
     // The user-facing README "Commit attribution" section is the
     // canonical disclosure surface for issue #1. Pin its presence
     // so a future README rewrite can't quietly drop:
     //   - the "Commit attribution" section heading
     //   - either of the two canonical Co-authored-by trailer lines
     //     (Copilot agent + copilot-ralph bot account)
-    //   - the RALPH_NO_ATTRIBUTION=1 opt-out env var
+    //   - the opt-out env var (primary AUTOPILOT_NO_ATTRIBUTION=1
+    //     OR legacy RALPH_NO_ATTRIBUTION=1; either disclosure
+    //     satisfies the contract while the rename rolls out)
     //   - the public-only-searchability caveat
     //
     // Also pin that the trailer literals in the README match the
@@ -4816,7 +4830,10 @@ test("README documents both Co-authored-by trailers and RALPH_NO_ATTRIBUTION opt
     assert.match(readme, /^## Commit attribution\b/m, "README must have a '## Commit attribution' section");
     assert.ok(readme.includes(BAKED_COPILOT_TRAILER), "README must spell out the canonical Copilot Co-authored-by trailer");
     assert.ok(readme.includes(BAKED_RALPH_TRAILER), "README must spell out the canonical copilot-ralph Co-authored-by trailer");
-    assert.ok(readme.includes(BAKED_ATTRIBUTION_OPT_OUT), `README must document the ${BAKED_ATTRIBUTION_OPT_OUT} opt-out env var`);
+    assert.ok(
+        readme.includes(BAKED_ATTRIBUTION_OPT_OUT) || readme.includes(BAKED_ATTRIBUTION_OPT_OUT_LEGACY),
+        `README must document either the ${BAKED_ATTRIBUTION_OPT_OUT} or legacy ${BAKED_ATTRIBUTION_OPT_OUT_LEGACY} opt-out env var`,
+    );
     // The public-only caveat is a required disclosure per the issue.
     assert.match(readme, /\bpublic[-\s]?repo[-\s]?(commits|only)\b/i, "README must disclose the public-repo-only searchability caveat");
     // Trailer order matters: GitHub's commit UI surfaces the first
@@ -5632,34 +5649,40 @@ function makeCaffeinateSpy({ failSpawn = false, failError = null } = {}) {
     return { calls, children, spawnFn };
 }
 
-async function armWithCaffeinate({ env = {}, platform = "darwin", spawnSpy } = {}) {
+async function armWithCaffeinate({ env = {}, platform = "darwin", spawnSpy, stderr } = {}) {
     const session = makeFakeSession();
+    // Reset per-process legacy-env notice flags so each arm starts
+    // from a clean slate (otherwise the second test that reads the
+    // legacy env var sees a stale "already warned" sentinel).
+    __test__._resetLegacyEnvNotices();
+    const stderrStub = stderr ?? { write() { /* swallow */ } };
     const controller = createRalphController({
         caffeinate: {
             env,
             platform,
             pid: 12345,
             spawnFn: spawnSpy.spawnFn,
+            stderr: stderrStub,
         },
     });
     controller.attach(session);
     const ralph = controller.tools.find((t) => t.name === "ap_loop");
     const armResult = await ralph.handler({ prompt: "go", max_iterations: 3 });
-    return { session, controller, armResult, ralph };
+    return { session, controller, armResult, ralph, stderr: stderrStub };
 }
 
 test("caffeinate: disabled by default — no spawn, no log line", async () => {
     const spy = makeCaffeinateSpy();
     const { session, armResult } = await armWithCaffeinate({ env: {}, spawnSpy: spy });
     assert.equal(armResult.armed, true);
-    assert.equal(spy.calls.length, 0, "must NOT spawn caffeinate when RALPH_CAFFEINATE is unset");
+    assert.equal(spy.calls.length, 0, "must NOT spawn caffeinate when AUTOPILOT_CAFFEINATE is unset");
     assert.equal(session.logs.some((l) => l.includes("caffeinate")), false, "no caffeinate log line when disabled");
 });
 
-test("caffeinate: enabled via RALPH_CAFFEINATE=1 spawns 'caffeinate -i -w <pid>' on darwin", async () => {
+test("caffeinate: enabled via AUTOPILOT_CAFFEINATE=1 spawns 'caffeinate -i -w <pid>' on darwin", async () => {
     const spy = makeCaffeinateSpy();
     const { session } = await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1" },
+        env: { AUTOPILOT_CAFFEINATE: "1" },
         platform: "darwin",
         spawnSpy: spy,
     });
@@ -5671,10 +5694,75 @@ test("caffeinate: enabled via RALPH_CAFFEINATE=1 spawns 'caffeinate -i -w <pid>'
     assert.ok(session.logs.some((l) => /keeping system awake via caffeinate/.test(l)), "must log activation line");
 });
 
+test("caffeinate: enabled via legacy RALPH_CAFFEINATE=1 still works (with deprecation)", async () => {
+    // Legacy env var: still honored as a fallback so existing user
+    // scripts don't break, but a one-line stderr deprecation fires
+    // the first time per process.
+    const spy = makeCaffeinateSpy();
+    const writes = [];
+    const stderr = { write(s) { writes.push(s); } };
+    const { session } = await armWithCaffeinate({
+        env: { RALPH_CAFFEINATE: "1" },
+        platform: "darwin",
+        spawnSpy: spy,
+        stderr,
+    });
+    assert.equal(spy.calls.length, 1, "legacy RALPH_CAFFEINATE=1 must still enable caffeinate");
+    assert.deepEqual(spy.calls[0].args, ["-i", "-w", "12345"]);
+    assert.ok(session.logs.some((l) => /keeping system awake via caffeinate/.test(l)));
+    assert.equal(writes.length, 1, "exactly one stderr deprecation must fire");
+    assert.match(writes[0], /\$RALPH_CAFFEINATE.*deprecated/i);
+    assert.match(writes[0], /\$AUTOPILOT_CAFFEINATE/);
+});
+
+test("caffeinate: AUTOPILOT_CAFFEINATE wins when BOTH primary and legacy are set; no deprecation fires", async () => {
+    // Decision B precedence: when a user has both spellings set
+    // (mid-migration scripts), the primary takes precedence and
+    // the legacy var is ignored — no deprecation noise either.
+    const spy = makeCaffeinateSpy();
+    const writes = [];
+    const stderr = { write(s) { writes.push(s); } };
+    await armWithCaffeinate({
+        env: { AUTOPILOT_CAFFEINATE: "1", RALPH_CAFFEINATE: "0" },
+        platform: "darwin",
+        spawnSpy: spy,
+        stderr,
+    });
+    assert.equal(spy.calls.length, 1, "primary AUTOPILOT_CAFFEINATE=1 must win over legacy RALPH_CAFFEINATE=0");
+    assert.deepEqual(writes, [], "no deprecation should fire when primary is set");
+});
+
+test("caffeinate: legacy-env deprecation fires at most ONCE per process", async () => {
+    // Read the legacy var multiple times in a row; only the first
+    // call should produce the stderr notice.
+    const { isCaffeinateEnabled, _resetLegacyEnvNotices } = __test__;
+    _resetLegacyEnvNotices();
+    const writes = [];
+    const stderr = { write(s) { writes.push(s); } };
+    for (let i = 0; i < 5; i++) {
+        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: "1" }, stderr), true);
+    }
+    assert.equal(writes.length, 1, "deprecation must fire exactly once across repeated reads");
+    assert.match(writes[0], /\$RALPH_CAFFEINATE/);
+});
+
+test("caffeinate: legacy-env deprecation fires at most once for SCOPE too", async () => {
+    const { resolveCaffeinateScope, _resetLegacyEnvNotices } = __test__;
+    _resetLegacyEnvNotices();
+    const writes = [];
+    const stderr = { write(s) { writes.push(s); } };
+    for (let i = 0; i < 5; i++) {
+        assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "idle+display" }, stderr), "idle+display");
+    }
+    assert.equal(writes.length, 1, "deprecation must fire exactly once across repeated reads");
+    assert.match(writes[0], /\$RALPH_CAFFEINATE_SCOPE/);
+    assert.match(writes[0], /\$AUTOPILOT_CAFFEINATE_SCOPE/);
+});
+
 test("caffeinate: scope=idle+display adds -d flag", async () => {
     const spy = makeCaffeinateSpy();
     await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1", RALPH_CAFFEINATE_SCOPE: "idle+display" },
+        env: { AUTOPILOT_CAFFEINATE: "1", AUTOPILOT_CAFFEINATE_SCOPE: "idle+display" },
         platform: "darwin",
         spawnSpy: spy,
     });
@@ -5684,7 +5772,7 @@ test("caffeinate: scope=idle+display adds -d flag", async () => {
 test("caffeinate: invalid scope falls back to idle", async () => {
     const spy = makeCaffeinateSpy();
     await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1", RALPH_CAFFEINATE_SCOPE: "bogus" },
+        env: { AUTOPILOT_CAFFEINATE: "1", AUTOPILOT_CAFFEINATE_SCOPE: "bogus" },
         platform: "darwin",
         spawnSpy: spy,
     });
@@ -5694,7 +5782,7 @@ test("caffeinate: invalid scope falls back to idle", async () => {
 test("caffeinate: child is killed on loop completion", async () => {
     const spy = makeCaffeinateSpy();
     const { session, controller } = await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1" },
+        env: { AUTOPILOT_CAFFEINATE: "1" },
         platform: "darwin",
         spawnSpy: spy,
     });
@@ -5709,7 +5797,7 @@ test("caffeinate: child is killed on loop completion", async () => {
 test("caffeinate: child is killed on ap_stop", async () => {
     const spy = makeCaffeinateSpy();
     const { controller } = await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1" },
+        env: { AUTOPILOT_CAFFEINATE: "1" },
         platform: "darwin",
         spawnSpy: spy,
     });
@@ -5721,7 +5809,7 @@ test("caffeinate: child is killed on ap_stop", async () => {
 test("caffeinate: non-darwin platform is a silent no-op (logged skip, no spawn)", async () => {
     const spy = makeCaffeinateSpy();
     const { session } = await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1" },
+        env: { AUTOPILOT_CAFFEINATE: "1" },
         platform: "linux",
         spawnSpy: spy,
     });
@@ -5732,7 +5820,7 @@ test("caffeinate: non-darwin platform is a silent no-op (logged skip, no spawn)"
 test("caffeinate: spawn throw does not abort the loop", async () => {
     const spy = makeCaffeinateSpy({ failSpawn: true });
     const { session, armResult, controller } = await armWithCaffeinate({
-        env: { RALPH_CAFFEINATE: "1" },
+        env: { AUTOPILOT_CAFFEINATE: "1" },
         platform: "darwin",
         spawnSpy: spy,
     });
@@ -5745,7 +5833,7 @@ test("caffeinate: truthy variants ('true', 'YES', 'on') all enable", async () =>
     for (const val of ["true", "YES", "on", "1"]) {
         const spy = makeCaffeinateSpy();
         await armWithCaffeinate({
-            env: { RALPH_CAFFEINATE: val },
+            env: { AUTOPILOT_CAFFEINATE: val },
             platform: "darwin",
             spawnSpy: spy,
         });
@@ -5757,7 +5845,7 @@ test("caffeinate: falsy values keep it off", async () => {
     for (const val of ["0", "false", "", "no", "off"]) {
         const spy = makeCaffeinateSpy();
         await armWithCaffeinate({
-            env: { RALPH_CAFFEINATE: val },
+            env: { AUTOPILOT_CAFFEINATE: val },
             platform: "darwin",
             spawnSpy: spy,
         });
@@ -10211,73 +10299,88 @@ test("VERB_BY_REASON: max_tokens has explicit entry; neutral exits fall through 
 });
 
 test("isCaffeinateEnabled: case + whitespace tolerant truthy parse (issue #8)", () => {
-    // The helper at extension/handler.mjs:536 lower-cases + trims env
-    // input before checking against the truthy set. Pin the contract
-    // directly so a future refactor swapping in a shared env-parser
-    // can't silently tighten or loosen what counts as "enabled" — the
-    // existing caffeinate end-to-end tests only exercise "1" and would
-    // pass even if the case/whitespace tolerance were dropped.
-    const { isCaffeinateEnabled } = __test__;
+    // The helper lower-cases + trims env input before checking
+    // against the truthy set. Pin the contract directly so a future
+    // refactor swapping in a shared env-parser can't silently
+    // tighten or loosen what counts as "enabled" — the existing
+    // caffeinate end-to-end tests only exercise "1" and would pass
+    // even if the case/whitespace tolerance were dropped.
+    const { isCaffeinateEnabled, _resetLegacyEnvNotices } = __test__;
+    _resetLegacyEnvNotices();
+    // Stub stderr so legacy-env deprecations during this test
+    // don't pollute the tap stream.
+    const stderrStub = { write() { /* swallow */ } };
 
     // Truthy variants — every documented form + capitalisation.
     for (const v of ["1", "true", "yes", "on", "TRUE", "YES", "ON",
         "True", "Yes", "On", "  1  ", "\t1\n", "  true  "]) {
-        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: v }), true,
-            `RALPH_CAFFEINATE=${JSON.stringify(v)} must enable caffeinate`);
+        assert.equal(isCaffeinateEnabled({ AUTOPILOT_CAFFEINATE: v }, stderrStub), true,
+            `AUTOPILOT_CAFFEINATE=${JSON.stringify(v)} must enable caffeinate`);
+        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: v }, stderrStub), true,
+            `legacy RALPH_CAFFEINATE=${JSON.stringify(v)} must still enable caffeinate`);
     }
 
     // Falsy / disabled — anything not in the truthy set, including
     // unset, empty string, and bogus tokens.
     for (const v of [undefined, "", "0", "false", "no", "off", "FALSE",
         "enable", "y", "  ", "1\n2"]) {
-        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: v }), false,
+        assert.equal(isCaffeinateEnabled({ AUTOPILOT_CAFFEINATE: v }, stderrStub), false,
+            `AUTOPILOT_CAFFEINATE=${JSON.stringify(v)} must NOT enable caffeinate`);
+        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: v }, stderrStub), false,
             `RALPH_CAFFEINATE=${JSON.stringify(v)} must NOT enable caffeinate`);
     }
 
     // Defensive: env arg itself absent / non-object → false (no throw).
-    assert.equal(isCaffeinateEnabled(undefined), false, "undefined env must not throw");
-    assert.equal(isCaffeinateEnabled(null), false, "null env must not throw");
-    assert.equal(isCaffeinateEnabled({}), false, "empty env must default to disabled");
+    assert.equal(isCaffeinateEnabled(undefined, stderrStub), false, "undefined env must not throw");
+    assert.equal(isCaffeinateEnabled(null, stderrStub), false, "null env must not throw");
+    assert.equal(isCaffeinateEnabled({}, stderrStub), false, "empty env must default to disabled");
 
     // Non-string values must NOT enable — protects against e.g.
-    // RALPH_CAFFEINATE=true (boolean) sneaking in via a wrapper.
+    // AUTOPILOT_CAFFEINATE=true (boolean) sneaking in via a wrapper.
     for (const v of [true, 1, {}, []]) {
-        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: v }), false,
+        assert.equal(isCaffeinateEnabled({ AUTOPILOT_CAFFEINATE: v }, stderrStub), false,
+            `AUTOPILOT_CAFFEINATE=${typeof v} (non-string) must NOT enable caffeinate`);
+        assert.equal(isCaffeinateEnabled({ RALPH_CAFFEINATE: v }, stderrStub), false,
             `RALPH_CAFFEINATE=${typeof v} (non-string) must NOT enable caffeinate`);
     }
 });
 
 test("resolveCaffeinateScope: case + whitespace tolerant; bogus → idle (issue #8)", () => {
-    const { resolveCaffeinateScope } = __test__;
+    const { resolveCaffeinateScope, _resetLegacyEnvNotices } = __test__;
+    _resetLegacyEnvNotices();
+    const stderrStub = { write() { /* swallow */ } };
 
     // Default (env unset / absent) → "idle".
-    assert.equal(resolveCaffeinateScope({}), "idle");
-    assert.equal(resolveCaffeinateScope(undefined), "idle");
-    assert.equal(resolveCaffeinateScope(null), "idle");
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: undefined }), "idle");
+    assert.equal(resolveCaffeinateScope({}, stderrStub), "idle");
+    assert.equal(resolveCaffeinateScope(undefined, stderrStub), "idle");
+    assert.equal(resolveCaffeinateScope(null, stderrStub), "idle");
+    assert.equal(resolveCaffeinateScope({ AUTOPILOT_CAFFEINATE_SCOPE: undefined }, stderrStub), "idle");
+    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: undefined }, stderrStub), "idle");
 
-    // Explicit "idle" passes through.
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "idle" }), "idle");
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "IDLE" }), "idle");
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "  idle  " }), "idle");
+    // Explicit "idle" passes through (both env-var spellings).
+    for (const k of ["AUTOPILOT_CAFFEINATE_SCOPE", "RALPH_CAFFEINATE_SCOPE"]) {
+        assert.equal(resolveCaffeinateScope({ [k]: "idle" }, stderrStub), "idle");
+        assert.equal(resolveCaffeinateScope({ [k]: "IDLE" }, stderrStub), "idle");
+        assert.equal(resolveCaffeinateScope({ [k]: "  idle  " }, stderrStub), "idle");
 
-    // "idle+display" — the only other documented scope.
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "idle+display" }), "idle+display");
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "IDLE+DISPLAY" }), "idle+display");
-    assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: "  Idle+Display  " }), "idle+display");
+        // "idle+display" — the only other documented scope.
+        assert.equal(resolveCaffeinateScope({ [k]: "idle+display" }, stderrStub), "idle+display");
+        assert.equal(resolveCaffeinateScope({ [k]: "IDLE+DISPLAY" }, stderrStub), "idle+display");
+        assert.equal(resolveCaffeinateScope({ [k]: "  Idle+Display  " }, stderrStub), "idle+display");
 
-    // Bogus values fall back to "idle" (safe default — keep the loop
-    // on rather than failing arm-time over a typo).
-    for (const v of ["display", "always", "idle+", "+display", "true",
-        "1", "", "  ", "\n"]) {
-        assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: v }), "idle",
-            `bogus scope ${JSON.stringify(v)} must collapse to "idle"`);
-    }
+        // Bogus values fall back to "idle" (safe default — keep the loop
+        // on rather than failing arm-time over a typo).
+        for (const v of ["display", "always", "idle+", "+display", "true",
+            "1", "", "  ", "\n"]) {
+            assert.equal(resolveCaffeinateScope({ [k]: v }, stderrStub), "idle",
+                `${k}=${JSON.stringify(v)} must collapse to "idle"`);
+        }
 
-    // Non-string → "idle".
-    for (const v of [true, 1, {}, []]) {
-        assert.equal(resolveCaffeinateScope({ RALPH_CAFFEINATE_SCOPE: v }), "idle",
-            `non-string scope ${typeof v} must collapse to "idle"`);
+        // Non-string → "idle".
+        for (const v of [true, 1, {}, []]) {
+            assert.equal(resolveCaffeinateScope({ [k]: v }, stderrStub), "idle",
+                `${k}=${typeof v} (non-string) must collapse to "idle"`);
+        }
     }
 });
 


### PR DESCRIPTION
## Summary

Stage 4 of the multi-stage rename in #49. Flips the `extension/handler.mjs`
runtime to prefer `AUTOPILOT_*` env vars, falling back to the legacy
`RALPH_*` spellings with a one-line stderr deprecation on first fallback
per process.

## Changes

- `extension/handler.mjs`
  - `BAKED_ATTRIBUTION_OPT_OUT` value flipped from `RALPH_NO_ATTRIBUTION=1`
    to `AUTOPILOT_NO_ATTRIBUTION=1`; constant NAME preserved so the
    `__test__` exports remain stable. Renamed the companion
    `_OPT_OUT_PRIMARY` constant to `_OPT_OUT_LEGACY` (now holds the
    RALPH_* spelling); the load-time validator continues to assert
    both literals are baked into every loop prompt.
  - `isCaffeinateEnabled` / `resolveCaffeinateScope`: prefer
    `$AUTOPILOT_CAFFEINATE` / `$AUTOPILOT_CAFFEINATE_SCOPE`; fall back
    to the legacy `$RALPH_*` spellings with a single per-process
    stderr deprecation via a new `_warnLegacyEnvOnce` helper. `stderr`
    is plumbed through `caffeinateDeps` so tests can stub it.
  - Comment cleanups: `~/.copilot/extensions/ralph/` ->
    `autopilot/` install path; `RALPH_CAFFEINATE` doc block
    flipped to AUTOPILOT_*; ap_loop description Note line; events
    default-emitter comment.

- `extension/extension.mjs`
  - `// Extension: ralph` -> `// Extension: autopilot`.
  - Boot-failure stderr `ralph extension:` -> `autopilot extension:`.

- `extension/prompts.mjs`
  - File-header comments switched `ralph-tui run` -> `autopilot run`.

- `test/extension.test.mjs`
  - Canonical-source / prompt-body / armLoop pin tests assert BOTH
    primary and legacy env-var spellings are baked into every loop
    prompt.
  - `isCaffeinateEnabled` / `resolveCaffeinateScope` unit tests
    parametrise over both spellings.
  - Caffeinate end-to-end tests migrated to `AUTOPILOT_CAFFEINATE`;
    new tests cover the legacy-fallback fires-once-per-process
    contract for both `RALPH_CAFFEINATE` and `RALPH_CAFFEINATE_SCOPE`,
    and that the primary spelling wins with no deprecation noise
    when both are set.
  - README test relaxed to accept either spelling while the README
    rewrite catches up in a later stage.

## Test plan

- [x] `npm test` — 925 passing (one pre-existing `bin where:` failure
  in the TUI package is unrelated and outside this unit's scope)
- [x] `npm run check` — clean
- [x] `_warnLegacyEnvOnce` deprecation fires exactly once per process
  per legacy var (covered by new tests)
- [x] Existing baked-prompt invariants enforced at module load

Refs #49.