### PR TITLE
docs: rename ralph-tui → autopilot in root README + add no-arg default note (refs #65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # copilot-ralph-extension
 
-> Ralph Wiggum-style autonomous iterative loop for **GitHub Copilot CLI**, packaged as the `ralph-tui` standalone TUI app.
+> Ralph Wiggum-style autonomous iterative loop for **GitHub Copilot CLI**, packaged as the `autopilot` standalone TUI app.
 
 [![CI](https://github.com/kloba/autopilot/actions/workflows/ci.yml/badge.svg)](https://github.com/kloba/autopilot/actions/workflows/ci.yml)
 [![Inspired by](https://img.shields.io/badge/inspired_by-Anthropic_Ralph_Wiggum-blue)](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum)
@@ -11,7 +11,7 @@
 
 Ralph Wiggum is an iterative-agent technique: re-feed the same prompt to a coding agent in a loop until it emits a "completion promise" (e.g. `COMPLETE`) or hits an iteration cap. Originally a Claude Code plugin by Anthropic.
 
-This project ships **`ralph-tui`** — a terminal app that drives the Copilot CLI in a Ralph loop by spawning each iteration as a fresh `copilot -p ...` subprocess and tailing the JSONL event stream live. Three baked SDLC prompts (`--prompt` / `--self-improve` / `--grow-project`) cover the common shapes; pause / resume / stop / status are out-of-band against a per-run state file so a long run can be checkpointed without losing context.
+This project ships **`autopilot`** — a terminal app that drives the Copilot CLI in a Ralph loop by spawning each iteration as a fresh `copilot -p ...` subprocess and tailing the JSONL event stream live. Three baked SDLC prompts (`--prompt` / `--self-improve` / `--grow-project`) cover the common shapes; pause / resume / stop / status are out-of-band against a per-run state file so a long run can be checkpointed without losing context.
 
 > **Migrating from an older install?** The previous in-session Copilot CLI extension (`ralph_loop` / `self_improve` / `grow_project` / `ralph_status` / `ralph_pause` / `ralph_resume` / `ralph_stop` tools, installed at `~/.copilot/extensions/ralph`) was retired. If you still have `~/.copilot/extensions/ralph` from an older install, `rm -rf ~/.copilot/extensions/ralph` and switch to the TUI driver below. See [`CHANGELOG.md`](CHANGELOG.md) for the full migration note.
 
@@ -28,7 +28,9 @@ node packages/tui/bin/tui.mjs --help
 cd packages/tui && npm install
 ```
 
-A future release will publish `ralph-tui` to npm so `npm i -g ralph-tui` works; until then the source checkout above is the supported install path.
+A future release will publish `autopilot` to npm so `npm i -g autopilot` works; until then the source checkout above is the supported install path.
+
+Bare `autopilot` (no subcommand) starts a self-improve loop with `--fresh` context, equivalent to `autopilot run --self-improve --fresh`.
 
 ## Usage
 
@@ -41,7 +43,7 @@ node packages/tui/bin/tui.mjs run --self-improve --continue --max 50
 
 # Grow the project backlog with a focus area, fresh context per iter.
 node packages/tui/bin/tui.mjs run --grow-project --fresh \
-  --focus "ralph-tui replay UX" --max 30
+  --focus "autopilot replay UX" --max 30
 
 # Custom prompt mode — re-fed verbatim every iter until COMPLETE.
 node packages/tui/bin/tui.mjs run \
@@ -54,39 +56,39 @@ Pick exactly one prompt mode (`--self-improve` / `--grow-project` / `--prompt ".
 * `--continue` captures the terminal `result.sessionId` from the JSONL stream on iter 1 and resumes via `--resume=<sessionId>` on iter 2+ so the agent's context grows monotonically.
 * `--fresh` re-spawns with no session reuse — every iteration starts from a clean slate.
 
-Events flow into `~/.copilot/ralph-tui/runs/<runId>/events.jsonl`. Use `ralph-tui list / replay / watch / stats / doctor / prune` to inspect them.
+Events flow into `~/.copilot/ralph-tui/runs/<runId>/events.jsonl`. Use `autopilot list / replay / watch / stats / doctor / prune` to inspect them.
 
 `SIGINT` / `SIGTERM` at the driver process flips `stopRequested=true` via the run's lock-protected state file; the in-flight Copilot child is allowed to exit naturally before the driver emits the terminal `abort` event with `reason: "user_stopped"`.
 
 ## Subcommands
 
 ```text
-ralph-tui list [--json] [--limit N]   Show recorded runs (newest first).
-ralph-tui replay <runId>              Print every event in a past run.
-ralph-tui watch [runId] [--plain]     Tail the given run (or the most
+autopilot list [--json] [--limit N]   Show recorded runs (newest first).
+autopilot replay <runId>              Print every event in a past run.
+autopilot watch [runId] [--plain]     Tail the given run (or the most
                                       recent one) in real time.
-ralph-tui doctor                      Diagnose the runs directory.
-ralph-tui prune [--older-than 30d]    Remove runs older than DURATION.
+autopilot doctor                      Diagnose the runs directory.
+autopilot prune [--older-than 30d]    Remove runs older than DURATION.
         [--dry-run]
-ralph-tui stats                       Aggregate stats across runs.
-ralph-tui where                       Print the resolved runs root.
-ralph-tui run …                       Drive an autonomous Copilot loop
+autopilot stats                       Aggregate stats across runs.
+autopilot where                       Print the resolved runs root.
+autopilot run …                       Drive an autonomous Copilot loop
                                       (see Usage above).
-ralph-tui --help     | -h
-ralph-tui --version  | -V
+autopilot --help     | -h
+autopilot --version  | -V
 ```
 
 `--plain` is **auto-enabled when stdout is not a TTY** so CI logs and `asciinema rec` outputs stay grep-friendly and ANSI-free.
 
 ## Self-improve
 
-`ralph-tui run --self-improve` drives a baked, **project-agnostic SDLC** prompt (`PROMPT_SELF_IMPROVE` in [`packages/tui/src/prompts.mjs`](packages/tui/src/prompts.mjs)). Each iteration walks the agent through nine stages: **ORIENT** (read recent commits + project docs, detect the test command) → **IDEATE** (pick ONE concrete change, prioritising red CI → stale open PR → open human-filed issue → rotating SDLC hardening) → **CRITIQUE** → **BASELINE** → **IMPLEMENT** → **TEST** → **COMMIT** (conventional-commit prefix + dual `Co-authored-by` trailers) → **PUSH** → **END** (emit `COMPLETE` or `ABORT_NO_IMPROVEMENTS`).
+`autopilot run --self-improve` drives a baked, **project-agnostic SDLC** prompt (`PROMPT_SELF_IMPROVE` in [`packages/tui/src/prompts.mjs`](packages/tui/src/prompts.mjs)). Each iteration walks the agent through nine stages: **ORIENT** (read recent commits + project docs, detect the test command) → **IDEATE** (pick ONE concrete change, prioritising red CI → stale open PR → open human-filed issue → rotating SDLC hardening) → **CRITIQUE** → **BASELINE** → **IMPLEMENT** → **TEST** → **COMMIT** (conventional-commit prefix + dual `Co-authored-by` trailers) → **PUSH** → **END** (emit `COMPLETE` or `ABORT_NO_IMPROVEMENTS`).
 
 Use it on **any repo** to drive an autonomous improvement loop without writing the prompt yourself. Default `--max` is 1000 (effectively unbounded — the loop is scope-driven via the `ABORT_NO_IMPROVEMENTS` token rather than iter-driven).
 
 ## Grow-project
 
-`ralph-tui run --grow-project` drives a parallel SDLC prompt that *grows* a codebase. On the first iteration it ideates a backlog of small, well-scoped features and persists them as **GitHub issues** (`gh issue create --label grow-project --label proposed`); subsequent iterations each pick one proposed issue, implement it, and close it. The per-feature completion gate is **three-part**: (a) tests stay green, (b) every checkbox in the issue's `acceptance_criteria` block passes, (c) the issue's `demo_command` is executed and its output is pasted back as a comment.
+`autopilot run --grow-project` drives a parallel SDLC prompt that *grows* a codebase. On the first iteration it ideates a backlog of small, well-scoped features and persists them as **GitHub issues** (`gh issue create --label grow-project --label proposed`); subsequent iterations each pick one proposed issue, implement it, and close it. The per-feature completion gate is **three-part**: (a) tests stay green, (b) every checkbox in the issue's `acceptance_criteria` block passes, (c) the issue's `demo_command` is executed and its output is pasted back as a comment.
 
 Each iteration walks through thirteen stages: **ORIENT** → **IDEATE** (only on iter 1 with empty backlog) → **SELECT** → **CRITIQUE** → **BASELINE** → **IMPLEMENT** → **TEST** → **ACCEPTANCE** → **DEMO** → **COMMIT** (with `Closes #N`) → **PUSH** → **CLOSE** → **END** (`COMPLETE`, or `ABORT_NO_BACKLOG` when no ready issues remain).
 
@@ -97,10 +99,10 @@ Each iteration walks through thirteen stages: **ORIENT** → **IDEATE** (only on
 Long autonomous runs sometimes need a manual checkpoint — to read a diff, run tests by hand, fix something, then continue. The TUI driver exposes pause / resume / stop / status as out-of-band flags against the run's state file:
 
 ```bash
-ralph-tui run --pause   <runId>     # pause at next iter boundary
-ralph-tui run --resume  <runId>     # resume a paused run
-ralph-tui run --stop    <runId>     # request graceful stop
-ralph-tui run --status  <runId>     # snapshot of run state
+autopilot run --pause   <runId>     # pause at next iter boundary
+autopilot run --resume  <runId>     # resume a paused run
+autopilot run --stop    <runId>     # request graceful stop
+autopilot run --status  <runId>     # snapshot of run state
 ```
 
 The currently-running iteration finishes normally; subsequent iters are short-circuited until `--resume`. State writes are CAS-protected via a per-state-file lockfile so concurrent `--pause` + `--stop` do not lose updates.
@@ -125,7 +127,7 @@ The first identifies the agent. The second attributes the commit to a dedicated 
 Set `RALPH_NO_ATTRIBUTION=1` in the environment before running the loop to suppress the second `copilot-ralph` trailer. The first `Copilot` trailer still ships, since it identifies the agent that made the change. The opt-out is **honored by the prompt** — the agent reads the env var during the COMMIT stage and omits the trailer accordingly.
 
 ```bash
-RALPH_NO_ATTRIBUTION=1 ralph-tui run --self-improve --fresh
+RALPH_NO_ATTRIBUTION=1 autopilot run --self-improve --fresh
 ```
 
 ### Caveats
@@ -135,7 +137,7 @@ RALPH_NO_ATTRIBUTION=1 ralph-tui run --self-improve --fresh
 
 ## Keep system awake (`caffeinate`, macOS)
 
-Long `ralph-tui run` loops can outlast macOS's idle-sleep timeout. The runner does not spawn `caffeinate` itself; the simplest workaround is to wrap the call:
+Long `autopilot run` loops can outlast macOS's idle-sleep timeout. The runner does not spawn `caffeinate` itself; the simplest workaround is to wrap the call:
 
 ```bash
 caffeinate -i node packages/tui/bin/tui.mjs run --self-improve --fresh


### PR DESCRIPTION
## Summary

Unit 2 of issue #65 — root `README.md` docs sweep.

- Replace every literal `ralph-tui` (binary name) in the root README with `autopilot`, including prose, the code-fenced subcommand listing, and inline backticked usage examples.
- Add a one-line note in the install section: bare `autopilot` (no subcommand) starts a self-improve loop with `--fresh` context, equivalent to `autopilot run --self-improve --fresh`. Placed right after the install snippet so new users see the zero-arg default before scrolling into Usage.
- Out-of-scope strings owned by #49 are left verbatim: filesystem path `~/.copilot/ralph-tui/runs`, env var `RALPH_NO_ATTRIBUTION`, env var `RALPH_TUI_COPILOT_BIN`, package name `copilot-ralph-extension`, the upstream `ralph-wiggum` plugin link, and the `#what-is-ralph-wiggum` heading anchor.

Refs #65.

## Test plan

- [x] `grep -n "ralph-tui" README.md` returns only the `~/.copilot/ralph-tui/runs/` filesystem path (owned by #49).
- [x] `npm test` from repo root: 458 tests, 0 failures.
- [x] No browser/UI/server e2e — pure prose change.

Co-authored-by: Copilot <copilot@github.com>
Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>