### PR TITLE
docs: rename ralph-tui → autopilot in contributor docs (refs #65)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Given a version `MAJOR.MINOR.PATCH`:
 
 | Bump  | Trigger                                                                                  |
 | ----- | ---------------------------------------------------------------------------------------- |
-| MAJOR | Breaking change in the `ralph-tui` CLI surface, the JSONL event contract, or env-var names. |
+| MAJOR | Breaking change in the `autopilot` CLI surface, the JSONL event contract, or env-var names. |
 | MINOR | New subcommand, new flag, new capability, or any backwards-compatible feature.           |
 | PATCH | Bug fix, prompt tweak, doc-only change to runtime behavior, internal refactor.           |
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,7 +16,7 @@ The repository has **zero npm runtime dependencies** for the non-render layer (`
 cd packages/tui && npm install   # pulls Ink + React + Yoga + Commander
 ```
 
-## Running ralph-tui locally
+## Running autopilot locally
 
 For day-to-day iteration:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-`copilot-ralph-extension` ships as the `ralph-tui` standalone TUI app. There is **no npm publish** today; releases are tagged commits on `main` plus an annotated GitHub Release page. The auto-attached source zipball / tarball is the canonical download.
+`copilot-ralph-extension` ships as the `autopilot` standalone TUI app. There is **no npm publish** today; releases are tagged commits on `main` plus an annotated GitHub Release page. The auto-attached source zipball / tarball is the canonical download.
 
 A tag-driven release-automation workflow ships at [`.github/workflows/release.yml`](../.github/workflows/release.yml) (see issue [#10](https://github.com/kloba/autopilot/issues/10) for the rationale). Pushing a `vX.Y.Z` tag verifies `package.json` matches the tag, asserts a matching `CHANGELOG.md` section exists, runs `npm test` + `npm run check`, and creates the GitHub Release with the matching changelog section as the body. The manual checklist below is the fallback when the workflow is unavailable or you need to cut a release out-of-band.
 
@@ -32,7 +32,7 @@ A tag-driven release-automation workflow ships at [`.github/workflows/release.ym
 
 We follow **Semantic Versioning**:
 
-- **MAJOR** — breaking change to the `ralph-tui` CLI surface (renamed/removed subcommand or flag, removed env var, changed JSONL event shape).
+- **MAJOR** — breaking change to the `autopilot` CLI surface (renamed/removed subcommand or flag, removed env var, changed JSONL event shape).
 - **MINOR** — new subcommand, new flag, new opt-in feature.
 - **PATCH** — bug fix, doc-only change, internal refactor with no user-visible behavior change.
 
@@ -49,7 +49,7 @@ git checkout vX.Y.Z
 node packages/tui/bin/tui.mjs --help
 ```
 
-A future release will publish `ralph-tui` to npm so `npm i -g ralph-tui@X.Y.Z` works; until then the source checkout above is the supported install path.
+A future release will publish `autopilot` to npm so `npm i -g autopilot@X.Y.Z` works; until then the source checkout above is the supported install path.
 
 ## Hotfix branches
 


### PR DESCRIPTION
## Summary
- Flip the binary-name hyphen form `ralph-tui` → `autopilot` across the contributor trio: `docs/RELEASING.md` (3 hits), `docs/CONTRIBUTING.md` (1 hit), `AGENTS.md` (1 hit).
- Scope-limited per issue #65 / Unit 6: tool-registration names (`ralph_loop` etc.), env vars (`RALPH_*`), filesystem paths (`~/.copilot/ralph-tui/runs`), `bin/tui.mjs`, the `copilot-ralph-extension` package name, and the `copilot-ralph` co-author trailer are deliberately untouched — those belong to issue #49.

Refs #65.

## Test plan
- [x] `grep -n "ralph-tui" docs/RELEASING.md docs/CONTRIBUTING.md AGENTS.md | grep -v "ralph-tui-fresh.sh"` returns zero hits
- [x] `npm test` green (392 pass, 0 fail, 66 skipped)

Co-authored-by: Copilot <copilot@github.com>
Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>