### PR TITLE
docs: rename ralph-tui → autopilot in MkDocs entry pages (refs #65)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,13 @@
 # Ralph
 
-A Ralph Wiggum-style autonomous loop for the GitHub Copilot CLI, packaged as the `ralph-tui` standalone TUI app.
+A Ralph Wiggum-style autonomous loop for the GitHub Copilot CLI, packaged as the `autopilot` standalone TUI app.
 
 !!! warning "Stub documentation site"
     This site is the v0 scaffold for [issue #2](https://github.com/kloba/autopilot/issues/2). The pages below mirror the planned navigation but are intentionally short — they will be filled in by follow-up PRs.
 
 ## What is this?
 
-Ralph turns the Copilot CLI into a self-driving iteration engine. You arm it with a prompt (or pick one of the baked SDLC modes — `--self-improve`, `--grow-project`), and the driver re-spawns `copilot -p ...` every iteration until either the agent emits a "done" phrase, you call `ralph-tui run --stop`, or a hard cap is reached.
+Ralph turns the Copilot CLI into a self-driving iteration engine. You arm it with a prompt (or pick one of the baked SDLC modes — `--self-improve`, `--grow-project`), and the driver re-spawns `copilot -p ...` every iteration until either the agent emits a "done" phrase, you call `autopilot run --stop`, or a hard cap is reached.
 
 See the [Quickstart](quickstart.md) to get going in under a minute.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -24,7 +24,7 @@ cd packages/tui && npm install
 node packages/tui/bin/tui.mjs run --self-improve --fresh --max 50
 
 # Grow the project backlog with a focus area.
-node packages/tui/bin/tui.mjs run --grow-project --fresh --focus "ralph-tui replay UX"
+node packages/tui/bin/tui.mjs run --grow-project --fresh --focus "autopilot replay UX"
 
 # Custom prompt mode — re-fed verbatim every iter until COMPLETE.
 node packages/tui/bin/tui.mjs run \


### PR DESCRIPTION
## Summary
- Replace literal `ralph-tui` (binary name, hyphen form) with `autopilot` in `docs/index.md` (2 hits) and `docs/quickstart.md` (1 hit).
- Out-of-scope items (underscore tool names, `RALPH_*` env vars, fs paths, `scripts/ralph-tui-fresh.sh`) intentionally left alone — those belong to issue #49.

Refs #65 (Unit 7 of the ralph-tui → autopilot binary rename).

## Test plan
- [x] `grep -n "ralph-tui" docs/index.md docs/quickstart.md | grep -v "ralph-tui-fresh.sh"` returns zero hits
- [x] `npm test` green (392 pass, 66 skipped, 0 fail)