### PR TITLE
docs: rename ralph-tui → autopilot in faq + concepts (refs #65)

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -5,14 +5,14 @@
 
 Topics planned:
 
-- The arming → subprocess-per-iter model used by `ralph-tui run`
+- The arming → subprocess-per-iter model used by `autopilot run`
 - Completion / abort / stagnation finish reasons
 - Pause / resume semantics
 - Adaptive iteration budget
 
 ## Pause / resume semantics
 
-`ralph-tui run --pause <runId>` and `ralph-tui run --resume <runId>` let you stop the next iteration from firing without losing the iteration counter or the captured Copilot session id (in `--continue` mode). The currently-running `copilot -p` subprocess is **never killed mid-iter** — the driver waits for it to finish naturally before honoring the pause flag at the next iter boundary.
+`autopilot run --pause <runId>` and `autopilot run --resume <runId>` let you stop the next iteration from firing without losing the iteration counter or the captured Copilot session id (in `--continue` mode). The currently-running `copilot -p` subprocess is **never killed mid-iter** — the driver waits for it to finish naturally before honoring the pause flag at the next iter boundary.
 
 State writes are CAS-protected via a per-run lockfile so a concurrent `--pause` + `--stop` from two terminals do not lose updates.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -17,11 +17,11 @@ git checkout vX.Y.Z
 node packages/tui/bin/tui.mjs --help
 ```
 
-Tags are immutable, so a pinned checkout never silently shifts. A future release will publish `ralph-tui` to npm so `npm i -g ralph-tui@X.Y.Z` works.
+Tags are immutable, so a pinned checkout never silently shifts. A future release will publish `autopilot` to npm so `npm i -g autopilot@X.Y.Z` works.
 
 ### What happened to the `~/.copilot/extensions/ralph` install?
 
-The previous in-session Copilot CLI extension was retired — see [`CHANGELOG.md`](../CHANGELOG.md). If you still have `~/.copilot/extensions/ralph` from an older install, `rm -rf ~/.copilot/extensions/ralph` and switch to `ralph-tui run` as documented in the [README](../README.md#usage).
+The previous in-session Copilot CLI extension was retired — see [`CHANGELOG.md`](../CHANGELOG.md). If you still have `~/.copilot/extensions/ralph` from an older install, `rm -rf ~/.copilot/extensions/ralph` and switch to `autopilot run` as documented in the [README](../README.md#usage).
 
 ## Running a loop
 
@@ -39,7 +39,7 @@ Three frequent causes:
 
 ### How do I stop a loop that's running away?
 
-Run `ralph-tui run --stop <runId>` from another terminal — it sets `stopRequested` in `state.json`. The currently-running iteration finishes normally; the driver emits a terminal `abort` event with `reason: "user_stopped"` afterwards. `SIGINT` / `SIGTERM` at the driver process flips the same flag.
+Run `autopilot run --stop <runId>` from another terminal — it sets `stopRequested` in `state.json`. The currently-running iteration finishes normally; the driver emits a terminal `abort` event with `reason: "user_stopped"` afterwards. `SIGINT` / `SIGTERM` at the driver process flips the same flag.
 
 ### Pause / resume — what's the difference vs stop?
 
@@ -58,16 +58,16 @@ By default: `~/.copilot/ralph-tui/runs/<runId>/events.jsonl`. Override the runs 
 ### How do I tail a running loop's events?
 
 ```bash
-ralph-tui watch              # tail the most recent run
-ralph-tui watch <runId>      # tail a specific run
-ralph-tui list               # enumerate recorded runs newest-first
-ralph-tui replay <runId>     # print every event in a past run
+autopilot watch              # tail the most recent run
+autopilot watch <runId>      # tail a specific run
+autopilot list               # enumerate recorded runs newest-first
+autopilot replay <runId>     # print every event in a past run
 ```
 
 ### How do I get a structured snapshot of a live run?
 
 ```bash
-ralph-tui run --status <runId>
+autopilot run --status <runId>
 ```
 
 Reads the run's `state.json` and renders iter counter, pause/stop flags, and (in `--continue` mode) the captured Copilot session id.


### PR DESCRIPTION
## Summary
- Replaces every literal `ralph-tui` (HYPHEN binary name) with `autopilot` in `docs/faq.md` and `docs/concepts.md`.
- Leaves out-of-scope identifiers untouched: `RALPH_*` env vars, the `~/.copilot/ralph-tui/runs/` filesystem path (owned by issue #49), underscore-form tool names, the `copilot-ralph` co-author trailer, and the `ralph-tui-fresh.sh` script filename.

Refs #65 (Unit 5 of binary rename: docs sweep — faq + concepts).

## Test plan
- [x] `grep -n "ralph-tui" docs/faq.md docs/concepts.md | grep -v "ralph-tui-fresh.sh"` returns only the in-scope-excluded `~/.copilot/ralph-tui/runs/` filesystem path on faq.md:56
- [x] `npm test` — 458 tests, 392 pass, 66 skipped, 0 fail