### PR TITLE
chore(scripts): update ralph-tui-fresh.sh banner strings to autopilot (refs #65)

### DIFF
--- a/scripts/ralph-tui-fresh.sh
+++ b/scripts/ralph-tui-fresh.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # scripts/ralph-tui-fresh.sh — wrapper for `node packages/tui/bin/tui.mjs`
 # that runs `git pull --quiet --ff-only` from the repo root immediately
-# before a `ralph-tui run` invocation, so each long-haul out-of-session
+# before an `autopilot run` invocation, so each long-haul out-of-session
 # loop starts on the latest source.
 #
 # Why this is safe:
-#   * `ralph-tui run` runs OUT-OF-SESSION — each iter is a fresh
+#   * `autopilot run` runs OUT-OF-SESSION — each iter is a fresh
 #     `copilot -p ...` subprocess. The TUI binary itself is loaded
 #     into memory once at Node startup, so a `git pull` immediately
 #     before `exec node …/tui.mjs` lands the new source on disk
@@ -14,7 +14,8 @@
 #     graph at process start, so a `git pull` running concurrently
 #     with the loop CANNOT change the running iter's behaviour.
 #
-# Why only `run` upgrades:
+# Why only `run` (and bare invocation) upgrades:
+#   Bare `autopilot` (no args) is a "run" invocation per #65 dispatch.
 #   The other subcommands (`list`, `replay`, `watch`, `doctor`,
 #   `prune`, `stats`, `where`) are millisecond-fast read ops on
 #   local files. Adding a `git pull` to those would make `list`
@@ -27,8 +28,8 @@
 #   `--ff-only` deliberately refuses to clobber local work-in-progress.
 #
 # Usage:
-#   alias ralph-tui="$PWD/scripts/ralph-tui-fresh.sh"   # in ~/.zshrc
-#   ralph-tui run --self-improve --continue
+#   alias autopilot="$PWD/scripts/ralph-tui-fresh.sh"   # in ~/.zshrc
+#   autopilot run --self-improve --continue
 #
 set -euo pipefail
 
@@ -38,7 +39,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # `exec node` below preserves it (the TUI's `run` subcommand spawns
 # `copilot -p` subprocesses that inherit cwd from the user, NOT this
 # wrapper's repo root).
-if [[ "${1:-}" == "run" ]]; then
+if [[ "${1:-}" == "run" || $# -eq 0 ]]; then
     ( cd "$ROOT" && git pull --quiet --ff-only ) 2>/dev/null || true
 fi
 


### PR DESCRIPTION
## Summary

Unit 8 of the `ralph-tui` → `autopilot` binary rename (refs #65).

Flips user-facing references to the binary name from `ralph-tui` to `autopilot` inside `scripts/ralph-tui-fresh.sh`:

- Header comment block describing what the script does
- `Why this is safe` rationale block
- Usage example: `alias autopilot="$PWD/scripts/ralph-tui-fresh.sh"`
- Example invocation: `autopilot run --self-improve --continue`

Also extends the `git pull` guard to fire on bare invocation (`$# -eq 0`), matching the new dispatch where bare `autopilot` (no args) is a "run".

The script's actual exec (`node packages/tui/bin/tui.mjs "$@"`) is unchanged.

## Out of scope

- The script's **filename** (`scripts/ralph-tui-fresh.sh`) stays as-is — filename rename is owned by **#49 (slice C)**.
- All `ralph_*` tool registrations, `RALPH_*` env vars, `~/.copilot/ralph-tui/runs` paths, and the `copilot-ralph` co-author trailer are deferred to **#49**.

## Test plan

- [x] `grep -n "ralph-tui" scripts/ralph-tui-fresh.sh | grep -v "ralph-tui-fresh.sh"` returns zero hits
- [x] `bash -n scripts/ralph-tui-fresh.sh` syntax-checks clean
- [x] `npm test` — 392 pass / 66 skip / 0 fail

Co-authored-by: Copilot <copilot@github.com>
Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>