### PR TITLE
docs(site): real landing page + autopilot site config (mkdocs.yml + index.md)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,19 +1,28 @@
-# Ralph
+# autopilot
 
-A Ralph Wiggum-style autonomous loop for the GitHub Copilot CLI, packaged as the `autopilot` standalone TUI app.
+Autonomous iterative loop for the GitHub Copilot CLI — a standalone TUI that re-feeds the same prompt to `copilot -p ...` until the agent declares completion or a hard cap fires.
 
-!!! warning "Stub documentation site"
-    This site is the v0 scaffold for [issue #2](https://github.com/kloba/autopilot/issues/2). The pages below mirror the planned navigation but are intentionally short — they will be filled in by follow-up PRs.
+## What it is
 
-## What is this?
+`autopilot` is a standalone TUI app that drives the GitHub Copilot CLI through autonomous iteration loops. You arm it with a prompt — or pick one of three baked SDLC modes (`--self-improve`, `--grow-project`, `--prompt`) — and the driver re-spawns `copilot -p ...` every iteration until either the agent emits a configurable completion phrase, you call `autopilot run --stop <runId>`, or `--max` is hit.
 
-Ralph turns the Copilot CLI into a self-driving iteration engine. You arm it with a prompt (or pick one of the baked SDLC modes — `--self-improve`, `--grow-project`), and the driver re-spawns `copilot -p ...` every iteration until either the agent emits a "done" phrase, you call `autopilot run --stop`, or a hard cap is reached.
+Out-of-band control is first-class: `--pause`, `--resume`, `--stop`, and `--status` can all be invoked from a second terminal, write to the run's `state.json` under a CAS-protected lockfile, and never kill an in-flight `copilot -p` subprocess mid-iteration. Plain mode is zero-dep — only Node ≥ 20 is required to drive a loop, tail events, list runs, or replay history. The Ink-rendered watch UI for `autopilot watch` and `autopilot run` adds Ink + React + Yoga + Commander; install it via `cd packages/tui && npm install` when you want the live TTY view.
 
-See the [Quickstart](quickstart.md) to get going in under a minute.
+!!! tip "Bare `autopilot` runs `--self-improve --fresh`"
+    Running the binary with no arguments is the same as `autopilot run --self-improve --fresh`. It starts a fresh self-improvement loop on the current repo against the baked prompt — no flags to remember on the happy path.
 
-## Why "Ralph"?
+## Why a loop?
 
-The loop is the simplest possible form of agentic autonomy: one prompt, repeated, until done. Like Ralph Wiggum eating glue — single-minded, persistent, surprisingly effective.
+The technique is the simplest possible form of agentic autonomy: keep re-feeding the same prompt until the agent promises it's done. Each iteration is a brand-new `copilot -p` subprocess, so context never poisons the next pass. The driver only owns the spawn / capture / decide-to-stop trichotomy — the Copilot agent does the work. This pattern is sometimes called the **Ralph Wiggum** technique after Anthropic's upstream prompt-loop plugin: single-minded, persistent, surprisingly effective.
+
+Anthropic ships a canonical reference implementation as a Claude Code plugin: see [anthropics/claude-code → plugins/ralph-wiggum](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum). `autopilot` adapts the same loop shape for the GitHub Copilot CLI and adds out-of-band control, structured event logs (`events.jsonl`), CAS-protected run state, completion / abort / stagnation triggers, and an adaptive iteration budget for `--self-improve`.
+
+## Read next
+
+- **[Quickstart](quickstart.md)** — clone, install, drive your first loop in under a minute.
+- **[Concepts](concepts.md)** — completion / abort / stagnation triggers, pause-resume semantics, adaptive budget.
+- **[Recipes](recipes.md)** — refactor-a-module, drain-a-backlog, long-running grow-project patterns.
+- **[FAQ](faq.md)** — the questions that come up most often when running loops in anger.
 
 ## Repository
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-# MkDocs Material configuration for the Ralph documentation site.
+# MkDocs Material configuration for the autopilot documentation site.
 # Tracked in issue #2: https://github.com/kloba/autopilot/issues/2
 #
 # Build locally:
@@ -7,9 +7,9 @@
 #
 # Deploys via .github/workflows/docs.yml on pushes to main.
 
-site_name: Ralph
-site_description: A Ralph Wiggum-style autonomous loop for the GitHub Copilot CLI.
-site_url: https://kloba.github.io/copilot-ralph-extension/
+site_name: autopilot
+site_description: Autonomous iterative loop for the GitHub Copilot CLI.
+site_url: https://kloba.github.io/autopilot/
 repo_url: https://github.com/kloba/autopilot
 repo_name: kloba/autopilot
 edit_uri: edit/main/docs/


### PR DESCRIPTION
## Summary

- Replace the v0 stub admonition on `docs/index.md` with a real landing page: H1 + tagline, "What it is" (1-2 paragraphs covering the standalone TUI, three SDLC modes, out-of-band pause/resume/stop/status, plain-mode zero-dep vs Ink watch UI), "Why a loop?" (Ralph Wiggum technique with link to Anthropic's upstream `anthropics/claude-code/plugins/ralph-wiggum`), and a "Read next" panel linking to Quickstart / Concepts / Recipes / FAQ.
- Update `mkdocs.yml`: `site_name: Ralph` -> `autopilot`, `site_description` -> `Autonomous iterative loop for the GitHub Copilot CLI.`, `site_url` -> `https://kloba.github.io/autopilot/`, header comment -> "autopilot documentation site".
- Theme/features/palette/nav/markdown_extensions blocks unchanged. `repo_url`, `repo_name`, `edit_uri` unchanged.

Refs #65.

## Test plan

- [x] `npm test` -> 446 pass / 0 fail / 68 skipped (514 total)
- [x] `npm run check` -> Syntax-checked 22 .mjs files, no errors
- [x] `mkdocs build` -> succeeds, renders `<title>autopilot</title>`
- [x] `mkdocs build --strict` reproduces the same 19 pre-existing warnings as `origin/main` (cross-doc links to `../README.md`, `../CHANGELOG.md`, `../packages/...`, missing anchor in `concepts.md`) — all in files outside this unit's scope (`ARCHITECTURE.md`, `CONTRIBUTING.md`, `RELEASING.md`, `cli-stack.md`, `concepts.md`, `faq.md`). My new `index.md` and updated `mkdocs.yml` introduce zero new warnings. Other parallel units (3-11) are responsible for those files.