### PR TITLE
docs(quickstart): full quickstart guide for autopilot

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,41 +1,154 @@
 # Quickstart
 
-!!! note "Stub page (issue #2)"
-    Scaffold only — to be expanded in follow-ups.
+A 5-minute on-ramp to your first autopilot loop. By the end you will have the
+`autopilot` binary on your `$PATH`, a self-improve run executing in your repo,
+and a second terminal tailing it live.
+
+## Prerequisites
+
+- **Node.js >= 20.** Check with `node --version`.
+- **GitHub Copilot CLI** on your `$PATH`. Check with `copilot --version`. If
+  the binary is missing, follow the upstream
+  [Copilot CLI install guide](https://github.com/github/gh-copilot) first —
+  autopilot drives `copilot -p ...` once per iteration and cannot start
+  without it.
+- **`git`** (any modern version) — autopilot inspects your working tree to
+  signal progress between iterations.
 
 ## Install
 
 ```bash
-git clone https://github.com/kloba/autopilot
-cd copilot-ralph-extension
-node packages/tui/bin/tui.mjs --help
+git clone https://github.com/kloba/autopilot.git
+cd autopilot
+cd packages/tui && npm install && npm link
+autopilot --help    # confirm install
 ```
 
-For the interactive Ink-rendered watch UI:
+`npm link` symlinks the `autopilot` bin into your global npm prefix so you can
+invoke it from any directory. If you would rather not pollute the global
+prefix, swap `npm link` for `npm install -g .` or skip the linking step and
+call the binary by path: `node packages/tui/bin/tui.mjs ...`.
+
+!!! tip "Plain mode is zero-dep"
+    The `list`, `replay`, `watch --plain`, `doctor`, `prune`, `stats`, and
+    `where` subcommands all run straight from a fresh checkout with no
+    `npm install` — `node packages/tui/bin/tui.mjs <subcommand>` is enough.
+    The `npm install` step is only required for the interactive Ink-rendered
+    TUI used by `autopilot run` (without `--headless` / `--plain`) and
+    `autopilot watch` (without `--plain`).
+
+## Run your first loop
 
 ```bash
-cd packages/tui && npm install
+autopilot          # bare invocation: starts run --self-improve --fresh
 ```
 
-## Drive a loop
+Bare `autopilot` is the canonical drive-the-backlog incantation. It expands
+internally to `autopilot run --self-improve --fresh` and kicks off a
+self-improving iteration loop in the **current working directory** — autopilot
+does not change directories or clone anything; the loop operates on whatever
+repository you cd-ed into. The Ink-rendered TUI mounts as soon as the run is
+armed and shows iter / stage / substage progress, the live event timeline, and
+a backlog-pressure summary.
+
+Press **`q`** to stop gracefully. The currently-running `copilot -p`
+subprocess is never killed mid-turn — the driver waits for it to finish, then
+honors the stop request at the next iter boundary. Hit Ctrl-C twice if you
+need a hard abort.
+
+!!! warning "`--fresh` discards in-flight session context"
+    `--fresh` starts a brand-new Copilot session every iteration, so the agent
+    has no memory of the previous turn beyond what landed on disk (commits,
+    notes, issue updates). Use `--continue` instead if you want the Copilot
+    session id to thread through every iter — but be aware the context window
+    grows monotonically and will eventually cost you a premium request per
+    turn.
+
+## Watch from another terminal
+
+`autopilot run` already shows live progress, but if you want a second view
+(e.g. the run is detached under `nohup`, or you closed the original terminal),
+open a new shell and tail it:
 
 ```bash
-# Drain the existing backlog (red CI → stale PRs → open issues → SDLC).
-node packages/tui/bin/tui.mjs run --self-improve --fresh --max 50
-
-# Grow the project backlog with a focus area.
-node packages/tui/bin/tui.mjs run --grow-project --fresh --focus "autopilot replay UX"
-
-# Custom prompt mode — re-fed verbatim every iter until COMPLETE.
-node packages/tui/bin/tui.mjs run \
-  --prompt "Refactor packages/tui/src/runner.mjs and add tests. Emit COMPLETE when green." \
-  --fresh
+autopilot watch              # tails the latest run
+autopilot watch <runId>      # tails a specific run by id
+autopilot watch --plain      # non-TTY-friendly stream (no Ink, no ANSI)
 ```
 
-Stop early:
+`--plain` is auto-enabled when stdout is not a TTY (CI logs, asciinema
+recordings, piping to `grep` / `tee`), so you rarely need to pass it
+explicitly.
+
+## Where the run lives
+
+Every armed run gets its own directory under the runs root:
+
+```
+~/.copilot/autopilot/runs/<runId>/
+  events.jsonl    # append-only event stream (one JSON object per line)
+  state.json      # per-run pause / stop / status flags + iter counter
+```
+
+A sibling `~/.copilot/autopilot/runs/index.jsonl` carries one row per `armed`
+event so `autopilot list` / `stats` / `prune` can enumerate runs without
+walking every directory.
+
+If you started using autopilot under its previous name (`ralph-tui`), the
+legacy `~/.copilot/ralph-tui/runs` root is still read on first start when it
+exists, with a one-line stderr migration notice. Override either root with
+`AUTOPILOT_RUNS_DIR=/abs/path` (canonical) — the legacy `RALPH_TUI_RUNS_DIR`
+still works as a fallback. Run `autopilot where` to print the resolved root.
+
+## Try the other modes
 
 ```bash
-node packages/tui/bin/tui.mjs run --stop <runId>
+autopilot run --grow-project --focus "TUI replay UX" --fresh --max 10
+autopilot run --prompt "Refactor packages/tui/src/runner.mjs and emit COMPLETE when tests pass." --fresh --max 5
 ```
 
-See the project [README](https://github.com/kloba/autopilot#readme) for the full reference until these pages are filled in.
+- **`--self-improve`** (the default) drains the existing backlog: failing CI
+  runs, stale PRs, open issues, latent improvements. The loop is
+  scope-driven, not iter-driven, so the default `--max` is the runaway-guard
+  ceiling (1000) and the agent self-aborts via `ABORT_NO_IMPROVEMENTS` when
+  the backlog is empty.
+- **`--grow-project`** plans new work and adds backlog items in the focus area
+  given via `--focus TEXT`. Default `--max 100`; aborts via
+  `ABORT_NO_BACKLOG` once the planned items are filed.
+- **`--prompt TEXT`** is the classic Ralph mode: your literal prompt is
+  re-fed verbatim every iteration until the agent emits `COMPLETE` (or your
+  custom `--completion-promise TOKEN`). Default `--max 100`.
+
+`--continue` vs `--fresh` is mandatory — there is no default because the
+context behaviour is too consequential to guess. Pick `--fresh` for cheap,
+deterministic iters; pick `--continue` when the agent genuinely needs a
+multi-turn conversation.
+
+## Stopping a long run
+
+`q` and Ctrl-C only work in the terminal that owns the run. To stop a run
+out-of-band — from any other terminal, a cron job, or a CI cancellation hook
+— use the sibling commands:
+
+```bash
+autopilot run --status <runId>   # peek at iter, paused, stopRequested
+autopilot run --pause <runId>    # gate the next iter without killing the loop
+autopilot run --resume <runId>   # flip pause back off
+autopilot run --stop <runId>     # graceful stop at the next iter boundary
+```
+
+All four operate on the run's `state.json` via a CAS-protected lockfile, so
+concurrent calls from two terminals never lose updates. As with `q`, the
+in-flight `copilot -p` subprocess is allowed to finish its turn before the
+flag is honored.
+
+## Read next
+
+- [Concepts](concepts.md) — the arming model, completion / abort triggers,
+  pause/resume semantics, adaptive iteration budget.
+- [Recipes](recipes.md) — copy-pasteable scenarios (focused refactors, CI
+  triage, scheduled grow-project sweeps).
+- [FAQ](faq.md) — premium-request budgeting, Copilot rate limits, debugging
+  a stuck loop.
+- [ARCHITECTURE](ARCHITECTURE.md) — full event-stream / runs-directory /
+  TUI-mount contract reference.


### PR DESCRIPTION
## Summary

Replaces the issue #2 stub in `docs/quickstart.md` with a copy-pasteable 5-minute on-ramp:

- Prerequisites (Node >= 20, GitHub Copilot CLI on `$PATH`, `git`) with one-line `--version` checks for each.
- Install flow: `git clone` -> `cd packages/tui && npm install && npm link` -> `autopilot --help`.
- Tip-admonition explaining that plain-mode subcommands (`list` / `replay` / `watch --plain` / `doctor` / `prune` / `stats` / `where`) work zero-dep via `node packages/tui/bin/tui.mjs ...` straight from a fresh checkout.
- "Run your first loop" section anchored on bare `autopilot` (the canonical drive-the-backlog incantation that expands to `run --self-improve --fresh`), with the `q` graceful-stop semantics called out and a warning-admonition that `--fresh` discards in-flight Copilot session context.
- "Watch from another terminal" with `autopilot watch [<runId>] [--plain]`.
- "Where the run lives" documenting `~/.copilot/autopilot/runs/<runId>/{events.jsonl,state.json}` plus the parent `index.jsonl`, with a one-line note that the legacy `~/.copilot/ralph-tui/runs` root is still read on first start when it exists. Mentions both canonical (`AUTOPILOT_RUNS_DIR`) and legacy (`RALPH_TUI_RUNS_DIR`) env-var overrides and the `autopilot where` debug command.
- The three run modes side-by-side (`--self-improve` drains backlog, `--grow-project` plans + adds backlog items, `--prompt` is custom) with one-paragraph explainers each.
- "Stopping a long run" covering the out-of-band `run --status` / `--pause` / `--resume` / `--stop <runId>` siblings and how they coexist with the in-terminal `q` keystroke.
- "Read next" linked list pointing to Concepts, Recipes, FAQ, and ARCHITECTURE.

Length: 154 lines (within the 120-180 target).

## Test plan

- [x] `npm install --no-audit --no-fund`
- [x] `npm test` — 514 tests, 446 pass / 68 skipped / 0 fail
- [x] `npm run check` — Syntax-checked 22 .mjs files
- [x] `mkdocs build --strict` — confirmed the 19 pre-existing warnings are unchanged by this PR (all from sibling pages owned by other worker units in the parallel slice plan); my new file introduces zero new warnings, and a non-strict `mkdocs build` renders `quickstart/index.html` cleanly.