### PR TITLE
docs(contributing): rebrand to autopilot

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing
 
-Thanks for your interest in `copilot-ralph-extension`! This page is the entry point for contributors. End-user docs live in the [README](../README.md).
+Thanks for your interest in autopilot! This page is the entry point for contributors. End-user docs live in the [README](../README.md).
 
 ## Local development setup
 
 ```bash
 git clone https://github.com/kloba/autopilot.git
-cd copilot-ralph-extension
+cd autopilot
 npm test    # runs the node:test suite under packages/*/test (no install needed for the non-render layer)
 ```
 
@@ -18,13 +18,20 @@ cd packages/tui && npm install   # pulls Ink + React + Yoga + Commander
 
 ## Running autopilot locally
 
-For day-to-day iteration:
+For day-to-day iteration (after `npm link` puts `autopilot` on your `$PATH`):
 
 ```bash
-# From the repo root, no install needed for plain mode:
-node packages/tui/bin/tui.mjs run --self-improve --fresh --max 5
+# From any directory:
+autopilot run --self-improve --fresh --max 5
 
 # Watch the live timeline in another terminal:
+autopilot watch
+```
+
+If you'd rather not `npm link`, invoke the bin script directly:
+
+```bash
+node packages/tui/bin/tui.mjs run --self-improve --fresh --max 5
 node packages/tui/bin/tui.mjs watch
 ```
 
@@ -42,10 +49,10 @@ Every commit MUST include both `Co-authored-by` trailers in this order:
 
 ```
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
-Co-authored-by: copilot-ralph <noreply+copilot-ralph@github.com>
+Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>
 ```
 
-The first attributes the underlying Copilot model; the second attributes the loop that executed the iteration. Order matters — GitHub surfaces the first co-author more prominently. See the [README "Commit attribution" section](../README.md#commit-attribution) and [CHANGELOG](../CHANGELOG.md) for full rationale and opt-out (`RALPH_NO_ATTRIBUTION=1`).
+The first attributes the underlying Copilot model; the second attributes the loop that executed the iteration. Order matters — GitHub surfaces the first co-author more prominently. See the [README "Commit attribution" section](../README.md#commit-attribution) and [CHANGELOG](../CHANGELOG.md) for full rationale and opt-out (`AUTOPILOT_NO_ATTRIBUTION=1`, with legacy `RALPH_NO_ATTRIBUTION=1` still recognized as fallback).
 
 ## Pull request expectations
 


### PR DESCRIPTION
## Summary

Sweeps `docs/CONTRIBUTING.md` for the autopilot rebrand. No code changes; doc-only.

- `copilot-ralph-extension` mentions and the `cd` target → `autopilot`
- `ralph-tui` mentions → `autopilot`
- Day-to-day invocations now use the bare `autopilot` binary (assuming `npm link`); the `node packages/tui/bin/tui.mjs ...` form is kept as the no-install fallback
- Co-author trailer email flipped from the older `<noreply+copilot-ralph@github.com>` to the canonical `<copilot-ralph@users.noreply.github.com>` (matches the README's "Commit attribution" section verbatim)
- `RALPH_NO_ATTRIBUTION=1` → `AUTOPILOT_NO_ATTRIBUTION=1`, with a parenthetical noting `RALPH_NO_ATTRIBUTION=1` is still recognized as a fallback

## Test plan

- [x] `npm test` (514 tests, 446 pass / 68 skipped, 0 fail)
- [x] `npm run check` (22 .mjs files syntax-checked)
- [x] `mkdocs build` succeeds; `mkdocs build --strict` aborts on 19 pre-existing warnings (verified zero net-new warnings vs. baseline; cross-repo links to README/CHANGELOG/SECURITY/etc. exist throughout the docs site, not introduced here)
- [x] `grep -n 'copilot-ralph-extension\|ralph-tui\b\|RALPH_NO_ATTRIBUTION' docs/CONTRIBUTING.md` returns one hit only, in the legacy-fallback parenthetical