### PR TITLE
docs(cli-stack): rebrand to autopilot + refresh pin-version table

### DIFF
--- a/docs/cli-stack.md
+++ b/docs/cli-stack.md
@@ -2,23 +2,24 @@
 
 > Stack-verification reference for `packages/tui/` (issue #22).
 >
-> The ralph TUI is built on the same proven trio used by today's leading
-> agentic-CLI tools: **Ink** (React for terminal UIs), **Yoga**
-> (Facebook's Flexbox engine that Ink uses for layout), and **Commander**
-> (the de-facto Node.js CLI argument parser). This document captures
-> *why* we picked each piece and *where* the same choice shows up in
-> Anthropic's Claude Code CLI and GitHub Copilot CLI, so future
-> contributors can ground design decisions in real-world precedent
-> rather than internet folklore.
+> The autopilot TUI under `packages/tui/` is built on the same proven
+> trio used by today's leading agentic-CLI tools: **Ink** (React for
+> terminal UIs), **Yoga** (Facebook's Flexbox engine that Ink uses for
+> layout), and **Commander** (the de-facto Node.js CLI argument parser).
+> This document captures *why* we picked each piece and *where* the same
+> choice shows up in Anthropic's Claude Code CLI and GitHub Copilot CLI,
+> so future contributors can ground design decisions in real-world
+> precedent rather than internet folklore.
 
 ## TL;DR
 
-| Layer            | Library     | Version pin           | Purpose                                                  |
-| ---------------- | ----------- | --------------------- | -------------------------------------------------------- |
-| Render           | `ink`       | `^5.0.1`              | React-based renderer for terminal UIs.                   |
-| Layout           | `yoga-layout` | (transitive via Ink)| Flexbox layout — `<Box>` / `<Text>` use Yoga internally. |
-| Argv             | `commander` | `^12.1.0`             | Subcommands (`watch`, `replay`, `list`) + `--plain`.     |
-| Spinners / glyphs | `ink-spinner` | `^5.0.0`           | Status indicators in `<Header>` and `<Controls>`.        |
+| Layer             | Library               | Version pin          | Purpose                                                  |
+| ----------------- | --------------------- | -------------------- | -------------------------------------------------------- |
+| Render            | `ink`                 | `^7.0.1`             | React-based renderer for terminal UIs.                   |
+| Layout            | `yoga-layout`         | (transitive via Ink) | Flexbox layout — `<Box>` / `<Text>` use Yoga internally. |
+| Argv              | `commander`           | `^14.0.3`            | Subcommands (`watch`, `replay`, `list`, `run`) + flags.  |
+| Spinners / glyphs | `ink-spinner`         | `^5.0.0`             | Status indicators in `<Header>` and `<Controls>`.        |
+| (Test only)       | `ink-testing-library` | `^4.0.0`             | Snapshot the Ink tree to a string buffer.                |
 
 These pins live in [`packages/tui/package.json`](../packages/tui/package.json)
 and are only required for the interactive Ink-rendered `watch` / `run`


### PR DESCRIPTION
## Summary

- Rebrand the CLI Stack page intro from "the ralph TUI" to "the autopilot TUI under `packages/tui/`" (matches PR #79's pattern).
- Refresh the TL;DR pin-version table to reflect actual `packages/tui/package.json` on `main` HEAD: `ink ^7.0.1`, `commander ^14.0.3` (with `run` subcommand added), and a new `(Test only)` row for `ink-testing-library ^4.0.0`.
- Leave the "Why Ink / Commander / Yoga" prose, evidence subsections, rejected-alternatives table, footprint, and see-also links untouched — this is a sweep + pin refresh, not a rewrite.

## Test plan

- [x] `grep -n 'ralph-tui\|the ralph TUI' docs/cli-stack.md` returns zero hits.
- [x] `npm test` — 514 tests, 446 pass / 68 skipped / 0 fail.
- [x] `npm run check` — 22 .mjs files syntax-checked.
- [x] `mkdocs build --strict` — pre-existing 19 warnings on origin/main (verified by stashing my diff). My edit does not introduce any new warnings; it only touches `docs/cli-stack.md`.
- [x] File length: 139 lines (within +/-10 of original 137).

Refs #65.