### PR TITLE
feat(tui): show ☕ awake pip in Header when wrapped by caffeinate (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,28 @@
   `IDEATE_NEXT_FEATURE` step. `PROMPT_GROW_PROJECT` is
   unchanged for now (a follow-up issue can collapse the
   two prompts once #49 lands the unified tool surface).
+- Issue #75 — TUI Header gains a dim `☕ awake` pip in the
+  heading row whenever the `autopilot` process is wrapped by
+  `caffeinate -i …`, providing in-TUI confirmation that the
+  documented sleep-prevention wrapper actually took effect for
+  long self-improve runs (no more `ps`-grepping from another
+  terminal). macOS-only — on Linux / Windows the detection
+  short-circuits via `process.platform !== "darwin"` and the
+  pip never renders, so non-darwin users incur zero detection
+  cost. Detection lives in a new `packages/tui/src/caffeinate.mjs`
+  helper that walks `process.ppid` ancestry once at TUI mount
+  time using `ps -o comm= -p <pid>` (synchronous `spawnSync`,
+  bounded to 8 ancestors and a 200ms-per-call timeout) and
+  caches the result for the process lifetime — no periodic
+  polling, no subprocess at render-time. `<Header>` accepts an
+  optional `caffeinateActive` boolean prop; when falsy / absent,
+  the pip is hidden and the heading row layout matches existing
+  snapshot tests. `<App>` forwards the prop through; `run-ui.mjs`
+  and `watch.mjs` call `detectCaffeinate()` once at mount and
+  pass the result down. When both the version pip (#59) and the
+  caffeinate pip render together they sit in a right-aligned
+  cluster with a two-space gutter between them; the version pip
+  stays at the far edge.
 
 - Issue #57 — `ralph-tui watch` Live panel streams the agent's
   output (assistant text, tool calls, tool results) for the

--- a/packages/tui/src/caffeinate.mjs
+++ b/packages/tui/src/caffeinate.mjs
@@ -1,0 +1,154 @@
+// Caffeinate-ancestry detection (issue #75).
+//
+// macOS-only helper that walks `process.ppid` ancestry once at TUI
+// mount time and returns `true` when any ancestor process is named
+// `caffeinate`. Powers the `<Header>` `☕ awake` pip so users running
+// long self-improve loops under `caffeinate -i …` (per the README's
+// recommendation) get an in-TUI confirmation that the wrapper took
+// effect, rather than having to `ps`-grep from another terminal.
+//
+// Design choices:
+//   * Stdlib-only — uses `node:child_process.spawnSync` to invoke
+//     `ps -o comm=,ppid= -p <pid>` per ancestor (single call gets
+//     both fields). No periodic polling, no subprocess at render-
+//     time; the result is computed once, cached for the process
+//     lifetime, and passed down through props.
+//   * Short-circuits on non-darwin platforms — `process.platform !==
+//     "darwin"` returns `false` immediately, so Linux / Windows users
+//     pay zero detection cost and never see the pip.
+//   * Defensive against ps failures — any spawn error, non-zero exit,
+//     missing stdout, or unparseable line returns `null` rather than
+//     throwing, and the walk terminates. The pip is purely
+//     informational; a bogus render is worse than no render.
+//   * Walks at most a small number of ancestors (cap below) to bound
+//     the worst-case cost on a deeply-nested process tree (shells
+//     inside shells inside terminal multiplexers). The `caffeinate`
+//     wrapper is typically the immediate parent or grandparent, so
+//     the cap is generous.
+//   * Injectable seams (`ppid`, `platform`, `exec`) so the unit test
+//     can mock the ancestry chain without spawning real processes.
+//     Production callers pass no args and get the platform defaults.
+
+import { spawnSync as nodeSpawnSync } from "node:child_process";
+import process from "node:process";
+
+// Maximum ancestors to walk before giving up. Caffeinate is almost
+// always the direct parent (`caffeinate -i node …`) or grandparent
+// (`caffeinate -i bash -c '…'`). Eight is generous enough for the
+// pathological tmux-inside-screen-inside-iterm case while still
+// bounded — eight `spawnSync("ps")` calls is < 10ms on macOS.
+const MAX_ANCESTORS = 8;
+
+// Per-process cache. Caffeinate ancestry doesn't change over a TUI
+// mount's lifetime (the parent process can't suddenly become
+// `caffeinate`), so we compute once and reuse. `undefined` ⇒ not yet
+// computed; `true` / `false` ⇒ cached result. Cleared by tests via
+// the injectable seams (each call with explicit overrides recomputes).
+let cached;
+
+/** Default exec — single `ps -o comm=,ppid= -p <pid>` call returns
+ *  both the command basename and the parent pid for `pid`. Returns
+ *  `{ comm, ppid }` on success or `null` on any failure (process gone,
+ *  ps unavailable, parse error). One subprocess per ancestor instead
+ *  of two halves the worst-case mount-time cost. */
+function defaultExec(pid) {
+    try {
+        const r = nodeSpawnSync("ps", ["-o", "comm=,ppid=", "-p", String(pid)], {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+            // Bounded ceiling so a wedged ps can't hang TUI startup.
+            // 200ms mirrors the defaultGitExec ceiling in runner.mjs.
+            timeout: 200,
+        });
+        if (r.status !== 0) return null;
+        if (typeof r.stdout !== "string") return null;
+        // Output is one line: "<comm> <ppid>" with the comm field
+        // potentially containing spaces or being an absolute path.
+        // Split on the LAST whitespace run so the trailing ppid
+        // separates cleanly from a path-style comm.
+        const trimmed = r.stdout.trim();
+        if (!trimmed) return null;
+        const lastSpace = trimmed.search(/\s+\d+$/);
+        if (lastSpace < 0) return null;
+        const comm = trimmed.slice(0, lastSpace);
+        const ppidStr = trimmed.slice(lastSpace).trim();
+        const ppid = Number.parseInt(ppidStr, 10);
+        if (!Number.isFinite(ppid) || ppid < 0) return null;
+        return { comm, ppid };
+    } catch {
+        return null;
+    }
+}
+
+/** Extract the basename of a command path. `ps -o comm=` may print
+ *  either a bare basename (`caffeinate`) or a full path
+ *  (`/usr/bin/caffeinate`) depending on how the process was invoked.
+ *  Strip everything before the last `/` so the comparison is
+ *  consistent. Also handles a trailing `:` that ps occasionally
+ *  appends for zombie / defunct processes. */
+function basename(comm) {
+    if (typeof comm !== "string") return "";
+    const stripped = comm.replace(/:$/, "").trim();
+    const slash = stripped.lastIndexOf("/");
+    return slash >= 0 ? stripped.slice(slash + 1) : stripped;
+}
+
+/**
+ * Detect whether the current process tree is wrapped by caffeinate.
+ *
+ * On macOS, walks the parent-process chain starting at `process.ppid`
+ * and returns `true` if any ancestor's executable basename is
+ * `caffeinate`. On any other platform, returns `false` without
+ * spawning a subprocess.
+ *
+ * Cached for the process lifetime — re-invocation with no overrides
+ * returns the cached value immediately. Tests pass explicit `ppid`,
+ * `platform`, and `exec` overrides to bypass the cache and exercise
+ * specific code paths.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.ppid]              Override for `process.ppid`.
+ * @param {string} [opts.platform]          Override for `process.platform`.
+ * @param {(pid: number) => {comm: string, ppid: number}|null}
+ *        [opts.exec]                       Override for the per-pid query.
+ *                                          Returns `{ comm, ppid }` for
+ *                                          `pid`, or `null` to terminate
+ *                                          the walk (process gone /
+ *                                          ps failure).
+ * @returns {boolean}
+ */
+export function detectCaffeinate(opts = {}) {
+    const hasOverrides = "ppid" in opts || "platform" in opts || "exec" in opts;
+    if (!hasOverrides && cached !== undefined) return cached;
+
+    const platform = opts.platform ?? process.platform;
+    if (platform !== "darwin") {
+        if (!hasOverrides) cached = false;
+        return false;
+    }
+
+    const exec = typeof opts.exec === "function" ? opts.exec : defaultExec;
+    let pid = opts.ppid ?? process.ppid;
+
+    let result = false;
+    for (let depth = 0; depth < MAX_ANCESTORS; depth += 1) {
+        if (!Number.isFinite(pid) || pid <= 1) break;
+        const row = exec(pid);
+        if (!row) break;
+        if (basename(row.comm) === "caffeinate") {
+            result = true;
+            break;
+        }
+        pid = row.ppid;
+    }
+
+    if (!hasOverrides) cached = result;
+    return result;
+}
+
+/** Reset the per-process cache. Test-only seam — exported so unit
+ *  tests can pin a specific result, then clear so production callers
+ *  start fresh. Production code never calls this. */
+export function _resetCacheForTest() {
+    cached = undefined;
+}

--- a/packages/tui/src/components/App.mjs
+++ b/packages/tui/src/components/App.mjs
@@ -70,6 +70,13 @@ function deriveTaskKey(snapshot) {
  *        row (issue #59). Snapshot tests + pre-issue-59 callers omit
  *        the prop, in which case the pip is hidden and the heading
  *        row stays single-text (existing layout).
+ * @param {boolean} [props.caffeinateActive] Optional flag set by the
+ *        caller (run-ui.mjs / watch.mjs) when `detectCaffeinate()`
+ *        returns true at mount time. Forwarded to <Header> so it
+ *        renders a dim `☕ awake` pip in the heading row (issue #75).
+ *        Snapshot tests + non-darwin callers omit / pass false; the
+ *        pip then stays hidden and the heading row layout is
+ *        unchanged.
  * @param {(reason: string) => void} [props.onUserAbort] Optional
  *        callback fired when the user requests to abort via Ctrl-C
  *        or `q`. When provided (issue #48 slice 8 — `ralph-tui run`
@@ -79,7 +86,7 @@ function deriveTaskKey(snapshot) {
  *        TUI tears down. Read-only callers (`ralph-tui watch`)
  *        omit it; the App still exits but no driver action occurs.
  */
-export default function App({ eventStream, events: initial = [], runId, appVersion, onUserAbort }) {
+export default function App({ eventStream, events: initial = [], runId, appVersion, caffeinateActive, onUserAbort }) {
     const [events, setEvents] = useState(initial);
     // `now` is read by <Header> to render the live elapsed clock. We
     // only tick it in live mode (eventStream present) so static-mode
@@ -225,7 +232,7 @@ export default function App({ eventStream, events: initial = [], runId, appVersi
     }, [sessionId]);
 
     return h(Box, { flexDirection: "column" },
-        h(Header, { snapshot, now: isLive ? now : undefined, appVersion }),
+        h(Header, { snapshot, now: isLive ? now : undefined, appVersion, caffeinateActive }),
         h(StagesRow, { snapshot }),
         h(TasksPane, { snapshot }),
         h(SubstagesPane, { snapshot }),

--- a/packages/tui/src/components/Header.mjs
+++ b/packages/tui/src/components/Header.mjs
@@ -22,6 +22,15 @@
 // version string from `src/version.mjs`. Hidden when the prop is
 // absent so snapshot tests stay deterministic.
 //
+// Issue #75: optional `caffeinateActive` boolean prop renders a dim
+// `☕ awake` pip alongside the version pip when truthy — at-a-glance
+// confirmation that a `caffeinate -i …` wrapper actually took effect
+// for long self-improve runs. Hidden when falsy / absent so snapshot
+// tests stay deterministic and non-darwin renders incur no row
+// reflow. Detection lives in `src/caffeinate.mjs`; the caller
+// (run-ui.mjs / watch.mjs) owns the one-shot `detectCaffeinate()`
+// call at mount time.
+//
 // Pure presentational component. Uses React.createElement directly so
 // the file loads in plain Node ESM (no JSX/TypeScript build step).
 
@@ -101,7 +110,7 @@ function backlogField(value) {
     return value === null || value === undefined ? "?" : String(value);
 }
 
-export default function Header({ snapshot, now, appVersion }) {
+export default function Header({ snapshot, now, appVersion, caffeinateActive }) {
     const status = snapshot?.status ?? "idle";
     const label = snapshot?.label ?? "(unknown)";
     const runId = snapshot?.runId ?? "(no run)";
@@ -248,14 +257,37 @@ export default function Header({ snapshot, now, appVersion }) {
     // empty prop ⇒ no pip, and the row collapses to a single
     // bold-underline "Run" text node (existing behaviour for
     // pre-issue-59 callers + snapshot tests).
+    //
+    // Issue #75: when `caffeinateActive` is truthy, a dim `☕ awake`
+    // pip joins the right side of the heading row, sitting to the
+    // left of the version pip (so the version stays anchored at the
+    // far right). Both pips are independent — either, both, or
+    // neither can render. When neither is present, the heading
+    // collapses to the original single-text layout for snapshot-
+    // test determinism.
     const versionPip = (typeof appVersion === "string" && appVersion.length > 0)
         ? h(Text, { dimColor: true }, "v" + appVersion)
         : null;
+    const caffeinatePip = caffeinateActive
+        ? h(Text, { dimColor: true }, "☕ awake")
+        : null;
     const headingText = h(Text, { bold: true, underline: true }, "Run");
-    const heading = versionPip
-        ? h(Box, { flexDirection: "row", justifyContent: "space-between" },
-            headingText, versionPip)
-        : headingText;
+    let heading;
+    if (caffeinatePip || versionPip) {
+        // Right-side pip cluster — caffeinate first, version last
+        // so the version stays at the far edge (its established
+        // position from issue #59). A two-space gutter separates
+        // the pips when both render so they don't visually merge.
+        const rightCluster = h(Box, { flexDirection: "row" },
+            caffeinatePip,
+            (caffeinatePip && versionPip) ? h(Text, null, "  ") : null,
+            versionPip,
+        );
+        heading = h(Box, { flexDirection: "row", justifyContent: "space-between" },
+            headingText, rightCluster);
+    } else {
+        heading = headingText;
+    }
 
     return h(Box, {
         borderStyle: "round",

--- a/packages/tui/src/run-ui.mjs
+++ b/packages/tui/src/run-ui.mjs
@@ -27,6 +27,7 @@ import process from "node:process";
 
 import { tailEventsFile } from "./tail.mjs";
 import { readTuiVersion } from "./version.mjs";
+import { detectCaffeinate } from "./caffeinate.mjs";
 
 /**
  * @param {Object} args
@@ -58,6 +59,11 @@ export async function mountRunUi({ runId, eventsPath, onUserAbort }) {
             events: [],
             eventStream,
             appVersion: readTuiVersion(),
+            // Issue #75 — one-shot caffeinate detection at mount.
+            // Returns false on non-darwin without spawning a
+            // subprocess; on darwin walks the ppid ancestry once
+            // and caches for the process lifetime.
+            caffeinateActive: detectCaffeinate(),
             onUserAbort,
         }),
         { exitOnCtrlC: false, patchConsole: false },

--- a/packages/tui/src/watch.mjs
+++ b/packages/tui/src/watch.mjs
@@ -9,6 +9,7 @@ import process from "node:process";
 
 import { tailEventsFile, readEventsFile } from "./tail.mjs";
 import { readTuiVersion } from "./version.mjs";
+import { detectCaffeinate } from "./caffeinate.mjs";
 
 /**
  * @param {Object} args
@@ -39,6 +40,11 @@ export async function runInteractive({ runId, eventsPath }) {
             events: initial,
             eventStream,
             appVersion: readTuiVersion(),
+            // Issue #75 — one-shot caffeinate detection at mount.
+            // Returns false on non-darwin without spawning a
+            // subprocess; on darwin walks the ppid ancestry once
+            // and caches for the process lifetime.
+            caffeinateActive: detectCaffeinate(),
         }),
     );
     await waitUntilExit();

--- a/packages/tui/test/caffeinate.test.mjs
+++ b/packages/tui/test/caffeinate.test.mjs
@@ -1,0 +1,173 @@
+// Unit tests for the caffeinate-ancestry detection helper (issue #75).
+//
+// Pure stdlib — exercises the helper through its injectable seams
+// (`platform`, `ppid`, `exec`) so the tests don't actually spawn any
+// subprocesses or touch the real /bin/ps. Each test passes the seams
+// explicitly; that bypasses the per-process cache so tests don't
+// leak into each other.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { detectCaffeinate, _resetCacheForTest } from "../src/caffeinate.mjs";
+
+// Helper — build an `exec` mock that resolves a deterministic
+// pid → { comm, ppid } table. Returns `null` for unknown pids so
+// the walk terminates cleanly.
+function makeExec(table) {
+    return (pid) => table[pid] ?? null;
+}
+
+test("detectCaffeinate: returns false on linux without invoking exec", () => {
+    let invoked = false;
+    const exec = () => { invoked = true; return null; };
+    const result = detectCaffeinate({ platform: "linux", ppid: 1234, exec });
+    assert.equal(result, false);
+    assert.equal(invoked, false, "linux short-circuit must not query ps");
+});
+
+test("detectCaffeinate: returns false on win32 without invoking exec", () => {
+    let invoked = false;
+    const exec = () => { invoked = true; return null; };
+    const result = detectCaffeinate({ platform: "win32", ppid: 1234, exec });
+    assert.equal(result, false);
+    assert.equal(invoked, false);
+});
+
+test("detectCaffeinate: returns true when direct parent is caffeinate", () => {
+    const exec = makeExec({
+        500: { comm: "caffeinate", ppid: 1 },
+    });
+    const result = detectCaffeinate({ platform: "darwin", ppid: 500, exec });
+    assert.equal(result, true);
+});
+
+test("detectCaffeinate: returns true when grandparent is caffeinate", () => {
+    // node ← bash ← caffeinate ← launchd
+    const exec = makeExec({
+        500: { comm: "bash", ppid: 400 },
+        400: { comm: "caffeinate", ppid: 1 },
+    });
+    const result = detectCaffeinate({ platform: "darwin", ppid: 500, exec });
+    assert.equal(result, true);
+});
+
+test("detectCaffeinate: returns true when caffeinate appears with absolute path", () => {
+    // ps -o comm= can return either bare basename or absolute path
+    // depending on how the process was invoked. The helper strips
+    // the path prefix so /usr/bin/caffeinate matches caffeinate.
+    const exec = makeExec({
+        500: { comm: "/usr/bin/caffeinate", ppid: 1 },
+    });
+    const result = detectCaffeinate({ platform: "darwin", ppid: 500, exec });
+    assert.equal(result, true);
+});
+
+test("detectCaffeinate: returns false when no ancestor is caffeinate", () => {
+    // node ← zsh ← terminal ← launchd
+    const exec = makeExec({
+        500: { comm: "zsh", ppid: 400 },
+        400: { comm: "terminal", ppid: 1 },
+    });
+    const result = detectCaffeinate({ platform: "darwin", ppid: 500, exec });
+    assert.equal(result, false);
+});
+
+test("detectCaffeinate: stops walking at pid 1 (launchd) without false positive", () => {
+    const exec = makeExec({
+        500: { comm: "node", ppid: 1 },
+    });
+    const result = detectCaffeinate({ platform: "darwin", ppid: 500, exec });
+    assert.equal(result, false);
+});
+
+test("detectCaffeinate: stops cleanly when exec returns null mid-walk", () => {
+    // Process exits during walk → ps returns null. Helper should
+    // return false rather than throwing or looping.
+    const exec = makeExec({
+        500: { comm: "bash", ppid: 400 },
+        // 400 deliberately absent — exec returns null for it.
+    });
+    const result = detectCaffeinate({ platform: "darwin", ppid: 500, exec });
+    assert.equal(result, false);
+});
+
+test("detectCaffeinate: bounded ancestry walk does not run forever on a cycle", () => {
+    // Pathological table where pid lookups loop back to themselves.
+    // The MAX_ANCESTORS cap should kick in and the helper should
+    // return false rather than spinning.
+    let lookups = 0;
+    const exec = (pid) => {
+        lookups += 1;
+        return { comm: "node", ppid: pid }; // self-loop
+    };
+    const result = detectCaffeinate({ platform: "darwin", ppid: 500, exec });
+    assert.equal(result, false);
+    // One lookup per ancestor, capped at MAX_ANCESTORS = 8.
+    assert.ok(lookups <= 8, `expected <= 8 lookups, got ${lookups}`);
+});
+
+test("detectCaffeinate: handles ps trailing colon for defunct processes", () => {
+    // ps occasionally appends a `:` to comm for zombie / defunct
+    // processes (e.g. "node:"). The basename normaliser should
+    // strip it so we still match "caffeinate:" as caffeinate.
+    const exec = makeExec({
+        500: { comm: "caffeinate:", ppid: 1 },
+    });
+    const result = detectCaffeinate({ platform: "darwin", ppid: 500, exec });
+    assert.equal(result, true);
+});
+
+test("detectCaffeinate: ignores caffeinate-substring (e.g. 'caffeinated-app') matches", () => {
+    // Basename equality, not substring contains — a process named
+    // `caffeinated-app` should NOT trigger the pip.
+    const exec = makeExec({
+        500: { comm: "caffeinated-app", ppid: 400 },
+        400: { comm: "node", ppid: 1 },
+    });
+    const result = detectCaffeinate({ platform: "darwin", ppid: 500, exec });
+    assert.equal(result, false);
+});
+
+test("detectCaffeinate: returns false when ppid is not finite (orphaned)", () => {
+    // ppid 0 means no parent (kernel sentinel). Helper should bail
+    // immediately rather than try to ps pid 0.
+    const result = detectCaffeinate({
+        platform: "darwin",
+        ppid: 0,
+        exec: () => { throw new Error("should not be called"); },
+    });
+    assert.equal(result, false);
+});
+
+test("detectCaffeinate: result is cached across calls without overrides", () => {
+    // First call with overrides primes a known result, but does NOT
+    // populate the cache (overrides bypass the cache). Subsequent
+    // calls without overrides hit the real platform / ppid path —
+    // we just assert the function returns a boolean (true or false
+    // depending on the test runner's actual ancestry).
+    _resetCacheForTest();
+    const r1 = detectCaffeinate();
+    const r2 = detectCaffeinate();
+    assert.equal(typeof r1, "boolean");
+    assert.equal(r1, r2, "cached call must return identical value");
+});
+
+test("detectCaffeinate: passing overrides bypasses the cache", () => {
+    _resetCacheForTest();
+    // Prime with one result …
+    const a = detectCaffeinate({
+        platform: "darwin",
+        ppid: 500,
+        exec: makeExec({ 500: { comm: "caffeinate", ppid: 1 } }),
+    });
+    assert.equal(a, true);
+    // … then a separate override-bearing call returns its own
+    // independent result. Cache is not contaminated either way.
+    const b = detectCaffeinate({
+        platform: "darwin",
+        ppid: 500,
+        exec: makeExec({ 500: { comm: "node", ppid: 1 } }),
+    });
+    assert.equal(b, false);
+});

--- a/packages/tui/test/components.test.mjs
+++ b/packages/tui/test/components.test.mjs
@@ -348,6 +348,84 @@ test("App: forwards appVersion prop through to Header pip", { skip }, () => {
     assert.match(out, /v9\.8\.7/);
 });
 
+// ─── caffeinateActive pip rendering (issue #75) ──────────────────
+// The Header's heading row renders a dim `☕ awake` pip alongside
+// the version pip when the `caffeinateActive` prop is truthy. Hidden
+// otherwise so non-darwin renders + snapshot tests stay deterministic
+// and the row layout doesn't reflow.
+
+test("Header: renders caffeinate pip when caffeinateActive is true", { skip }, () => {
+    const snapshot = {
+        status: "running",
+        label: "self_improve",
+        runId: "self_improve-1",
+        iteration: 0,
+        maxIterations: 10,
+        tokens: { input: 0, output: 0 },
+    };
+    const out = render(React.createElement(Header, {
+        snapshot, caffeinateActive: true,
+    })).lastFrame();
+    assert.match(out, /awake/);
+});
+
+test("Header: hides caffeinate pip when caffeinateActive is false", { skip }, () => {
+    const snapshot = {
+        status: "running",
+        label: "self_improve",
+        runId: "self_improve-2",
+        iteration: 0,
+        maxIterations: 10,
+        tokens: { input: 0, output: 0 },
+    };
+    const out = render(React.createElement(Header, {
+        snapshot, caffeinateActive: false,
+    })).lastFrame();
+    assert.doesNotMatch(out, /awake/);
+});
+
+test("Header: hides caffeinate pip when caffeinateActive is omitted", { skip }, () => {
+    const snapshot = {
+        status: "idle",
+        label: "ralph_loop",
+        runId: "ralph_loop-3",
+        iteration: 0,
+        maxIterations: 10,
+        tokens: { input: 0, output: 0 },
+    };
+    const out = render(React.createElement(Header, { snapshot })).lastFrame();
+    assert.doesNotMatch(out, /awake/);
+});
+
+test("Header: renders both caffeinate and version pips together", { skip }, () => {
+    // When both pips are active, both must render — the heading row
+    // becomes a flex row with the cluster pinned to the right edge.
+    const snapshot = {
+        status: "running",
+        label: "self_improve",
+        runId: "self_improve-4",
+        iteration: 1,
+        maxIterations: 10,
+        tokens: { input: 0, output: 0 },
+    };
+    const out = render(React.createElement(Header, {
+        snapshot, appVersion: "1.2.3", caffeinateActive: true,
+    })).lastFrame();
+    assert.match(out, /awake/);
+    assert.match(out, /v1\.2\.3/);
+    assert.match(out, /Run/);
+});
+
+test("App: forwards caffeinateActive prop through to Header pip", { skip }, () => {
+    const events = [
+        { type: "armed", runId: "r1", at: 1, label: "ralph_loop", maxIterations: 10 },
+    ];
+    const out = render(React.createElement(App, {
+        events, runId: "r1", caffeinateActive: true,
+    })).lastFrame();
+    assert.match(out, /awake/);
+});
+
 test("Controls hint row shows live indicator when status is running", { skip }, () => {
     const out = render(React.createElement(Controls, { status: "running" })).lastFrame();
     assert.match(out, /quit/);


### PR DESCRIPTION
## Summary
- Adds a dim `☕ awake` pip to the `<Header>` heading row when the `autopilot` process is wrapped by `caffeinate -i …` on macOS, giving users an in-TUI confirmation that the documented sleep-prevention wrapper actually took effect (no more `ps`-grepping from another terminal mid-run).
- New `packages/tui/src/caffeinate.mjs` helper walks `process.ppid` ancestry once at mount via a single `ps -o comm=,ppid=` per ancestor (bounded to 8 ancestors, 200ms timeout per call, cached for the process lifetime). Short-circuits to `false` on non-darwin platforms — Linux / Windows incur zero detection cost.
- `<Header>` and `<App>` accept an optional `caffeinateActive` boolean prop; when falsy / absent the pip is hidden and the heading row layout matches existing snapshot tests. Both `run-ui.mjs` and `watch.mjs` call `detectCaffeinate()` once at mount and pass the result down. When both the version pip (#59) and the caffeinate pip render, they cluster right-aligned with a two-space gutter and the version pip stays at the far edge.

Closes #75.

## Test plan
- [x] `npm test` from repo root — 533/533 passing (added 14 unit tests for `detectCaffeinate` covering linux short-circuit, win32 short-circuit, direct-parent caffeinate, grandparent caffeinate, absolute-path comm, no-ancestor-caffeinate, pid-1 termination, mid-walk null exec, MAX_ANCESTORS cycle bound, defunct-process trailing colon, `caffeinated-app` substring rejection, ppid 0 orphaned, cache reuse across calls, and override-bypasses-cache; plus 5 new component tests for the pip rendering / hiding / coexistence with the version pip / `<App>`-forwarding).
- [x] `npm run check` from repo root — 23/23 .mjs syntax-checked.
- [x] `node packages/tui/bin/tui.mjs --help` — exits 0, no regression.
- [x] Smoke against real ancestry — `detectCaffeinate()` returns `false` on a non-caffeinate shell; simulated darwin+caffeinate ancestor returns `true`.
- [ ] e2e: deferred — needs a real macOS terminal under `caffeinate -i` to do a true end-to-end UI check. Component test asserts the render path; the helper test asserts the detection logic.