### PR TITLE
feat(tui): per-iter duration/token/premium/files stats on Timeline rows (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,36 @@
   caffeinate pip render together they sit in a right-aligned
   cluster with a two-space gutter between them; the version pip
   stays at the far edge.
+- Issue #56 — TUI `<Timeline>` rows gain four per-iter stat cells
+  between the iteration # and the excerpt: `4.2s` / `1m23s`
+  duration (live-elapsed for the in-flight iter via `<App>`'s 1Hz
+  tick), `1.2k tok` token delta (cumulative `snap.tokens` minus an
+  iter-start snapshot captured by `foldEvents` on
+  `iteration_start`), `⊕N` premium-request delta (same shape;
+  hidden when both cur and start are null), and `📁N` files-changed
+  count (committed delta + uncommitted churn computed by the
+  runner at iter close via `git diff --name-only` + `git status
+  --porcelain` and attached to the `iteration_end` event). All
+  cells render dim-on-zero so quiet iters stay quiet, and missing
+  data renders `—` (or hides the cell entirely for premium /
+  files) so a pre-this-issue `events.jsonl` replay shows no
+  crash, no `NaN`, no `undefined`. New helpers `formatDuration`,
+  `formatTokenDelta`, `computeTokenDelta`, `computePremiumDelta`
+  exported from `<Timeline>` for unit-testability; new
+  `computeIterFilesChanged` exported from `runner.mjs` (with
+  shared `gitRevParseHead` + `SHA_RE` extracted from the existing
+  `readHeadCommit`). `iteration_end` event schema gains an
+  optional `filesChanged: number` field; the serializer drops
+  malformed values (NaN / Infinity / negative) so a third-party
+  emitter cannot poison the stream. New tests pin every cell:
+  `formatDuration` boundary cases, in-flight live elapsed, 0-ms
+  iter renders `0.0s` not `NaN`, token delta renders `1.2k` for
+  ≥ 1000, replay-safety dash for old iters without
+  `tokensAtStart`, premium cell hidden when both null,
+  `filesChanged` round-trips through serialize/parse, and an
+  end-to-end `runRalphTui` test stubs `gitExec` with canned
+  diff/status output and pins the iter-end event's `filesChanged`
+  field.
 
 - Issue #57 — `ralph-tui watch` Live panel streams the agent's
   output (assistant text, tool calls, tool results) for the

--- a/packages/tui/package-lock.json
+++ b/packages/tui/package-lock.json
@@ -15,7 +15,7 @@
         "react": "^19.2.5"
       },
       "bin": {
-        "ralph-tui": "bin/tui.mjs"
+        "autopilot": "bin/tui.mjs"
       },
       "devDependencies": {
         "ink-testing-library": "^4.0.0"

--- a/packages/tui/src/components/App.mjs
+++ b/packages/tui/src/components/App.mjs
@@ -236,7 +236,7 @@ export default function App({ eventStream, events: initial = [], runId, appVersi
         h(StagesRow, { snapshot }),
         h(TasksPane, { snapshot }),
         h(SubstagesPane, { snapshot }),
-        h(Timeline, { snapshot }),
+        h(Timeline, { snapshot, now: isLive ? now : undefined }),
         h(LiveOutputPane, {
             snapshot,
             lines: liveOutput.lines,

--- a/packages/tui/src/components/Timeline.mjs
+++ b/packages/tui/src/components/Timeline.mjs
@@ -2,6 +2,12 @@
 //
 // Renders the most recent N iterations newest-first. Pure component;
 // uses React.createElement (no JSX) so it runs in plain Node ESM.
+//
+// Issue #56 — per-iter stats cells. Each row gets four cells between
+// the iteration # and the excerpt: duration, token delta, premium
+// delta, files changed. All render dim-on-zero so cheap iters stay
+// quiet; cells with no data render `—` (replay-safe for old runs
+// that lack the snapshot fields).
 
 import React from "react";
 import { Box, Text } from "ink";
@@ -30,6 +36,73 @@ function pad(n, w) {
     return String(n).padStart(w, " ");
 }
 
+// Two-space gap between row cells. Factory rather than a shared
+// element instance — React siblings should be distinct objects.
+const sep = () => h(Text, null, "  ");
+
+// Compute the duration ms for an iter row. Closed iters use
+// `endedAt - startedAt`; in-flight iters use `now - startedAt`
+// (where `now` is App's 1Hz tick when supplied, else `Date.now()`
+// so static / non-live renders still get a number).
+function computeDurMs(it, now) {
+    if (Number.isFinite(it.endedAt) && Number.isFinite(it.startedAt)) {
+        return it.endedAt - it.startedAt;
+    }
+    if (Number.isFinite(it.startedAt)) {
+        const tickNow = Number.isFinite(now) ? now : Date.now();
+        return tickNow - it.startedAt;
+    }
+    return null;
+}
+
+// Format an elapsed duration: `4.2s` for < 60s, `1m23s` otherwise.
+// Non-finite or negative ms renders `—` so a runaway clock or a
+// missing `startedAt` doesn't surface as `NaN` / `-Infinity`.
+export function formatDuration(ms) {
+    if (!Number.isFinite(ms) || ms < 0) return "—";
+    if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}m${seconds}s`;
+}
+
+// Format a per-iter token delta as `1.2k` for ≥ 1000, raw integer
+// otherwise. `null`/non-finite renders `—` (old iters without a
+// `tokensAtStart` snapshot). Negative deltas clamp to 0 defensively
+// — cumulative tokens should only grow.
+export function formatTokenDelta(delta) {
+    if (delta == null || !Number.isFinite(delta)) return "—";
+    const n = Math.max(0, Math.floor(delta));
+    if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+    return String(n);
+}
+
+// Per-iter token delta = cumulative `snap.tokens` − iter-start
+// snapshot. Returns `null` for old iters lacking `tokensAtStart`
+// (replay-safe).
+export function computeTokenDelta(iter, snap) {
+    if (!iter || !iter.tokensAtStart) return null;
+    const cur = snap?.tokens;
+    if (!cur) return null;
+    const curTotal = (Number.isFinite(cur.input) ? cur.input : 0)
+        + (Number.isFinite(cur.output) ? cur.output : 0);
+    const startTotal = (Number.isFinite(iter.tokensAtStart.input) ? iter.tokensAtStart.input : 0)
+        + (Number.isFinite(iter.tokensAtStart.output) ? iter.tokensAtStart.output : 0);
+    return curTotal - startTotal;
+}
+
+// Per-iter premium-request delta. Returns `null` when both cur and
+// start are null (pre-iter-1 / SDK that doesn't emit premium counts)
+// so the renderer hides the cell entirely.
+export function computePremiumDelta(iter, snap) {
+    if (!iter) return null;
+    const start = iter.premiumAtStart;
+    const cur = snap?.premiumRequests;
+    if (start == null && cur == null) return null;
+    return (cur ?? 0) - (start ?? 0);
+}
+
 // Flatten whitespace and cap a string at `n` UTF-16 code units, then
 // append a single trailing "…" iff truncation actually happened. The
 // reserved byte for the ellipsis is taken from `n` so the rendered
@@ -48,7 +121,7 @@ export function truncate(s, n) {
     return safeSliceChars(flat, n - 1) + "…";
 }
 
-export default function Timeline({ snapshot, limit = DEFAULT_LIMIT }) {
+export default function Timeline({ snapshot, limit = DEFAULT_LIMIT, now }) {
     const all = snapshot?.iterations ?? [];
     const recent = all.slice(-limit).reverse();
     const totalWidth = String(snapshot?.maxIterations ?? all.length ?? 0).length || 1;
@@ -81,13 +154,35 @@ export default function Timeline({ snapshot, limit = DEFAULT_LIMIT }) {
         } else {
             excerptCell = h(Text, { dimColor: true }, "(no excerpt)");
         }
-        return h(Box, { key: it.iteration, flexDirection: "row" },
+
+        // Per-iter stats cells. Order: duration, tokens, premium,
+        // files. Dim-on-zero so quiet iters don't fight for
+        // attention; null cells are omitted entirely (replay-safe
+        // for old runs missing the snapshot fields).
+        const durMs = computeDurMs(it, now);
+        const tokenDelta = computeTokenDelta(it, snapshot);
+        const premiumDelta = computePremiumDelta(it, snapshot);
+        const filesChanged = it.filesChanged;
+
+        const cells = [
             h(Text, { color }, GLYPH[kind]),
             h(Text, null, " "),
             h(Text, null, "#" + pad(it.iteration, totalWidth)),
-            h(Text, null, "  "),
-            excerptCell,
-        );
+            sep(),
+            h(Text, { dimColor: !Number.isFinite(durMs) || durMs === 0 }, formatDuration(durMs)),
+            sep(),
+            h(Text, { dimColor: tokenDelta == null || tokenDelta === 0 },
+                tokenDelta == null ? "—" : `${formatTokenDelta(tokenDelta)} tok`),
+        ];
+        if (premiumDelta != null) {
+            cells.push(sep(), h(Text, { dimColor: premiumDelta === 0 }, `⊕${premiumDelta}`));
+        }
+        if (filesChanged != null) {
+            cells.push(sep(), h(Text, { dimColor: filesChanged === 0 }, `📁${filesChanged}`));
+        }
+        cells.push(sep(), excerptCell);
+
+        return h(Box, { key: it.iteration, flexDirection: "row" }, ...cells);
     });
 
     return h(Box, {

--- a/packages/tui/src/events.mjs
+++ b/packages/tui/src/events.mjs
@@ -352,6 +352,13 @@ export function serializeEvent(ev) {
     if (Number.isFinite(ev.premiumRequests) && ev.premiumRequests >= 0) {
         out.premiumRequests = ev.premiumRequests;
     }
+    // Per-iter file-change count (committed delta + uncommitted
+    // churn). Strictly opt-in: emitted only when finite and
+    // non-negative so a missing field on old runs renders dim (`—`)
+    // in the Timeline rather than `0` (which would be a lie).
+    if (Number.isFinite(ev.filesChanged) && ev.filesChanged >= 0) {
+        out.filesChanged = ev.filesChanged;
+    }
     if (typeof ev.note === "string") out.note = safeSliceChars(ev.note, 500);
 
     // Stage-level fields (issue #48 slice 1). Strictly opt-in: only
@@ -784,6 +791,13 @@ export function foldEvents(events) {
                         startedAt: ev.ts,
                         endedAt: null,
                         excerpt: null,
+                        // Snapshot cumulative-for-the-run counters at
+                        // iter open so the Timeline can derive
+                        // per-iter deltas (tokens, premium). The
+                        // `filesChanged` field is set later on
+                        // `iteration_end`.
+                        tokensAtStart: { ...snap.tokens },
+                        premiumAtStart: snap.premiumRequests,
                     });
                 }
                 snap.status = "running";
@@ -800,6 +814,12 @@ export function foldEvents(events) {
                 if (last && (!Number.isFinite(ev.iteration) || last.iteration === ev.iteration)) {
                     last.endedAt = ev.ts;
                     if (typeof ev.excerpt === "string") last.excerpt = ev.excerpt;
+                    // Strictly opt-in: missing on old runs leaves
+                    // the iter without a `filesChanged` field so
+                    // the Timeline cell stays hidden (replay-safe).
+                    if (Number.isFinite(ev.filesChanged) && ev.filesChanged >= 0) {
+                        last.filesChanged = ev.filesChanged;
+                    }
                 }
                 if (typeof ev.excerpt === "string") snap.lastExcerpt = ev.excerpt;
                 if (ev.tokens) {

--- a/packages/tui/src/runner.mjs
+++ b/packages/tui/src/runner.mjs
@@ -529,6 +529,11 @@ export function looksLikeGitCommit(command) {
     return false;
 }
 
+/** Validate a git SHA: 7–40 lowercase or uppercase hex chars. Used
+ *  by `readHeadCommit`, `computeIterFilesChanged`, and the iter-start
+ *  HEAD capture in the iter loop. */
+const SHA_RE = /^[0-9a-f]{7,40}$/i;
+
 /** Default `gitExec` implementation — runs a git subcommand
  *  synchronously via `child_process.spawnSync` and returns the
  *  stdout (UTF-8) on success, or `null` on any error / non-zero
@@ -802,7 +807,7 @@ export function sweepOrphanWorktrees({ runsRoot, cwd, env, gitExec, now = () => 
 export function readHeadCommit({ gitExec, cwd, env }) {
     if (typeof gitExec !== "function") return null;
     const sha = (gitExec({ args: ["rev-parse", "--short", "HEAD"], cwd, env }) ?? "").trim();
-    if (!/^[0-9a-f]{7,40}$/i.test(sha)) return null;
+    if (!SHA_RE.test(sha)) return null;
     // %s = subject, then a literal NUL separator we control,
     // then %(trailers:only=true,unfold=true) = each trailer on
     // its own line.
@@ -823,6 +828,61 @@ export function readHeadCommit({ gitExec, cwd, env }) {
         if (trailers.length >= 8) break;
     }
     return { sha, subject, trailers };
+}
+
+/** Run `gitExec` and return a trimmed SHA when the output validates,
+ *  otherwise null. Centralises the rev-parse → trim → validate dance
+ *  used at iter start and inside `computeIterFilesChanged`. */
+function gitRevParseHead({ gitExec, cwd, env }) {
+    if (typeof gitExec !== "function") return null;
+    const raw = (gitExec({ args: ["rev-parse", "HEAD"], cwd, env }) ?? "").trim();
+    return SHA_RE.test(raw) ? raw : null;
+}
+
+/** Compute the per-iter file-change count: committed delta (file
+ *  count between `iterStartSha` and current HEAD) + uncommitted
+ *  churn (file count from `git status --porcelain`).
+ *
+ *  Returns `null` when `gitExec` is not a function so the caller
+ *  can omit the field from the `iteration_end` payload — the
+ *  Timeline cell stays hidden for non-git cwds / test injection
+ *  without a stub. When `iterStartSha` is null, the committed
+ *  delta is skipped and only the uncommitted churn contributes
+ *  (partial visibility beats none).
+ *
+ *  @param {object} opts
+ *  @param {(req: {args: string[], cwd: string, env: object}) => string|null} opts.gitExec
+ *  @param {string} opts.cwd
+ *  @param {object} [opts.env]
+ *  @param {string|null} opts.iterStartSha
+ *  @returns {number|null}
+ */
+export function computeIterFilesChanged({ gitExec, cwd, env, iterStartSha }) {
+    if (typeof gitExec !== "function") return null;
+    let committed = 0;
+    if (typeof iterStartSha === "string" && SHA_RE.test(iterStartSha)) {
+        const curSha = gitRevParseHead({ gitExec, cwd, env });
+        if (curSha && curSha !== iterStartSha) {
+            const diffOut = gitExec({
+                args: ["diff", "--name-only", `${iterStartSha}..HEAD`],
+                cwd, env,
+            });
+            if (typeof diffOut === "string") committed = countNonEmptyLines(diffOut);
+        }
+    }
+    const statusOut = gitExec({ args: ["status", "--porcelain"], cwd, env });
+    const uncommitted = typeof statusOut === "string" ? countNonEmptyLines(statusOut) : 0;
+    return committed + uncommitted;
+}
+
+/** Count non-empty lines in a string. Tolerates `\r\n` line endings
+ *  and treats whitespace-only lines as empty. */
+function countNonEmptyLines(s) {
+    let count = 0;
+    for (const rawLine of s.split("\n")) {
+        if (rawLine.replace(/\r$/, "").trim()) count++;
+    }
+    return count;
 }
 
 /** Parse the line count from `gh ... list` text output. The agent's
@@ -1475,6 +1535,13 @@ export async function runRalphTui(opts) {
         });
         stdout.write?.(`# iter ${iter}/${max}\n`);
 
+        // Capture HEAD SHA at iter start so the iter-end
+        // `filesChanged` calc can diff committed work landed during
+        // the iter. Returns null for non-git cwds / wedged repos,
+        // in which case the per-iter file delta degrades to
+        // "uncommitted churn only".
+        const iterStartSha = gitRevParseHead({ gitExec, cwd, env });
+
         // Decide whether to resume an existing session or start a
         // fresh one. --continue captures sessionId at iter 1 then
         // resumes it; --fresh always starts fresh.
@@ -2061,6 +2128,16 @@ export async function runRalphTui(opts) {
             tokens: { input: 0, output: runOutputTokens },
         };
         if (runPremiumRequests !== null) iterEndEv.premiumRequests = runPremiumRequests;
+        // Per-iter file-change count (committed delta + uncommitted
+        // churn). Returns null when `gitExec` is unavailable, in
+        // which case we omit the field so the Timeline cell stays
+        // hidden rather than rendering `0` (which would lie).
+        const filesChanged = computeIterFilesChanged({
+            gitExec, cwd, env, iterStartSha,
+        });
+        if (Number.isFinite(filesChanged) && filesChanged >= 0) {
+            iterEndEv.filesChanged = filesChanged;
+        }
         emitter.write(iterEndEv);
         updateState(runId, (s) => { s.iter = iter; return s; }, env);
         if (onIteration) {

--- a/packages/tui/test/components.test.mjs
+++ b/packages/tui/test/components.test.mjs
@@ -10,6 +10,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 let render, React, App, Header, Timeline, LiveOutputPane, Controls, truncateTimeline, formatElapsed;
+let formatDuration, formatTokenDelta, computeTokenDelta, computePremiumDelta;
 let inkAvailable = false;
 try {
     ({ render } = await import("ink-testing-library"));
@@ -21,6 +22,10 @@ try {
     const TimelineMod = await import("../src/components/Timeline.mjs");
     Timeline = TimelineMod.default;
     truncateTimeline = TimelineMod.truncate;
+    formatDuration = TimelineMod.formatDuration;
+    formatTokenDelta = TimelineMod.formatTokenDelta;
+    computeTokenDelta = TimelineMod.computeTokenDelta;
+    computePremiumDelta = TimelineMod.computePremiumDelta;
     LiveOutputPane = (await import("../src/components/LiveOutputPane.mjs")).default;
     Controls = (await import("../src/components/Controls.mjs")).default;
     inkAvailable = true;
@@ -1186,4 +1191,200 @@ test("Issue #54 slice 2a: Timeline shows live-streamed excerpt on the in-flight 
     assert.match(out, /ORIENT: scanning the backlog/);
     assert.doesNotMatch(out, /working…/);
     assert.doesNotMatch(out, /no excerpt/);
+});
+
+// ─── Issue #56 — per-iter stats cells on Timeline rows ────────────
+
+test("Issue #56 slice 1: formatDuration < 60s renders one decimal seconds", { skip }, () => {
+    assert.equal(formatDuration(0), "0.0s");
+    assert.equal(formatDuration(4200), "4.2s");
+    assert.equal(formatDuration(59999), "60.0s");
+});
+
+test("Issue #56 slice 1: formatDuration >= 60s renders MmSSs", { skip }, () => {
+    assert.equal(formatDuration(60000), "1m0s");
+    assert.equal(formatDuration(83000), "1m23s");
+    assert.equal(formatDuration(3600000), "60m0s");
+});
+
+test("Issue #56 slice 1: formatDuration NaN / negative renders dash", { skip }, () => {
+    assert.equal(formatDuration(NaN), "—");
+    assert.equal(formatDuration(undefined), "—");
+    assert.equal(formatDuration(null), "—");
+    assert.equal(formatDuration(-1), "—");
+});
+
+test("Issue #56 slice 1: Timeline closed iter renders duration cell from endedAt - startedAt", { skip }, () => {
+    const snapshot = {
+        iterations: [
+            { iteration: 1, startedAt: 1000, endedAt: 5200, excerpt: "ok" },
+        ],
+    };
+    const out = render(React.createElement(Timeline, { snapshot })).lastFrame();
+    assert.match(out, /4\.2s/);
+});
+
+test("Issue #56 slice 1: Timeline in-flight iter ticks live elapsed against `now`", { skip }, () => {
+    const snapshot = {
+        iterations: [
+            { iteration: 1, startedAt: 0, endedAt: null, excerpt: null },
+        ],
+    };
+    // Pass a deterministic `now` so the elapsed cell renders 5.0s.
+    const out = render(React.createElement(Timeline, { snapshot, now: 5000 })).lastFrame();
+    assert.match(out, /5\.0s/);
+});
+
+test("Issue #56 slice 1: Timeline 0-ms iter renders 0.0s (not NaN / -0)", { skip }, () => {
+    const snapshot = {
+        iterations: [
+            { iteration: 1, startedAt: 1000, endedAt: 1000, excerpt: "instant" },
+        ],
+    };
+    const out = render(React.createElement(Timeline, { snapshot })).lastFrame();
+    assert.match(out, /0\.0s/);
+    assert.doesNotMatch(out, /NaN/);
+});
+
+test("Issue #56 slice 2: formatTokenDelta renders 1.2k for >= 1000, raw int otherwise", { skip }, () => {
+    assert.equal(formatTokenDelta(0), "0");
+    assert.equal(formatTokenDelta(42), "42");
+    assert.equal(formatTokenDelta(999), "999");
+    assert.equal(formatTokenDelta(1000), "1.0k");
+    assert.equal(formatTokenDelta(1234), "1.2k");
+    assert.equal(formatTokenDelta(12500), "12.5k");
+});
+
+test("Issue #56 slice 2: formatTokenDelta null/non-finite renders dash", { skip }, () => {
+    assert.equal(formatTokenDelta(null), "—");
+    assert.equal(formatTokenDelta(undefined), "—");
+    assert.equal(formatTokenDelta(NaN), "—");
+});
+
+test("Issue #56 slice 2: computeTokenDelta sums input+output minus tokensAtStart", { skip }, () => {
+    const iter = { tokensAtStart: { input: 100, output: 200 } };
+    const snap = { tokens: { input: 150, output: 1450 } };
+    // (150+1450) - (100+200) = 1300
+    assert.equal(computeTokenDelta(iter, snap), 1300);
+});
+
+test("Issue #56 slice 2: computeTokenDelta returns null when tokensAtStart missing (replay-safe)", { skip }, () => {
+    const iter = { iteration: 1 };  // old iter without tokensAtStart
+    const snap = { tokens: { input: 100, output: 200 } };
+    assert.equal(computeTokenDelta(iter, snap), null);
+});
+
+test("Issue #56 slice 2: Timeline renders '1.2k tok' for a closed iter with token delta >= 1000", { skip }, () => {
+    const snapshot = {
+        iterations: [
+            { iteration: 1, startedAt: 0, endedAt: 1000,
+              tokensAtStart: { input: 0, output: 0 }, excerpt: "ok" },
+        ],
+        tokens: { input: 0, output: 1234 },
+    };
+    const out = render(React.createElement(Timeline, { snapshot })).lastFrame();
+    assert.match(out, /1\.2k tok/);
+});
+
+test("Issue #56 slice 2: Timeline renders dash for old iter without tokensAtStart (replay-safety)", { skip }, () => {
+    const snapshot = {
+        iterations: [
+            { iteration: 1, startedAt: 0, endedAt: 1000, excerpt: "ok" }, // no tokensAtStart
+        ],
+        tokens: { input: 0, output: 1234 },
+    };
+    const out = render(React.createElement(Timeline, { snapshot })).lastFrame();
+    // The token cell renders `—` standalone (not `— tok`) for missing data.
+    assert.match(out, /—/);
+    assert.doesNotMatch(out, /1\.2k/);
+});
+
+test("Issue #56 slice 2: Timeline in-flight iter ticks token delta from live snap.tokens", { skip }, () => {
+    const snapshot = {
+        iterations: [
+            { iteration: 1, startedAt: 0, endedAt: null,
+              tokensAtStart: { input: 0, output: 0 }, excerpt: "working" },
+        ],
+        tokens: { input: 0, output: 500 },  // 500 tok delta live
+    };
+    const out = render(React.createElement(Timeline, { snapshot, now: 1000 })).lastFrame();
+    assert.match(out, /500 tok/);
+});
+
+test("Issue #56 slice 3: computePremiumDelta returns null when both null (hidden cell)", { skip }, () => {
+    const iter = { premiumAtStart: null };
+    const snap = { premiumRequests: null };
+    assert.equal(computePremiumDelta(iter, snap), null);
+});
+
+test("Issue #56 slice 3: computePremiumDelta returns delta when both present", { skip }, () => {
+    const iter = { premiumAtStart: 5 };
+    const snap = { premiumRequests: 8 };
+    assert.equal(computePremiumDelta(iter, snap), 3);
+});
+
+test("Issue #56 slice 3: Timeline renders ⊕N for premium delta when data present", { skip }, () => {
+    const snapshot = {
+        iterations: [
+            { iteration: 1, startedAt: 0, endedAt: 1000,
+              tokensAtStart: { input: 0, output: 0 },
+              premiumAtStart: 0, excerpt: "ok" },
+        ],
+        tokens: { input: 0, output: 0 },
+        premiumRequests: 2,
+    };
+    const out = render(React.createElement(Timeline, { snapshot })).lastFrame();
+    assert.match(out, /⊕2/);
+});
+
+test("Issue #56 slice 3: Timeline hides premium cell when both snap and iter values null", { skip }, () => {
+    const snapshot = {
+        iterations: [
+            { iteration: 1, startedAt: 0, endedAt: 1000,
+              tokensAtStart: { input: 0, output: 0 },
+              premiumAtStart: null, excerpt: "ok" },
+        ],
+        tokens: { input: 0, output: 0 },
+        premiumRequests: null,
+    };
+    const out = render(React.createElement(Timeline, { snapshot })).lastFrame();
+    assert.doesNotMatch(out, /⊕/);
+});
+
+test("Issue #56 slice 4: Timeline renders 📁N for filesChanged when present", { skip }, () => {
+    const snapshot = {
+        iterations: [
+            { iteration: 1, startedAt: 0, endedAt: 1000,
+              tokensAtStart: { input: 0, output: 0 },
+              filesChanged: 3, excerpt: "ok" },
+        ],
+        tokens: { input: 0, output: 0 },
+    };
+    const out = render(React.createElement(Timeline, { snapshot })).lastFrame();
+    assert.match(out, /📁3/);
+});
+
+test("Issue #56 slice 4: Timeline hides files-changed cell when filesChanged absent (replay-safety)", { skip }, () => {
+    const snapshot = {
+        iterations: [
+            { iteration: 1, startedAt: 0, endedAt: 1000,
+              tokensAtStart: { input: 0, output: 0 }, excerpt: "ok" }, // no filesChanged
+        ],
+        tokens: { input: 0, output: 0 },
+    };
+    const out = render(React.createElement(Timeline, { snapshot })).lastFrame();
+    assert.doesNotMatch(out, /📁/);
+});
+
+test("Issue #56 slice 4: Timeline renders 📁0 (dim) when filesChanged is 0", { skip }, () => {
+    const snapshot = {
+        iterations: [
+            { iteration: 1, startedAt: 0, endedAt: 1000,
+              tokensAtStart: { input: 0, output: 0 },
+              filesChanged: 0, excerpt: "ok" },
+        ],
+        tokens: { input: 0, output: 0 },
+    };
+    const out = render(React.createElement(Timeline, { snapshot })).lastFrame();
+    assert.match(out, /📁0/);
 });

--- a/packages/tui/test/events.test.mjs
+++ b/packages/tui/test/events.test.mjs
@@ -1634,3 +1634,110 @@ test("foldEvents: malformed worktree_created (missing fields) is a no-op", () =>
     const snap = foldEvents(events);
     assert.equal(snap.activeWorktree, null);
 });
+
+// ─── Issue #56 — per-iter stat snapshots & filesChanged carry-through ───
+
+test("Issue #56: foldEvents — iteration_start snapshots tokensAtStart from cumulative tokens", () => {
+    const events = [
+        { type: "armed", ts: 100, runId: "r", label: "self_improve" },
+        { type: "iteration_start", ts: 200, runId: "r", iteration: 1 },
+        { type: "iteration_end", ts: 300, runId: "r", iteration: 1, excerpt: "ok",
+          tokens: { input: 0, output: 500 }, premiumRequests: 2 },
+        // Iter 2 starts with cumulative tokens=500, premium=2.
+        { type: "iteration_start", ts: 400, runId: "r", iteration: 2 },
+    ];
+    const snap = foldEvents(events);
+    assert.equal(snap.iterations.length, 2);
+    // Iter 1 captured tokens={0,0} (run had not yet emitted any usage).
+    assert.deepEqual(snap.iterations[0].tokensAtStart, { input: 0, output: 0 });
+    assert.equal(snap.iterations[0].premiumAtStart, null);
+    // Iter 2 snapshot picks up the post-iter-1 totals.
+    assert.deepEqual(snap.iterations[1].tokensAtStart, { input: 0, output: 500 });
+    assert.equal(snap.iterations[1].premiumAtStart, 2);
+});
+
+test("Issue #56: foldEvents — iteration_end carries filesChanged through to iter object", () => {
+    const events = [
+        { type: "armed", ts: 100, runId: "r", label: "self_improve" },
+        { type: "iteration_start", ts: 200, runId: "r", iteration: 1 },
+        { type: "iteration_end", ts: 300, runId: "r", iteration: 1, excerpt: "ok",
+          tokens: { input: 0, output: 100 }, filesChanged: 7 },
+    ];
+    const snap = foldEvents(events);
+    assert.equal(snap.iterations[0].filesChanged, 7);
+});
+
+test("Issue #56: foldEvents — iteration_end without filesChanged leaves field undefined (replay-safe)", () => {
+    const events = [
+        { type: "armed", ts: 100, runId: "r", label: "self_improve" },
+        { type: "iteration_start", ts: 200, runId: "r", iteration: 1 },
+        // No filesChanged — pre-issue-56 events.jsonl shape.
+        { type: "iteration_end", ts: 300, runId: "r", iteration: 1, excerpt: "ok",
+          tokens: { input: 0, output: 100 } },
+    ];
+    const snap = foldEvents(events);
+    assert.equal(snap.iterations[0].filesChanged, undefined);
+});
+
+test("Issue #56: serializeEvent — filesChanged round-trips on iteration_end when finite >= 0", () => {
+    const ev = {
+        type: "iteration_end",
+        ts: 1,
+        runId: "r",
+        iteration: 1,
+        excerpt: "ok",
+        tokens: { input: 0, output: 50 },
+        filesChanged: 3,
+    };
+    const line = serializeEvent(ev);
+    const back = parseEventLine(line);
+    assert.equal(back.filesChanged, 3);
+});
+
+test("Issue #56: serializeEvent — filesChanged of 0 round-trips (zero is a valid value)", () => {
+    const ev = {
+        type: "iteration_end",
+        ts: 1,
+        runId: "r",
+        iteration: 1,
+        excerpt: "ok",
+        tokens: { input: 0, output: 50 },
+        filesChanged: 0,
+    };
+    const back = parseEventLine(serializeEvent(ev));
+    assert.equal(back.filesChanged, 0);
+});
+
+test("Issue #56: serializeEvent — malformed filesChanged is dropped", () => {
+    for (const bad of [Number.NaN, Infinity, -1, "5", null]) {
+        const out = serializeEvent({
+            type: "iteration_end",
+            ts: 1,
+            runId: "r",
+            iteration: 1,
+            excerpt: "ok",
+            tokens: { input: 0, output: 50 },
+            filesChanged: bad,
+        });
+        const back = parseEventLine(out);
+        assert.equal(back.filesChanged, undefined, `bad value ${bad} must be dropped`);
+    }
+});
+
+test("Issue #56: foldEvents — second iter's tokensAtStart reflects mid-iter usage_update accumulation", () => {
+    // Pin that the snapshot at iter-2 start picks up usage_update
+    // increments from iter 1, not just iteration_end totals. Mirrors
+    // the live-emission path in runner.mjs.
+    const events = [
+        { type: "armed", ts: 100, runId: "r", label: "self_improve" },
+        { type: "iteration_start", ts: 200, runId: "r", iteration: 1 },
+        { type: "usage_update", ts: 250, runId: "r", iteration: 1,
+          tokens: { input: 0, output: 750 }, premiumRequests: 1 },
+        { type: "iteration_end", ts: 300, runId: "r", iteration: 1, excerpt: "ok",
+          tokens: { input: 0, output: 750 }, premiumRequests: 1 },
+        { type: "iteration_start", ts: 400, runId: "r", iteration: 2 },
+    ];
+    const snap = foldEvents(events);
+    assert.deepEqual(snap.iterations[1].tokensAtStart, { input: 0, output: 750 });
+    assert.equal(snap.iterations[1].premiumAtStart, 1);
+});

--- a/packages/tui/test/runner.test.mjs
+++ b/packages/tui/test/runner.test.mjs
@@ -1327,6 +1327,7 @@ import {
     computePinnedTailAmendments,
     looksLikeGitCommit,
     readHeadCommit,
+    computeIterFilesChanged,
 } from "../src/runner.mjs";
 import { PINNED_TAIL_STAGES } from "../src/events.mjs";
 
@@ -1691,10 +1692,16 @@ test("runRalphTui: failed git commit substage does NOT trigger commit_observed",
         worktree: false,
     });
     assert.equal(events.filter((e) => e.type === "commit_observed").length, 0);
-    // Arm-time replay-on-mount calls gitExec once (rev-parse).
-    // Returns null → readHeadCommit short-circuits, no log call.
+    // gitExec call sites in this scenario:
+    //   1. arm-time replay-on-mount `rev-parse --short HEAD` (issue #54 slice 2c)
+    //      → returns null → readHeadCommit short-circuits, no log call.
+    //   2. iter-start `rev-parse HEAD` (issue #56 slice 4) → returns null
+    //      → iterStartSha stays null.
+    //   3. iter-end `git status --porcelain` (issue #56 slice 4) →
+    //      returns null → filesChanged degrades to 0 (omitted).
     // Failed-commit substage path doesn't shell to git either.
-    assert.equal(gitExecCalls, 1, "gitExec called once at arm-time replay (rev-parse), short-circuits on null");
+    assert.equal(gitExecCalls, 3,
+        "arm-time rev-parse + iter-start rev-parse + iter-end status --porcelain");
 });
 
 test("runRalphTui: non-bash tool with 'git commit' in argsSummary does NOT fire commit_observed", async () => {
@@ -2272,9 +2279,14 @@ test("runRalphTui smoke: full marker stream surfaces stage_plan + task_list + ta
     assert.equal(snap.lastCommit?.sha, "abc1234");
     assert.equal(snap.lastCommit?.subject, "feat(tui): smoke");
 
-    // The runner shelled out to git four times: arm-time
-    // (rev-parse + log) + iter-1 commit (rev-parse + log).
-    assert.equal(gitCalls, 4, "arm-time + iter-1 each compose rev-parse + log");
+    // The runner shelled out to git six times:
+    //   - arm-time replay (rev-parse --short HEAD + log)
+    //   - iter-1 commit substage (rev-parse --short HEAD + log)
+    //   - iter-1 start: rev-parse HEAD (issue #56 slice 4 — stub
+    //     returns null for non-`--short` rev-parse, so iterStartSha
+    //     is null and the iter-end skips the diff)
+    //   - iter-1 end: status --porcelain (issue #56 slice 4)
+    assert.equal(gitCalls, 6, "arm-time + iter-1 each compose rev-parse + log; plus issue #56 iter-start rev-parse + iter-end status --porcelain");
 });
 
 // ─── Issue #57 — session_attached emission contract ──────────────
@@ -2412,4 +2424,166 @@ test("runRalphTui: omits session_attached when result.sessionId is missing", asy
     });
     const sa = events.filter((e) => e.type === "session_attached");
     assert.equal(sa.length, 0, "no event when reducer didn't surface a sessionId");
+});
+
+// ─── Issue #56 slice 4 — computeIterFilesChanged + iteration_end carries field ───
+
+test("computeIterFilesChanged: gitExec=null returns null (non-git cwd / test injection)", () => {
+    assert.equal(computeIterFilesChanged({
+        gitExec: null, cwd: "/repo", env: {}, iterStartSha: "abc1234",
+    }), null);
+});
+
+test("computeIterFilesChanged: HEAD changed → counts diff + status lines", () => {
+    const calls = [];
+    const gitExec = ({ args }) => {
+        calls.push(args.join(" "));
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "def5678\n";
+        if (args[0] === "diff" && args[1] === "--name-only") {
+            // 3 committed files
+            return "src/a.mjs\nsrc/b.mjs\ntest/c.test.mjs\n";
+        }
+        if (args[0] === "status" && args[1] === "--porcelain") {
+            // 2 uncommitted churn lines
+            return " M README.md\n?? new-file.txt\n";
+        }
+        return null;
+    };
+    const out = computeIterFilesChanged({
+        gitExec, cwd: "/repo", env: {}, iterStartSha: "abc1234",
+    });
+    assert.equal(out, 5, "3 committed + 2 uncommitted");
+    assert.deepEqual(calls, [
+        "rev-parse HEAD",
+        "diff --name-only abc1234..HEAD",
+        "status --porcelain",
+    ]);
+});
+
+test("computeIterFilesChanged: HEAD unchanged → committed=0, status only", () => {
+    const gitExec = ({ args }) => {
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "abc1234\n";
+        if (args[0] === "status" && args[1] === "--porcelain") return " M one.mjs\n";
+        return null;
+    };
+    const out = computeIterFilesChanged({
+        gitExec, cwd: "/repo", env: {}, iterStartSha: "abc1234",
+    });
+    assert.equal(out, 1, "no commit landed → only the one uncommitted file counts");
+});
+
+test("computeIterFilesChanged: iterStartSha=null → skip diff entirely, count only status", () => {
+    const calls = [];
+    const gitExec = ({ args }) => {
+        calls.push(args[0]);
+        if (args[0] === "status") return "?? a\n?? b\n?? c\n";
+        return null;
+    };
+    const out = computeIterFilesChanged({
+        gitExec, cwd: "/repo", env: {}, iterStartSha: null,
+    });
+    assert.equal(out, 3);
+    // No rev-parse / diff calls when iterStartSha is null.
+    assert.deepEqual(calls, ["status"]);
+});
+
+test("computeIterFilesChanged: gitExec returns null for everything → 0 (clean repo)", () => {
+    const out = computeIterFilesChanged({
+        gitExec: () => null, cwd: "/repo", env: {}, iterStartSha: "abc1234",
+    });
+    assert.equal(out, 0);
+});
+
+test("computeIterFilesChanged: tolerates blank lines / \\r\\n line endings", () => {
+    const gitExec = ({ args }) => {
+        if (args[0] === "status") return "?? a\r\n\r\n?? b\r\n";
+        return null;
+    };
+    assert.equal(computeIterFilesChanged({
+        gitExec, cwd: "/repo", env: {}, iterStartSha: null,
+    }), 2);
+});
+
+test("runRalphTui: iteration_end carries filesChanged when gitExec returns canned diff/status", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "files-changed-test",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    // gitExec stub: arm-time + iter-1 readHeadCommit, plus iter-start
+    // rev-parse HEAD (returns SHA1), iter-end rev-parse HEAD (returns
+    // SHA2 — HEAD changed), iter-end diff (2 files), iter-end status
+    // (1 uncommitted).
+    let revParseHeadCalls = 0;
+    const gitExec = ({ args }) => {
+        if (args[0] === "rev-parse" && args[1] === "--short") return "abc1234\n";
+        if (args[0] === "log") return "subject ";
+        if (args[0] === "rev-parse" && args[1] === "HEAD") {
+            revParseHeadCalls += 1;
+            // 1st = iter-start; 2nd = iter-end (computeIterFilesChanged).
+            return revParseHeadCalls === 1 ? "0000aaa\n" : "0000bbb\n";
+        }
+        if (args[0] === "diff" && args[1] === "--name-only") {
+            return "file1.mjs\nfile2.mjs\n";  // 2 committed
+        }
+        if (args[0] === "status" && args[1] === "--porcelain") {
+            return " M dirty.mjs\n";  // 1 uncommitted
+        }
+        return null;
+    };
+    const spawn = makeMockSpawn([
+        {
+            stdout: [
+                JSON.stringify({ type: "assistant.message", data: { content: "wrap up COMPLETE" } }),
+                JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+            ].join("\n") + "\n",
+            exitCode: 0,
+        },
+    ]);
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+        gitExec,
+    });
+    const iterEnds = events.filter((e) => e.type === "iteration_end");
+    assert.equal(iterEnds.length, 1);
+    assert.equal(iterEnds[0].filesChanged, 3, "2 committed + 1 uncommitted");
+});
+
+test("runRalphTui: iteration_end omits filesChanged when gitExec is not provided (test/non-git)", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "no-files-changed-test",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    const spawn = makeMockSpawn([
+        {
+            stdout: [
+                JSON.stringify({ type: "assistant.message", data: { content: "wrap up COMPLETE" } }),
+                JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+            ].join("\n") + "\n",
+            exitCode: 0,
+        },
+    ]);
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+        gitExec: null,
+    });
+    const iterEnds = events.filter((e) => e.type === "iteration_end");
+    assert.equal(iterEnds.length, 1);
+    assert.equal(iterEnds[0].filesChanged, undefined,
+        "field omitted when gitExec is null so Timeline cell stays hidden");
 });


### PR DESCRIPTION
Closes #56.

## Summary

Add four cells to each `<Timeline>` row, between the iteration # and the excerpt:

```
✓ #  3  4.2s  1.2k tok  ⊕2  📁3  [STAGE: COMMIT] All 247 tests…
│  │    │     │         │   │    └─ excerpt
│  │    │     │         │   └────── files changed (📁N) — committed delta + uncommitted churn
│  │    │     │         └────────── premium-request delta (⊕N)
│  │    │     └──────────────────── token delta this iter
│  │    └────────────────────────── duration (live elapsed for in-flight)
│  └─────────────────────────────── iteration #
└────────────────────────────────── status glyph
```

All cells render dim-on-zero so quiet iters stay quiet. Cells with no data render `—` (or hide entirely for premium / files) so a pre-this-issue `events.jsonl` replay shows no crash, no `NaN`, no `undefined`.

### Slices

- **Slice 1 (duration)**: `formatDuration(ms)` → `4.2s` (< 60s) / `1m23s` (≥ 60s). Live-elapsed for in-flight iter via `<App>`'s existing 1Hz `now` tick (already used by `<Header>`'s elapsed counter).
- **Slice 2 (tokens)**: `foldEvents` snapshots `tokensAtStart = { ...snap.tokens }` on `iteration_start`; Timeline derives `tokensThisIter = (snap.tokens.input + snap.tokens.output) - (iter.tokensAtStart.input + iter.tokensAtStart.output)`. Format: `1.2k` for ≥ 1000, raw int otherwise.
- **Slice 3 (premium)**: same shape via `premiumAtStart`. Glyph `⊕N`. Hidden when both cur and start are null.
- **Slice 4 (files)**: new optional `filesChanged: number` field on `iteration_end`. Runner captures HEAD SHA at iter start (`gitRevParseHead` helper extracted from `readHeadCommit`); at iter end, `computeIterFilesChanged` sums `git diff --name-only <iter-start-sha>..HEAD` line count + `git status --porcelain` line count.

## Test plan

- [x] `npm test` from repo root — 549 passing, 0 failing, 0 skipped (with `cd packages/tui && npm install` for the Ink renderer).
- [x] `npm run check` from repo root — clean.
- [x] `node packages/tui/bin/tui.mjs --help` — exit 0.
- [x] 16 new `components.test.mjs` tests pin every cell (formatters, in-flight live tick, 0-ms iter renders `0.0s` not `NaN`, replay-safety dash for old iters, premium cell hidden when both null, files-changed dim-on-zero).
- [x] 6 new `events.test.mjs` tests pin `tokensAtStart` / `premiumAtStart` capture, `filesChanged` carry-through, and serialize/parse round-trip for the new field (including malformed-value drops).
- [x] 7 new `runner.test.mjs` tests for `computeIterFilesChanged` (HEAD changed / unchanged / iterStartSha=null / clean repo / CRLF tolerance) plus an end-to-end `runRalphTui` test that stubs `gitExec` with canned diff/status output and pins the iter-end event's `filesChanged` field.
- [x] Updated two pre-existing runner tests that pin exact `gitExec` call counts to account for the new iter-start `rev-parse HEAD` and iter-end `status --porcelain` shells.

## Replay-safety

- Existing `events.jsonl` files lack `tokensAtStart` / `premiumAtStart` snapshots and `filesChanged` field. The Timeline renders:
  - `—` (dim) for the token cell when `tokensAtStart` is missing.
  - Premium and files cells hidden entirely (not just dim) when their values are missing.
- The `iteration_end` event schema gain is strictly additive — the serializer drops malformed values (NaN / Infinity / negative) so a third-party emitter cannot poison the stream.