### PR TITLE
feat(tui-run)!: replace --continue/--fresh with --reset-on={workitem|iter|never} (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@
 - Startup sweep removes orphan worktrees from prior `terminated` runs (~200 ms budget). (#66)
 
 ### Breaking
-- Binary renamed `ralph-tui` → `autopilot`. Bare invocation now starts `run --self-improve --fresh` (was: print help). Use `autopilot --help` for the previous help output. (#65)
+- Issue #51 — Replaced `ralph-tui run --continue` / `--fresh` with
+  `--reset-on={workitem|iter|never}` (default `workitem`). The old
+  flags continue to work as aliases for one release with a one-shot
+  stderr deprecation notice on first use (`--continue` → `--reset-on=never`,
+  `--fresh` → `--reset-on=iter`). Users who relied on `--continue`'s
+  implicit "always continue" semantics must pass `--reset-on=never`
+  (or the deprecated `--continue` alias) to keep the old behaviour.
+  The new `workitem` default starts a fresh Copilot session at every
+  `[WORKITEM_END]` boundary (or any iter exit), so stages within a
+  single work item share one reasoning chain but unrelated backlog
+  items don't cross-pollinate.
+- Binary renamed `ralph-tui` → `autopilot`. Bare invocation now starts `run --self-improve` with the post-issue-#51 default `--reset-on=workitem` (was: print help). Use `autopilot --help` for the previous help output. (#65)
 - Issue #50 — Removed the in-session Copilot CLI extension.
   The project now ships only as the `ralph-tui` standalone TUI
   app. The `ralph_loop`, `ralph_status`, `ralph_pause`,
@@ -112,7 +123,22 @@
   end-to-end `runRalphTui` test stubs `gitExec` with canned
   diff/status output and pins the iter-end event's `filesChanged`
   field.
-
+- Issue #51 — `autopilot run --reset-on=workitem` (the new default)
+  starts a fresh Copilot session at each `[WORKITEM_END]` boundary,
+  so stages within a work item share context but unrelated backlog
+  items don't cross-pollinate. The `iter` value preserves the
+  status-quo `--fresh` behaviour (every iter starts fresh) and
+  `never` preserves the status-quo `--continue` behaviour (single
+  Copilot session for the whole run). Treats every iter exit as an
+  implicit work-item boundary so a half-finished item never carries
+  stale context into the next iter. The runner's existing
+  per-iter `result.sessionId` capture is reused: in `workitem` mode
+  the captured value is dropped at every iter-exit (whether or not
+  `[WORKITEM_END]` fired); in `never` mode it persists for the whole
+  run; in `iter` mode the runner never captures it. `armed` events
+  now carry both the legacy `contextMode` (continue/fresh/workitem)
+  and the new `resetOn` field so back-compat consumers
+  (`autopilot list / stats`) keep working.
 - Issue #57 — `ralph-tui watch` Live panel streams the agent's
   output (assistant text, tool calls, tool results) for the
   currently active L3 task, sourced directly from the Copilot

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ autopilot --help
 autopilot --version
 ```
 
-Bare `autopilot` (no subcommand) starts a self-improve loop with `--fresh` context, equivalent to `autopilot run --self-improve --fresh`.
+Bare `autopilot` (no subcommand) starts a self-improve loop with the default `--reset-on=workitem` boundary, equivalent to `autopilot run --self-improve`.
 
 ### Plain mode (no install)
 
@@ -45,29 +45,40 @@ A future release will publish `autopilot` to npm so `npm i -g autopilot` works; 
 ## Usage
 
 ```bash
-# Default — bare invocation runs --self-improve --fresh.
+# Default — bare invocation runs --self-improve with the per-work-item
+# reset (stages within a work item share context; new work item → fresh
+# Copilot session).
 autopilot
 
-# Drive a backlog-drain loop, fresh context every iter (50-iter cap).
-autopilot run --self-improve --fresh --max 50
+# Drive a backlog-drain loop with the default per-work-item reset.
+# 50-iter cap.
+autopilot run --self-improve --max 50
 
-# Same, but resume the same Copilot session every iter (context grows).
-autopilot run --self-improve --continue --max 50
+# Same, but reset every iter regardless of work-item boundaries
+# (status-quo `--fresh`).
+autopilot run --self-improve --reset-on=iter --max 50
 
-# Grow the project backlog with a focus area, fresh context per iter.
-autopilot run --grow-project --fresh \
+# Resume the same Copilot session every iter (context grows
+# monotonically; status-quo `--continue`).
+autopilot run --self-improve --reset-on=never --max 50
+
+# Grow the project backlog with a focus area.
+autopilot run --grow-project --reset-on=iter \
   --focus "autopilot replay UX" --max 30
 
 # Custom prompt mode — re-fed verbatim every iter until COMPLETE.
 autopilot run \
   --prompt "Refactor packages/tui/src/runner.mjs and add tests. Emit COMPLETE when green." \
-  --fresh --max 20
+  --reset-on=iter --max 20
 ```
 
-Pick exactly one prompt mode (`--self-improve` / `--grow-project` / `--prompt "..."`) AND exactly one context mode (`--continue` / `--fresh`).
+Pick exactly one prompt mode (`--self-improve` / `--grow-project` / `--prompt "..."`). The optional `--reset-on={workitem|iter|never}` flag picks the context-reset boundary; default is `workitem`:
 
-* `--continue` captures the terminal `result.sessionId` from the JSONL stream on iter 1 and resumes via `--resume=<sessionId>` on iter 2+ so the agent's context grows monotonically.
-* `--fresh` re-spawns with no session reuse — every iteration starts from a clean slate.
+* `--reset-on=workitem` (default) — start a fresh Copilot session at every `[WORKITEM_END]` marker (or any iter exit). Stages within a work item share one reasoning chain (so IMPLEMENT can see what BASELINE detected, etc.); unrelated backlog items don't cross-pollinate.
+* `--reset-on=iter` — every iter starts a brand-new Copilot session (clean context per iter; status-quo `--fresh`).
+* `--reset-on=never` — capture iter 1's `result.sessionId` from the JSONL stream and resume via `--resume=<sessionId>` on iter 2+ so the agent's context grows monotonically (status-quo `--continue`).
+
+The legacy `--continue` and `--fresh` flags continue to work as aliases for `--reset-on=never` and `--reset-on=iter` respectively, with a one-shot stderr deprecation notice on first use; they will be removed in a future release.
 
 Events flow into `~/.copilot/autopilot/runs/<runId>/events.jsonl`. Use `autopilot list / replay / watch / stats / doctor / prune` to inspect them.
 
@@ -163,7 +174,7 @@ The first identifies the agent. The second attributes the commit to a dedicated 
 Set `AUTOPILOT_NO_ATTRIBUTION=1` in the environment before running the loop to suppress the second `copilot-ralph` trailer. The first `Copilot` trailer still ships, since it identifies the agent that made the change. The opt-out is **honored by the prompt** — the agent reads the env var during the COMMIT stage and omits the trailer accordingly.
 
 ```bash
-AUTOPILOT_NO_ATTRIBUTION=1 autopilot run --self-improve --fresh
+AUTOPILOT_NO_ATTRIBUTION=1 autopilot run --self-improve
 ```
 
 > Legacy `RALPH_NO_ATTRIBUTION=1` is still recognized as a fallback for one release.
@@ -178,7 +189,7 @@ AUTOPILOT_NO_ATTRIBUTION=1 autopilot run --self-improve --fresh
 Long `autopilot run` loops can outlast macOS's idle-sleep timeout. Set `AUTOPILOT_CAFFEINATE=1` and the runner will spawn `caffeinate -i` for the duration of the run:
 
 ```bash
-AUTOPILOT_CAFFEINATE=1 autopilot run --self-improve --fresh
+AUTOPILOT_CAFFEINATE=1 autopilot run --self-improve
 ```
 
 To also keep the display awake, opt into `idle+display` scope:
@@ -192,9 +203,9 @@ The wrapper script [`scripts/autopilot-fresh.sh`](scripts/autopilot-fresh.sh) is
 ## Limitations
 
 - **Substring-match completion can self-trigger.** Both `--completion-promise` and `--abort-promise` use plain substring matching against the assistant's accumulated turn output. If the agent quotes the trigger phrase mid-thought (e.g. *"I'll mark this COMPLETE when done"*), the loop will finish on that turn. Pick a phrase the agent is unlikely to mention casually.
-- **Prompt is re-injected verbatim every iteration.** The loop has no concept of progress — the agent must derive what's already done from its own conversation history (in `--continue` mode) or from the working tree (in `--fresh` mode).
+- **Prompt is re-injected verbatim every iteration.** The loop has no concept of progress — the agent must derive what's already done from its own conversation history (in `--reset-on=never`) or from the working tree (in `--reset-on=workitem` / `--reset-on=iter` modes).
 - **One loop per `runId`.** The driver coordinates pause / resume / stop via the per-run state file; concurrently driving the same `runId` from two processes is unsupported.
-- **`--continue` mode requires a clean session-resume contract from the Copilot CLI.** If `copilot -p ... --output-format json` ever stops emitting a terminal `result.sessionId`, `--continue` falls back to `--fresh` and logs the regression.
+- **`--reset-on=never` requires a clean session-resume contract from the Copilot CLI.** If `copilot -p ... --output-format json` ever stops emitting a terminal `result.sessionId`, the resume becomes a fresh session for the next iter and the regression is logged.
 - **Attribution opt-out is honored by the prompt, not enforced by the runtime.** `AUTOPILOT_NO_ATTRIBUTION=1` suppresses the second `copilot-ralph` `Co-authored-by:` trailer only because the prompt instructs the agent to read the env var during COMMIT and omit the trailer. The driver does not rewrite commits — if a sub-agent ignores the env var, the trailer can still ship.
 - **No automatic rollback.** Loop-driven commits are not auto-reverted if a later iteration regresses. Treat the working branch as expendable, push to a feature branch, and review the diff before merging.
 - **An idle Copilot subscription still costs.** The loop keeps the Copilot CLI busy for the full run; budget accordingly.

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -32,6 +32,12 @@ autopilot stats                      Aggregate stats across the run
                                      p50/p95 durations, top SDLC tools).
 autopilot where                      Print the resolved runs root path
                                      so a contributor can `cd` into it.
+autopilot run …                      Drive an autonomous Copilot loop.
+                                     Pick exactly one prompt mode
+                                     (`--self-improve` / `--grow-project`
+                                     / `--prompt TEXT`) and optionally
+                                     `--reset-on={workitem|iter|never}`
+                                     (default `workitem`).
 autopilot --help     | -h            Show usage.
 autopilot --version  | -V            Print the autopilot package version.
 ```
@@ -42,6 +48,22 @@ interactive Ink-rendered watch UI (Header / Timeline / LiveOutputPane /
 Controls — see [docs/cli-stack.md](../../docs/cli-stack.md)) ships in
 the next slice; if its module isn't installed, `watch` falls back to
 `--plain` automatically.
+
+`--reset-on` controls when the runner starts a new Copilot session:
+
+* `workitem` (default) — fresh session at every `[WORKITEM_END]`
+  marker (or any iter exit). Stages within a single work item share
+  one Copilot session so the agent's reasoning chain stays intact;
+  unrelated backlog items don't cross-pollinate.
+* `iter` — fresh session every iter (status-quo `--fresh`).
+* `never` — same Copilot session for the whole run; iter 1's
+  `result.sessionId` is captured and reused via `--resume=<sessionId>`
+  for iter 2+ (status-quo `--continue`).
+
+The legacy `--continue` and `--fresh` flags continue to work as
+aliases for `--reset-on=never` and `--reset-on=iter` respectively,
+with a one-shot stderr deprecation notice on first use; they will be
+removed in a future release.
 
 ## Quick start
 
@@ -139,7 +161,7 @@ with the same args.
 alias autopilot="$HOME/repos/copilot-ralph-extension/scripts/ralph-tui-fresh.sh"
 
 # Then long-haul runs auto-upgrade before iter 1:
-autopilot run --self-improve --continue
+autopilot run --self-improve --reset-on=never
 
 # Quick read-only subcommands skip the upgrade (no `git pull` cost):
 autopilot list

--- a/packages/tui/bin/tui.mjs
+++ b/packages/tui/bin/tui.mjs
@@ -28,9 +28,15 @@
 //                                subprocess. Choose exactly one prompt
 //                                mode (`--self-improve` /
 //                                `--grow-project` / `--prompt`) AND
-//                                one context mode (`--continue` /
-//                                `--fresh`). Sibling `--pause <runId>`
-//                                / `--resume <runId>` / `--stop
+//                                optionally a context-reset boundary
+//                                (`--reset-on={workitem|iter|never}`,
+//                                default `workitem`). Legacy
+//                                `--continue` / `--fresh` flags map
+//                                onto `--reset-on=never` /
+//                                `--reset-on=iter` with a one-shot
+//                                stderr deprecation notice.
+//                                Sibling `--pause <runId>` /
+//                                `--resume <runId>` / `--stop
 //                                <runId>` / `--status <runId>` operate
 //                                on the run state file of an in-flight
 //                                loop.
@@ -66,7 +72,7 @@ USAGE
   autopilot stats
   autopilot where
   autopilot run (--self-improve | --grow-project | --prompt TEXT)
-                (--continue | --fresh)
+                [--reset-on={workitem|iter|never}]
                 [--max N] [--focus TEXT] [--headless | --plain]
                 [--completion-promise TOKEN] [--abort-promise TOKEN]
   autopilot run --pause <runId>
@@ -88,10 +94,15 @@ OPTIONS
   --self-improve  For \`run\`: drive the baked self_improve SDLC prompt.
   --grow-project  For \`run\`: drive the baked grow_project SDLC prompt.
   --prompt TEXT   For \`run\`: drive a ralph_loop-style custom prompt.
-  --continue  For \`run\`: every iter resumes the same Copilot session
-              (context grows monotonically).
-  --fresh     For \`run\`: every iter starts a brand-new Copilot session
-              (clean context per iter).
+  --reset-on={workitem|iter|never}
+              For \`run\`: when to start a fresh Copilot session.
+              Default \`workitem\` — new session at each
+              \`[WORKITEM_END]\` (or iter exit). \`iter\` resets every
+              iter; \`never\` keeps one session for the whole run.
+  --continue  Deprecated alias for \`--reset-on=never\` (one-shot
+              stderr notice on first use).
+  --fresh     Deprecated alias for \`--reset-on=iter\` (one-shot
+              stderr notice on first use).
   --max N     For \`run\`: iteration cap (default 100; default 1000 —
               effectively unbounded — for --self-improve since the
               loop is scope-driven, not iter-driven; max 1000).
@@ -125,11 +136,11 @@ ENV
  *  known value-taking flags listed in `VALUE_FLAGS` below
  *  (currently: --older-than for `prune`, --limit for `list`, plus
  *  the `run` subcommand's --max, --focus, --prompt,
- *  --completion-promise, --abort-promise, --pause, --resume, --stop,
- *  --status). When adding a new value flag, append it to
- *  `VALUE_FLAGS` AND update the USAGE block above so
+ *  --completion-promise, --abort-promise, --reset-on, --pause,
+ *  --resume, --stop, --status). When adding a new value flag, append
+ *  it to `VALUE_FLAGS` AND update the USAGE block above so
  *  `autopilot --help` keeps matching the parser. */
-const VALUE_FLAGS = new Set(["older-than", "limit", "max", "focus", "prompt", "completion-promise", "abort-promise", "pause", "resume", "stop", "status"]);
+const VALUE_FLAGS = new Set(["older-than", "limit", "max", "focus", "prompt", "completion-promise", "abort-promise", "pause", "resume", "stop", "status", "reset-on"]);
 
 /** Default `--max` iterations per loop mode for `autopilot run`.
  *
@@ -270,6 +281,28 @@ function fail(msg, code = 2) {
     process.stderr.write(`autopilot: ${msg}\n`);
     process.exit(code);
 }
+
+// Issue #51 — one-shot stderr deprecation notice for the legacy
+// `--continue` / `--fresh` flags. The flag itself keeps working
+// (mapped to `--reset-on=never` / `--reset-on=iter`) for one
+// release; the notice prints exactly once per process even if a
+// caller passes the flag twice (no-op by argv parser, but defensive).
+// Module-level guard so the same process can't print the same
+// message twice across multiple `cmdRun` invocations either.
+const _deprecationWarned = new Set();
+export function warnDeprecatedFlagOnce(flag, mapping, sink = process.stderr) {
+    if (_deprecationWarned.has(flag)) return;
+    _deprecationWarned.add(flag);
+    sink.write?.(`autopilot run: --${flag} is deprecated; use --reset-on=${mapping} instead. ` +
+        `--${flag} will be removed in a future release.\n`);
+}
+// Test-only hook so the bin.test.mjs cases for the deprecation
+// notice can run independently. The `__test__` bag is the
+// project-wide convention for "tests can reach in but library
+// users should not" — see also writer.mjs.
+export const __test__ = {
+    resetDeprecationWarnings: () => _deprecationWarned.clear(),
+};
 
 /** Format the user-visible message printed when the user requests
  *  abort via `q` (or, in the future, any other voluntary stop
@@ -599,16 +632,46 @@ export async function cmdRun(flags) {
         return 2;
     }
 
-    let contextMode = null;
-    if (flags.continue) contextMode = "continue";
+    // Issue #51 — `--reset-on={workitem|iter|never}` (default
+    // `workitem`) replaces the binary `--continue` / `--fresh` flag.
+    // Legacy flags continue to work as aliases with a one-shot
+    // stderr deprecation notice; mixing the new flag with either
+    // alias is a usage error so a stale script can't accidentally
+    // half-migrate.
+    const acceptedResetOn = runner.RESET_ON_VALUES;
+    let resetOn = null;
+    if (flags["reset-on"] !== undefined) {
+        const v = flags["reset-on"];
+        if (v === true || typeof v !== "string") {
+            fail(`run --reset-on: requires a value of ${acceptedResetOn.join(", ")}`);
+            return 2;
+        }
+        if (!acceptedResetOn.includes(v)) {
+            fail(`run --reset-on: expected one of ${acceptedResetOn.join(", ")} (got '${v}')`);
+            return 2;
+        }
+        resetOn = v;
+    }
+    if (flags.continue) {
+        if (resetOn !== null) {
+            fail(`run: --continue is a deprecated alias for --reset-on=never; pass only one`);
+            return 2;
+        }
+        warnDeprecatedFlagOnce("continue", "never");
+        resetOn = "never";
+    }
     if (flags.fresh) {
-        if (contextMode) { fail(`run: choose exactly one of --continue / --fresh`); return 2; }
-        contextMode = "fresh";
+        if (resetOn !== null) {
+            fail(`run: --fresh is a deprecated alias for --reset-on=iter; pass only one of --reset-on / --continue / --fresh`);
+            return 2;
+        }
+        warnDeprecatedFlagOnce("fresh", "iter");
+        resetOn = "iter";
     }
-    if (!contextMode) {
-        fail(`run: choose one of --continue / --fresh (no default — context behaviour is too consequential to guess)`);
-        return 2;
-    }
+    // Default: per-work-item resets. See the issue #51 design
+    // discussion in the runner's header comment for why this is
+    // the right default.
+    if (resetOn === null) resetOn = "workitem";
 
     let max;
     if (flags.max !== undefined) {
@@ -728,7 +791,7 @@ export async function cmdRun(flags) {
     try {
         const result = await runner.runRalphTui({
             mode,
-            contextMode,
+            resetOn,
             prompt: promptText,
             focus,
             max,
@@ -841,14 +904,15 @@ export async function main(argv = process.argv.slice(2)) {
         return 0;
     }
     // Bare invocation (no subcommand, no positional) defaults to
-    // `run --self-improve --fresh` so the user does not have to memorise
-    // the canonical drive-the-backlog incantation. `--help` / `--version`
-    // already short-circuited above; explicit subcommands keep their
-    // existing behaviour via the switch below.
+    // `run --self-improve` (which inherits `--reset-on=workitem`,
+    // the post-issue-#51 default). The user does not have to
+    // memorise the canonical drive-the-backlog incantation.
+    // `--help` / `--version` already short-circuited above; explicit
+    // subcommands keep their existing behaviour via the switch
+    // below.
     if (!cmd && !positional.length) {
-        process.stderr.write("autopilot: starting self-improve loop (--fresh). Press q to stop.\n");
+        process.stderr.write("autopilot: starting self-improve loop (--reset-on=workitem). Press q to stop.\n");
         flags["self-improve"] = true;
-        flags.fresh = true;
         return await cmdRun(flags);
     }
     switch (cmd) {

--- a/packages/tui/src/runner.mjs
+++ b/packages/tui/src/runner.mjs
@@ -1,12 +1,19 @@
 // `ralph-tui run` driver — runs each iteration as a fresh
-// `copilot -p ...` subprocess. Two session modes:
+// `copilot -p ...` subprocess. Three context-reset boundaries
+// (selected via `--reset-on={workitem|iter|never}`, default
+// `workitem`):
 //
-//   --continue   resume the same Copilot session every iter; context
-//                grows monotonically across iterations.
-//   --fresh      brand-new Copilot session every iter (clean context;
-//                the iter sees only the prompt + tool results).
+//   workitem   New Copilot session every time the runner observes
+//              `[WORKITEM_END]` (or the iter exits without emitting
+//              one). Stages within a single work item share one
+//              Copilot session so IMPLEMENT can see what BASELINE
+//              detected, etc.; unrelated backlog items don't
+//              cross-pollinate. Default.
+//   iter       New Copilot session every iter (status-quo `--fresh`).
+//   never      Same Copilot session for the whole run (status-quo
+//              `--continue`). Context accumulates monotonically.
 //
-// Both modes use the same baked SDLC prompts (PROMPT_SELF_IMPROVE /
+// All modes use the same baked SDLC prompts (PROMPT_SELF_IMPROVE /
 // PROMPT_GROW_PROJECT) from `./prompts.mjs`.
 //
 // The driver subprocess runs `copilot -p "..." --allow-all-tools
@@ -14,9 +21,10 @@
 //   - root assistant.message.data.content (no agentId field) — the
 //     iter's user-visible response, scanned for the
 //     completion_promise / abort_promise tokens.
-//   - terminal `result` event with `result.sessionId` — captured at
-//     iter 1 and reused via `--resume=<sessionId>` for iter 2+ when
-//     the driver is in --continue mode.
+//   - terminal `result` event with `result.sessionId` — captured per
+//     iter and reused via `--resume=<sessionId>` for the NEXT iter
+//     when the driver is not at a work-item boundary (workitem mode)
+//     or never resets (never mode).
 //
 // Pause/resume/stop are out-of-band: a sibling `ralph-tui run --pause
 // <runId>` flips a flag in the run's state.json (CAS-protected via
@@ -1267,6 +1275,25 @@ export function runOneIteration({
 
 // ─── Multi-iter loop ────────────────────────────────────────────────
 
+/** Map a legacy `contextMode` value (`continue` / `fresh`) to a
+ *  `resetOn` value (`never` / `iter`). Returns null when the input
+ *  is not a recognised legacy value so the caller can keep its own
+ *  validation flow. Pure / exported for testing.
+ *
+ *  Used at the API boundary so any caller still passing the old
+ *  `contextMode` parameter (test fixtures, downstream tooling) keeps
+ *  working until the next major. */
+export function legacyContextModeToResetOn(contextMode) {
+    if (contextMode === "continue") return "never";
+    if (contextMode === "fresh") return "iter";
+    return null;
+}
+
+const RESET_ON_VALUES = Object.freeze(["workitem", "iter", "never"]);
+const RESET_ON_SET = new Set(RESET_ON_VALUES);
+
+export { RESET_ON_VALUES };
+
 /**
  * Run the full multi-iter loop. Returns when the loop terminates via
  * completion_promise, abort_promise, max_iterations, stopRequested,
@@ -1274,7 +1301,12 @@ export function runOneIteration({
  *
  * Required:
  *   mode           "self-improve" | "grow-project" | "prompt"
- *   contextMode    "continue" | "fresh"
+ *
+ * One of (default `resetOn = "workitem"`):
+ *   resetOn        "workitem" (default) | "iter" | "never"
+ *   contextMode    Legacy alias: "continue" → "never", "fresh" →
+ *                  "iter". Honored at the API boundary for callers
+ *                  that haven't migrated.
  *
  * Optional:
  *   prompt              Required when mode === "prompt".
@@ -1299,6 +1331,7 @@ export function runOneIteration({
 export async function runRalphTui(opts) {
     const {
         mode,
+        resetOn: resetOnRaw,
         contextMode,
         prompt,
         focus,
@@ -1342,9 +1375,35 @@ export async function runRalphTui(opts) {
     if (mode !== "self-improve" && mode !== "grow-project" && mode !== "prompt") {
         throw new TypeError(`runRalphTui: invalid mode "${mode}"`);
     }
-    if (contextMode !== "continue" && contextMode !== "fresh") {
-        throw new TypeError(`runRalphTui: contextMode must be "continue" or "fresh"`);
+
+    // Resolve the effective resetOn value. Precedence:
+    //   1. Explicit `resetOn` (new API) — must be one of RESET_ON_VALUES.
+    //   2. Legacy `contextMode` (`continue` / `fresh`) — mapped via
+    //      legacyContextModeToResetOn so existing callers keep working.
+    //   3. Default to "workitem" when neither is provided.
+    let resetOn;
+    if (resetOnRaw !== undefined) {
+        if (!RESET_ON_SET.has(resetOnRaw)) {
+            throw new TypeError(`runRalphTui: resetOn must be one of ${RESET_ON_VALUES.join(", ")}`);
+        }
+        resetOn = resetOnRaw;
+    } else if (contextMode !== undefined) {
+        const mapped = legacyContextModeToResetOn(contextMode);
+        if (mapped === null) {
+            throw new TypeError(`runRalphTui: contextMode must be "continue" or "fresh"`);
+        }
+        resetOn = mapped;
+    } else {
+        resetOn = "workitem";
     }
+    // Internal mirror used by the existing event-emit / state-file
+    // paths that still surface `contextMode` for backwards-compatible
+    // consumers (`autopilot list`, `autopilot run --status`). Pinned
+    // to the legacy vocabulary for `iter` / `never` so dashboards
+    // built against the old strings keep rendering; `workitem` is
+    // surfaced as itself because it has no legacy synonym.
+    const RESET_ON_TO_LEGACY = { never: "continue", iter: "fresh", workitem: "workitem" };
+    const contextModeForEmit = RESET_ON_TO_LEGACY[resetOn];
     if (mode === "prompt" && (!prompt || typeof prompt !== "string")) {
         throw new TypeError(`runRalphTui: --prompt requires a non-empty string when mode === "prompt"`);
     }
@@ -1365,12 +1424,13 @@ export async function runRalphTui(opts) {
     const composedPrompt = composePrompt({ mode, prompt, focus: focusCheck.value });
 
     // Initial state-file. terminationReason starts as null; the loop
-    // sets it on exit. sessionId is captured after iter 1 in
-    // --continue mode.
+    // sets it on exit. sessionId is captured per-iter when resetOn
+    // permits the next iter to resume.
     initState(runId, {
         runId,
         mode,
-        contextMode,
+        contextMode: contextModeForEmit,
+        resetOn,
         startedAt,
         max,
         iter: 0,
@@ -1403,7 +1463,9 @@ export async function runRalphTui(opts) {
     }
 
     // Emit the canonical `armed` event so `ralph-tui list/stats`
-    // pick up this run.
+    // pick up this run. `contextMode` keeps the legacy continue/fresh
+    // vocabulary for back-compat consumers; `resetOn` carries the new
+    // tri-valued seam.
     emitter.write({
         type: "armed",
         ts: now(),
@@ -1412,7 +1474,8 @@ export async function runRalphTui(opts) {
         startedAt,
         maxIterations: max,
         minIterations: 1,
-        contextMode,
+        contextMode: contextModeForEmit,
+        resetOn,
         mode,
     });
 
@@ -1543,10 +1606,20 @@ export async function runRalphTui(opts) {
         const iterStartSha = gitRevParseHead({ gitExec, cwd, env });
 
         // Decide whether to resume an existing session or start a
-        // fresh one. --continue captures sessionId at iter 1 then
-        // resumes it; --fresh always starts fresh.
-        const resumeSessionId = (contextMode === "continue" && iter > 1) ? capturedSessionId : null;
-        const sessionNameForIter = (contextMode === "continue" && iter === 1) ? sessionName : null;
+        // fresh one.
+        //   never:    capture sessionId at iter 1, resume it for
+        //             every iter after that.
+        //   iter:     never capture, never resume — every iter is
+        //             a brand-new session.
+        //   workitem: capture sessionId per iter; resume the captured
+        //             one on the next iter UNLESS we observed
+        //             `[WORKITEM_END]` in this iter or the previous
+        //             iter exited without one (the post-iter logic
+        //             below clears `capturedSessionId` in either case
+        //             when in workitem mode).
+        const canResume = resetOn !== "iter" && capturedSessionId !== null;
+        const resumeSessionId = canResume ? capturedSessionId : null;
+        const sessionNameForIter = (resetOn !== "iter" && !canResume) ? sessionName : null;
 
         let result;
         // Issue #48 / streaming emission: extract `stage_start` /
@@ -1721,6 +1794,13 @@ export async function runRalphTui(opts) {
                         });
                     } catch { /* serializer rejection — skip */ }
                     activeWorkItemRef = null;
+                    // Note: in `workitem` reset mode this marker is
+                    // the conceptual reason we drop the captured
+                    // sessionId at iter exit (post-iter cleanup
+                    // below), but the cleanup runs on every iter
+                    // exit regardless because we treat any iter-exit
+                    // as an implicit work-item boundary too. So
+                    // there's nothing to track per-marker here.
                 } else if (item.kind === "stage_plan") {
                     const p = item.payload || {};
                     if (!Array.isArray(p.stages) || p.stages.length === 0) continue;
@@ -2013,7 +2093,14 @@ export async function runRalphTui(opts) {
 
         const reduced = reduceCopilotEvents(result.events);
         lastAssistantContent = reduced.assistantContent;
-        if (contextMode === "continue" && iter === 1 && reduced.sessionId) {
+        // Issue #51 — capture the sessionId per-iter for resetOn
+        // modes that resume across iters (`never` and `workitem`).
+        // For `never` this matches the legacy --continue behaviour
+        // (capture once at iter 1, reuse forever); for `workitem`
+        // we re-capture each iter so the post-iter cleanup below
+        // can drop the most recent value at the work-item boundary.
+        // `iter` mode skips capture entirely.
+        if (resetOn !== "iter" && reduced.sessionId) {
             capturedSessionId = reduced.sessionId;
             updateState(runId, (s) => { s.sessionId = capturedSessionId; return s; }, env);
         }
@@ -2178,6 +2265,29 @@ export async function runRalphTui(opts) {
                     branch: iterWorktree.branch,
                 });
             } catch { /* serializer rejection — skip */ }
+        }
+
+        // Issue #51 — workitem-mode session reset.
+        //
+        // Drop the captured sessionId at any work-item boundary so
+        // the next iter's resume logic starts a brand-new Copilot
+        // session. Two boundaries collapse here:
+        //
+        //   (a) `[WORKITEM_END]` was observed during this iter (the
+        //       agent emitted the structured marker — work item
+        //       genuinely closed).
+        //   (b) The iter exited without emitting `[WORKITEM_END]`
+        //       (ABORT, hit max iters, process death, the agent
+        //       just forgot). We treat any iter-exit as an implicit
+        //       work-item boundary so a half-finished item never
+        //       silently carries stale context into the next iter.
+        //
+        // `never` mode skips this — that's the whole point of the
+        // escape hatch. `iter` mode never captured anything so the
+        // reset is a no-op.
+        if (resetOn === "workitem" && capturedSessionId !== null) {
+            capturedSessionId = null;
+            updateState(runId, (s) => { s.sessionId = null; return s; }, env);
         }
 
         if (result.exitCode !== 0) {

--- a/packages/tui/test/bin.test.mjs
+++ b/packages/tui/test/bin.test.mjs
@@ -907,13 +907,15 @@ test("formatAbortMessage: unknown reason still produces a message (don't silentl
     assert.match(msg, /custom_reason received/);
 });
 
-// ─── Issue #65: bare `autopilot` defaults to `run --self-improve --fresh` ──
+// ─── Issue #65: bare `autopilot` defaults to `run --self-improve` ──
 //
 // Pre-issue-65 behaviour: bare `ralph-tui` with no args printed USAGE.
 // Post-issue-65: bare `autopilot` (no subcommand, no flags, no positional)
-// invokes `cmdRun` with `flags["self-improve"] = true` and
-// `flags.fresh = true` so the user does not have to memorise the canonical
-// drive-the-backlog incantation. `--help` / `-h` still print USAGE.
+// invokes `cmdRun` with `flags["self-improve"] = true` so the user
+// does not have to memorise the canonical drive-the-backlog
+// incantation. `--help` / `-h` still print USAGE. Issue #51 dropped
+// the implicit `flags.fresh = true` — the `--reset-on=workitem`
+// default applies (logged in the banner).
 
 test("parseArgv: bare argv has no cmd / positional / flags (defaults dispatch happens in main)", () => {
     // Pin the parser contract: bare argv produces an empty result. The
@@ -942,10 +944,12 @@ async function captureIo(fn) {
     return { stdout: stdoutBuf, stderr: stderrBuf };
 }
 
-test("main: bare argv writes self-improve banner to stderr and routes to cmdRun (--self-improve --fresh)", async () => {
+test("main: bare argv writes self-improve banner to stderr and routes to cmdRun (--self-improve)", async () => {
     // Pin both halves of the issue #65 dispatch contract: the user-visible
     // stderr banner fires BEFORE any subprocess work, AND cmdRun receives
-    // flags with self-improve + fresh set.
+    // flags with self-improve set. Issue #51 dropped the implicit
+    // `--fresh` so the run inherits the new `--reset-on=workitem`
+    // default (banner labels it accordingly).
     //
     // To avoid spawning a real `copilot` subprocess, point
     // RALPH_TUI_COPILOT_BIN at a nonexistent path so the runner's spawn
@@ -968,7 +972,7 @@ test("main: bare argv writes self-improve banner to stderr and routes to cmdRun 
         else process.env.RALPH_TUI_RUNS_DIR = origRunsDir;
         rmSync(dir, { recursive: true, force: true });
     }
-    assert.match(captured.stderr, /autopilot: starting self-improve loop \(--fresh\)\. Press q to stop\./,
+    assert.match(captured.stderr, /autopilot: starting self-improve loop \(--reset-on=workitem\)\. Press q to stop\./,
         "bare invocation must print the self-improve banner to stderr before invoking cmdRun");
 });
 
@@ -993,4 +997,120 @@ test("parseArgv: --help is recognised and main short-circuits to USAGE before ba
     assert.equal(parseArgv(["--help"]).flags.help, true);
     assert.equal(parseArgv(["--help"]).cmd, null);
     assert.equal(parseArgv(["-h"]).flags.help, true);
+});
+
+// ─── Issue #51 — `--reset-on={workitem|iter|never}` ───────────────────
+//
+// Pin the new flag, the legacy `--continue` / `--fresh` aliases (with
+// a one-shot stderr deprecation notice), and the validation that an
+// unknown value errors with a useful message.
+
+import { warnDeprecatedFlagOnce, __test__ as binTestHooks } from "../bin/tui.mjs";
+
+test("parseArgv: --reset-on=workitem (= form) sets flags['reset-on']", () => {
+    const r = parseArgv(["run", "--self-improve", "--reset-on=workitem"]);
+    assert.equal(r.flags["reset-on"], "workitem");
+});
+
+test("parseArgv: --reset-on iter (space form) sets flags['reset-on']", () => {
+    const r = parseArgv(["run", "--self-improve", "--reset-on", "iter"]);
+    assert.equal(r.flags["reset-on"], "iter");
+});
+
+test("USAGE block documents --reset-on", () => {
+    const r = runBin(["--help"]);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /--reset-on/);
+    assert.match(r.stdout, /workitem.*iter.*never/);
+});
+
+test("USAGE block notes --continue / --fresh as deprecated aliases", () => {
+    const r = runBin(["--help"]);
+    assert.equal(r.status, 0);
+    // Either the explicit "deprecated" word OR the alias mapping
+    // wording — keep the assertion forgiving so prose tweaks don't
+    // brittle the check.
+    assert.match(r.stdout, /Deprecated alias/i);
+});
+
+test("warnDeprecatedFlagOnce: writes to stderr exactly once per process per flag", () => {
+    binTestHooks.resetDeprecationWarnings();
+    let buf = "";
+    const sink = { write: (chunk) => { buf += String(chunk); return true; } };
+    warnDeprecatedFlagOnce("continue", "never", sink);
+    warnDeprecatedFlagOnce("continue", "never", sink);
+    warnDeprecatedFlagOnce("continue", "never", sink);
+    const matches = buf.match(/--continue is deprecated/g) ?? [];
+    assert.equal(matches.length, 1, "deprecation notice must fire exactly once per process per flag");
+    assert.match(buf, /--reset-on=never/, "the notice tells the user how to migrate");
+});
+
+test("warnDeprecatedFlagOnce: distinct flags warn independently (each fires once)", () => {
+    binTestHooks.resetDeprecationWarnings();
+    let buf = "";
+    const sink = { write: (chunk) => { buf += String(chunk); return true; } };
+    warnDeprecatedFlagOnce("continue", "never", sink);
+    warnDeprecatedFlagOnce("fresh", "iter", sink);
+    warnDeprecatedFlagOnce("continue", "never", sink); // second call is no-op
+    warnDeprecatedFlagOnce("fresh", "iter", sink);     // second call is no-op
+    assert.equal((buf.match(/--continue is deprecated/g) ?? []).length, 1);
+    assert.equal((buf.match(/--fresh is deprecated/g) ?? []).length, 1);
+});
+
+test("bin run --reset-on=foo: rejects with a clear error", () => {
+    const dir = tmp();
+    const r = runBin(["run", "--self-improve", "--reset-on=foo"], { RALPH_TUI_RUNS_DIR: dir });
+    assert.equal(r.status, 2, "invalid --reset-on value must exit 2");
+    assert.match(r.stderr, /reset-on/, "error message must reference --reset-on");
+    assert.match(r.stderr, /workitem.*iter.*never|workitem, iter, never/,
+        "error message must list the accepted values so the user can fix it");
+    rmSync(dir, { recursive: true, force: true });
+});
+
+test("bin run --reset-on (no value): rejects with a clear error", () => {
+    const dir = tmp();
+    // `--reset-on` with no following arg parses as `flags["reset-on"] === true`
+    // because the parser only consumes the next arg when it isn't another
+    // flag. cmdRun must reject this with a helpful message.
+    const r = runBin(["run", "--self-improve", "--reset-on"], { RALPH_TUI_RUNS_DIR: dir });
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /requires a value/);
+    rmSync(dir, { recursive: true, force: true });
+});
+
+test("bin run --continue: prints deprecation notice to stderr and proceeds (or fails for unrelated reason)", () => {
+    const dir = tmp();
+    // Point copilot bin at a nonexistent path so the runner fails fast
+    // with ENOENT — we only care that the deprecation notice fires
+    // BEFORE that failure. status code is unimportant here.
+    const r = runBin(["run", "--self-improve", "--continue", "--max", "1"], {
+        RALPH_TUI_RUNS_DIR: dir,
+        RALPH_TUI_COPILOT_BIN: "/nonexistent-copilot-binary-issue-51",
+    });
+    assert.match(r.stderr, /--continue is deprecated/,
+        "the deprecation notice must surface on stderr when --continue is passed");
+    assert.match(r.stderr, /--reset-on=never/,
+        "the notice must point users at the new spelling");
+    rmSync(dir, { recursive: true, force: true });
+});
+
+test("bin run --fresh: prints deprecation notice to stderr (--reset-on=iter migration hint)", () => {
+    const dir = tmp();
+    const r = runBin(["run", "--self-improve", "--fresh", "--max", "1"], {
+        RALPH_TUI_RUNS_DIR: dir,
+        RALPH_TUI_COPILOT_BIN: "/nonexistent-copilot-binary-issue-51-fresh",
+    });
+    assert.match(r.stderr, /--fresh is deprecated/);
+    assert.match(r.stderr, /--reset-on=iter/);
+    rmSync(dir, { recursive: true, force: true });
+});
+
+test("bin run: combining --reset-on=iter and --continue rejects with a clear error", () => {
+    const dir = tmp();
+    const r = runBin(["run", "--self-improve", "--reset-on=iter", "--continue"], {
+        RALPH_TUI_RUNS_DIR: dir,
+    });
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /--continue is a deprecated alias/);
+    rmSync(dir, { recursive: true, force: true });
 });

--- a/packages/tui/test/runner.test.mjs
+++ b/packages/tui/test/runner.test.mjs
@@ -2426,164 +2426,418 @@ test("runRalphTui: omits session_attached when result.sessionId is missing", asy
     assert.equal(sa.length, 0, "no event when reducer didn't surface a sessionId");
 });
 
-// ─── Issue #56 slice 4 — computeIterFilesChanged + iteration_end carries field ───
+// ─── Issue #51 — `--reset-on={workitem|iter|never}` ───────────────────
+//
+// Pin the three-valued reset boundary contract:
+//   - `never`    behaves like the legacy `--continue` — captures
+//                sessionId on iter 1, resumes for iter 2+.
+//   - `iter`     behaves like the legacy `--fresh` — every iter
+//                starts a brand-new session.
+//   - `workitem` (default) — drops the captured sessionId at every
+//                work-item boundary, including any iter-exit (the
+//                runner treats iter-exit as an implicit boundary so
+//                a half-finished work item never carries stale
+//                context into the next iter).
+//
+// Plus the legacy `contextMode: "continue"|"fresh"` API boundary stays
+// honored for back-compat callers.
 
-test("computeIterFilesChanged: gitExec=null returns null (non-git cwd / test injection)", () => {
-    assert.equal(computeIterFilesChanged({
-        gitExec: null, cwd: "/repo", env: {}, iterStartSha: "abc1234",
-    }), null);
+import { legacyContextModeToResetOn, RESET_ON_VALUES } from "../src/runner.mjs";
+
+test("legacyContextModeToResetOn: maps continue→never and fresh→iter", () => {
+    assert.equal(legacyContextModeToResetOn("continue"), "never");
+    assert.equal(legacyContextModeToResetOn("fresh"), "iter");
 });
 
-test("computeIterFilesChanged: HEAD changed → counts diff + status lines", () => {
-    const calls = [];
-    const gitExec = ({ args }) => {
-        calls.push(args.join(" "));
-        if (args[0] === "rev-parse" && args[1] === "HEAD") return "def5678\n";
-        if (args[0] === "diff" && args[1] === "--name-only") {
-            // 3 committed files
-            return "src/a.mjs\nsrc/b.mjs\ntest/c.test.mjs\n";
-        }
-        if (args[0] === "status" && args[1] === "--porcelain") {
-            // 2 uncommitted churn lines
-            return " M README.md\n?? new-file.txt\n";
-        }
-        return null;
-    };
-    const out = computeIterFilesChanged({
-        gitExec, cwd: "/repo", env: {}, iterStartSha: "abc1234",
-    });
-    assert.equal(out, 5, "3 committed + 2 uncommitted");
-    assert.deepEqual(calls, [
-        "rev-parse HEAD",
-        "diff --name-only abc1234..HEAD",
-        "status --porcelain",
-    ]);
+test("legacyContextModeToResetOn: returns null for unknown / non-string input", () => {
+    assert.equal(legacyContextModeToResetOn("workitem"), null,
+        "the new vocabulary is not a legacy value — caller validates separately");
+    assert.equal(legacyContextModeToResetOn("bogus"), null);
+    assert.equal(legacyContextModeToResetOn(undefined), null);
+    assert.equal(legacyContextModeToResetOn(null), null);
+    assert.equal(legacyContextModeToResetOn(42), null);
 });
 
-test("computeIterFilesChanged: HEAD unchanged → committed=0, status only", () => {
-    const gitExec = ({ args }) => {
-        if (args[0] === "rev-parse" && args[1] === "HEAD") return "abc1234\n";
-        if (args[0] === "status" && args[1] === "--porcelain") return " M one.mjs\n";
-        return null;
-    };
-    const out = computeIterFilesChanged({
-        gitExec, cwd: "/repo", env: {}, iterStartSha: "abc1234",
-    });
-    assert.equal(out, 1, "no commit landed → only the one uncommitted file counts");
+test("RESET_ON_VALUES exposes the three accepted values in canonical order", () => {
+    assert.deepEqual([...RESET_ON_VALUES], ["workitem", "iter", "never"]);
 });
 
-test("computeIterFilesChanged: iterStartSha=null → skip diff entirely, count only status", () => {
-    const calls = [];
-    const gitExec = ({ args }) => {
-        calls.push(args[0]);
-        if (args[0] === "status") return "?? a\n?? b\n?? c\n";
-        return null;
-    };
-    const out = computeIterFilesChanged({
-        gitExec, cwd: "/repo", env: {}, iterStartSha: null,
-    });
-    assert.equal(out, 3);
-    // No rev-parse / diff calls when iterStartSha is null.
-    assert.deepEqual(calls, ["status"]);
+test("runRalphTui: rejects unknown resetOn value", async () => {
+    await assert.rejects(
+        runRalphTui({ mode: "self-improve", resetOn: "bogus" }),
+        /resetOn must be one of/,
+    );
 });
 
-test("computeIterFilesChanged: gitExec returns null for everything → 0 (clean repo)", () => {
-    const out = computeIterFilesChanged({
-        gitExec: () => null, cwd: "/repo", env: {}, iterStartSha: "abc1234",
-    });
-    assert.equal(out, 0);
-});
-
-test("computeIterFilesChanged: tolerates blank lines / \\r\\n line endings", () => {
-    const gitExec = ({ args }) => {
-        if (args[0] === "status") return "?? a\r\n\r\n?? b\r\n";
-        return null;
-    };
-    assert.equal(computeIterFilesChanged({
-        gitExec, cwd: "/repo", env: {}, iterStartSha: null,
-    }), 2);
-});
-
-test("runRalphTui: iteration_end carries filesChanged when gitExec returns canned diff/status", async () => {
+test("runRalphTui: defaults resetOn to workitem when neither resetOn nor contextMode is passed", async () => {
     const events = [];
     const eventEmitter = {
-        runId: "files-changed-test",
+        runId: "default-resetOn",        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    const spawn = makeMockSpawn([{
+        stdout: [
+            JSON.stringify({ type: "assistant.message", data: { content: "COMPLETE" } }),
+            JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+        ].join("\n") + "\n",
+        exitCode: 0,
+    }]);
+    await runRalphTui({
+        mode: "self-improve",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+    });
+    const armed = events.find((e) => e.type === "armed");
+    assert.equal(armed.resetOn, "workitem", "default resetOn must be 'workitem'");
+});
+
+test("runRalphTui: legacy contextMode='continue' maps to resetOn='never' (back-compat)", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "legacy-continue",
         eventsPath: "/dev/null",
         write: (ev) => events.push(ev),
         close: () => {},
     };
-    // gitExec stub: arm-time + iter-1 readHeadCommit, plus iter-start
-    // rev-parse HEAD (returns SHA1), iter-end rev-parse HEAD (returns
-    // SHA2 — HEAD changed), iter-end diff (2 files), iter-end status
-    // (1 uncommitted).
-    let revParseHeadCalls = 0;
-    const gitExec = ({ args }) => {
-        if (args[0] === "rev-parse" && args[1] === "--short") return "abc1234\n";
-        if (args[0] === "log") return "subject ";
-        if (args[0] === "rev-parse" && args[1] === "HEAD") {
-            revParseHeadCalls += 1;
-            // 1st = iter-start; 2nd = iter-end (computeIterFilesChanged).
-            return revParseHeadCalls === 1 ? "0000aaa\n" : "0000bbb\n";
-        }
-        if (args[0] === "diff" && args[1] === "--name-only") {
-            return "file1.mjs\nfile2.mjs\n";  // 2 committed
-        }
-        if (args[0] === "status" && args[1] === "--porcelain") {
-            return " M dirty.mjs\n";  // 1 uncommitted
-        }
-        return null;
-    };
-    const spawn = makeMockSpawn([
-        {
-            stdout: [
-                JSON.stringify({ type: "assistant.message", data: { content: "wrap up COMPLETE" } }),
-                JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
-            ].join("\n") + "\n",
-            exitCode: 0,
-        },
-    ]);
+    const spawn = makeMockSpawn([{
+        stdout: [
+            JSON.stringify({ type: "assistant.message", data: { content: "COMPLETE" } }),
+            JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+        ].join("\n") + "\n",
+        exitCode: 0,
+    }]);
     await runRalphTui({
+        mode: "self-improve",
+        contextMode: "continue",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+    });
+    const armed = events.find((e) => e.type === "armed");
+    assert.equal(armed.resetOn, "never", "contextMode='continue' must map to resetOn='never'");
+    assert.equal(armed.contextMode, "continue", "armed event keeps the legacy contextMode value for back-compat consumers");
+});
+
+test("runRalphTui: legacy contextMode='fresh' maps to resetOn='iter' (back-compat)", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "legacy-fresh",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    const spawn = makeMockSpawn([{
+        stdout: [
+            JSON.stringify({ type: "assistant.message", data: { content: "COMPLETE" } }),
+            JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+        ].join("\n") + "\n",
+        exitCode: 0,
+    }]);    await runRalphTui({
         mode: "self-improve",
         contextMode: "fresh",
         max: 1,
         env: makeEnv(),
         spawn,
         eventEmitter,
-        gitExec,
     });
-    const iterEnds = events.filter((e) => e.type === "iteration_end");
-    assert.equal(iterEnds.length, 1);
-    assert.equal(iterEnds[0].filesChanged, 3, "2 committed + 1 uncommitted");
+    const armed = events.find((e) => e.type === "armed");
+    assert.equal(armed.resetOn, "iter");
+    assert.equal(armed.contextMode, "fresh");
 });
 
-test("runRalphTui: iteration_end omits filesChanged when gitExec is not provided (test/non-git)", async () => {
+// resetOn=workitem — the default. Spawn calls always start a new
+// session (no --resume) regardless of how many iters run, because
+// every iter-exit is treated as a work-item boundary that drops the
+// captured sessionId.
+test("runRalphTui: resetOn=workitem drops captured sessionId at iter exit (no --resume on iter 2+)", async () => {
+    const argLog = [];
+    const spawn = function (_bin, args) {
+        argLog.push([...args]);
+        const handlers = { stdout: [], close: [] };
+        const child = {
+            stdout: { on: (ev, fn) => handlers.stdout.push(fn), pipe: () => {} },
+            stderr: { on: () => {}, pipe: () => {} },
+            on: (ev, fn) => { if (ev === "close") handlers.close.push(fn); },
+            kill: () => {},
+        };
+        setImmediate(() => {
+            const isLast = argLog.length === 3;
+            const events = [
+                JSON.stringify({
+                    type: "assistant.message",
+                    data: { content: isLast ? "wrap up COMPLETE" : "iter going" },
+                }),
+                JSON.stringify({ type: "result", success: true, result: { sessionId: `sess-${argLog.length}` } }),
+            ];
+            for (const fn of handlers.stdout) fn(Buffer.from(events.join("\n") + "\n"));
+            for (const fn of handlers.close) fn(0);
+        });
+        return child;
+    };
+    await runRalphTui({
+        mode: "self-improve",
+        resetOn: "workitem",
+        max: 3,
+        env: makeEnv(),
+        spawn,
+    });
+    // Every iter must NOT carry a --resume argument: we drop the
+    // captured sessionId at every iter-exit (work-item boundary,
+    // implicit or explicit).
+    assert.equal(argLog.length, 3, "all 3 iters should run");
+    for (let i = 0; i < argLog.length; i++) {
+        assert.ok(!argLog[i].some((a) => typeof a === "string" && a.startsWith("--resume=")),
+            `iter ${i + 1} (resetOn=workitem) must not pass --resume — every iter starts a fresh session`);
+    }
+});
+
+// resetOn=workitem with an explicit `[WORKITEM_END]` marker mid-iter:
+// the runner observes the boundary and the post-iter cleanup drops
+// the captured sessionId. This test pins the marker-driven path
+// distinctly from the implicit-iter-exit path above.
+test("runRalphTui: resetOn=workitem drops sessionId after [WORKITEM_END] marker", async () => {
     const events = [];
     const eventEmitter = {
-        runId: "no-files-changed-test",
+        runId: "wi-reset-test",        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    // Two iters: iter 1 emits a complete WORKITEM_START + WORKITEM_END;
+    // iter 2 wraps up with COMPLETE. After iter 1 the captured
+    // sessionId should be dropped (workitem mode treats the
+    // WORKITEM_END marker as the canonical reset point), so iter 2
+    // must spawn without --resume.
+    const argLog = [];
+    const spawn = function (_bin, args) {
+        argLog.push([...args]);
+        const handlers = { stdout: [], close: [] };
+        const child = {
+            stdout: { on: (ev, fn) => handlers.stdout.push(fn), pipe: () => {} },
+            stderr: { on: () => {}, pipe: () => {} },
+            on: (ev, fn) => { if (ev === "close") handlers.close.push(fn); },
+            kill: () => {},
+        };
+        setImmediate(() => {
+            const isFirst = argLog.length === 1;
+            const lines = isFirst
+                ? [
+                    JSON.stringify({
+                        type: "assistant.message",
+                        timestamp: "2026-01-01T00:00:00.000Z",
+                        data: { content: '[WORKITEM_START: {"kind":"issue","ref":1,"title":"x"}]\n[WORKITEM_END: {"kind":"issue","ref":1,"closesN":1}]' },
+                    }),
+                    JSON.stringify({ type: "result", success: true, result: { sessionId: "sess-1" } }),
+                ]
+                : [
+                    JSON.stringify({ type: "assistant.message", data: { content: "COMPLETE" } }),
+                    JSON.stringify({ type: "result", success: true, result: { sessionId: "sess-2" } }),
+                ];
+            for (const fn of handlers.stdout) fn(Buffer.from(lines.join("\n") + "\n"));
+            for (const fn of handlers.close) fn(0);
+        });
+        return child;
+    };
+    await runRalphTui({
+        mode: "self-improve",
+        resetOn: "workitem",
+        max: 2,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+    });
+    assert.ok(events.some((e) => e.type === "workitem_end"),
+        "the WORKITEM_END marker fired the workitem_end event");
+    assert.ok(!argLog[1].some((a) => typeof a === "string" && a.startsWith("--resume=")),
+        "iter 2 must not resume — sessionId dropped at the WORKITEM_END boundary");
+});
+
+test("runRalphTui: resetOn=never resumes the captured sessionId on iter 2+ (status-quo --continue)", async () => {
+    const argLog = [];
+    const spawn = function (_bin, args) {
+        argLog.push([...args]);
+        const handlers = { stdout: [], close: [] };
+        const child = {
+            stdout: { on: (ev, fn) => handlers.stdout.push(fn), pipe: () => {} },
+            stderr: { on: () => {}, pipe: () => {} },
+            on: (ev, fn) => { if (ev === "close") handlers.close.push(fn); },
+            kill: () => {},
+        };
+        setImmediate(() => {
+            const isFirst = argLog.length === 1;
+            const lines = isFirst
+                ? [
+                    JSON.stringify({ type: "assistant.message", data: { content: "iter 1" } }),
+                    JSON.stringify({ type: "result", success: true, result: { sessionId: "STABLE-SID" } }),
+                ]
+                : [
+                    JSON.stringify({ type: "assistant.message", data: { content: "iter 2 COMPLETE" } }),
+                    JSON.stringify({ type: "result", success: true, result: { sessionId: "STABLE-SID" } }),
+                ];
+            for (const fn of handlers.stdout) fn(Buffer.from(lines.join("\n") + "\n"));
+            for (const fn of handlers.close) fn(0);
+        });
+        return child;
+    };
+    const result = await runRalphTui({
+        mode: "self-improve",
+        resetOn: "never",
+        max: 5,
+        env: makeEnv(),
+        spawn,
+    });
+    assert.equal(result.terminationReason, "complete");
+    assert.ok(argLog[0].some((a) => a === "-n"), "iter 1 names a fresh session");
+    assert.ok(argLog[1].some((a) => a === "--resume=STABLE-SID"), "iter 2 must --resume the captured session");
+});
+
+test("runRalphTui: resetOn=iter never resumes (status-quo --fresh)", async () => {
+    const argLog = [];
+    const spawn = function (_bin, args) {
+        argLog.push([...args]);
+        const handlers = { stdout: [], close: [] };
+        const child = {
+            stdout: { on: (ev, fn) => handlers.stdout.push(fn), pipe: () => {} },
+            stderr: { on: () => {}, pipe: () => {} },
+            on: (ev, fn) => { if (ev === "close") handlers.close.push(fn); },
+            kill: () => {},
+        };
+        setImmediate(() => {
+            const isLast = argLog.length === 2;
+            const lines = [
+                JSON.stringify({
+                    type: "assistant.message",
+                    data: { content: isLast ? "wrap up COMPLETE" : "still going" },
+                }),
+                JSON.stringify({ type: "result", success: true, result: { sessionId: "ignored" } }),
+            ];
+            for (const fn of handlers.stdout) fn(Buffer.from(lines.join("\n") + "\n"));
+            for (const fn of handlers.close) fn(0);
+        });
+        return child;
+    };
+    await runRalphTui({
+        mode: "self-improve",
+        resetOn: "iter",
+        max: 3,
+        env: makeEnv(),
+        spawn,
+    });
+    for (let i = 0; i < argLog.length; i++) {
+        assert.ok(!argLog[i].some((a) => typeof a === "string" && a.startsWith("--resume=")),
+            `iter ${i + 1} (resetOn=iter) must never --resume`);
+        assert.ok(!argLog[i].some((a) => a === "-n"),
+            `iter ${i + 1} (resetOn=iter) must never -n (no named session)`);
+    }
+});
+
+// resetOn=workitem with an iter that does NOT emit WORKITEM_END
+// (e.g. ABORT mid-iter, or a custom prompt that never opens a work
+// item). The runner must STILL drop the captured sessionId at iter
+// exit so the next iter starts a brand-new session.
+test("runRalphTui: resetOn=workitem drops sessionId on iter exit even WITHOUT a [WORKITEM_END] marker", async () => {
+    const argLog = [];
+    const spawn = function (_bin, args) {
+        argLog.push([...args]);
+        const handlers = { stdout: [], close: [] };
+        const child = {
+            stdout: { on: (ev, fn) => handlers.stdout.push(fn), pipe: () => {} },
+            stderr: { on: () => {}, pipe: () => {} },
+            on: (ev, fn) => { if (ev === "close") handlers.close.push(fn); },
+            kill: () => {},
+        };
+        setImmediate(() => {
+            const isLast = argLog.length === 2;
+            // No WORKITEM markers at all — just a plain assistant
+            // message and the terminal result. workitem mode must
+            // STILL reset the session at iter exit.
+            const lines = [
+                JSON.stringify({
+                    type: "assistant.message",
+                    data: { content: isLast ? "second iter COMPLETE" : "first iter (no markers)" },
+                }),
+                JSON.stringify({ type: "result", success: true, result: { sessionId: `sid-${argLog.length}` } }),
+            ];
+            for (const fn of handlers.stdout) fn(Buffer.from(lines.join("\n") + "\n"));
+            for (const fn of handlers.close) fn(0);
+        });
+        return child;
+    };
+    await runRalphTui({
+        mode: "self-improve",
+        resetOn: "workitem",
+        max: 2,
+        env: makeEnv(),
+        spawn,
+    });
+    assert.equal(argLog.length, 2, "two iters ran");
+    assert.ok(!argLog[1].some((a) => typeof a === "string" && a.startsWith("--resume=")),
+        "iter 2 (resetOn=workitem, no WORKITEM_END in iter 1) must still start fresh — implicit work-item boundary");
+});
+
+// Multiple `[WORKITEM_END]` markers within a single iter (edge case:
+// the agent processes two unrelated items in one subprocess). The
+// runner observes the markers, emits workitem_end events for each,
+// and at iter exit drops the captured sessionId so the next iter
+// starts fresh — the within-iter resets are bookkeeping; the
+// inter-iter session reset still fires once per iter exit.
+test("runRalphTui: resetOn=workitem with multiple WORKITEM_END markers in one iter still resets at iter exit", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "wi-multi-test",
         eventsPath: "/dev/null",
         write: (ev) => events.push(ev),
         close: () => {},
     };
-    const spawn = makeMockSpawn([
-        {
-            stdout: [
-                JSON.stringify({ type: "assistant.message", data: { content: "wrap up COMPLETE" } }),
-                JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
-            ].join("\n") + "\n",
-            exitCode: 0,
-        },
-    ]);
+    const argLog = [];
+    const spawn = function (_bin, args) {
+        argLog.push([...args]);
+        const handlers = { stdout: [], close: [] };
+        const child = {
+            stdout: { on: (ev, fn) => handlers.stdout.push(fn), pipe: () => {} },
+            stderr: { on: () => {}, pipe: () => {} },
+            on: (ev, fn) => { if (ev === "close") handlers.close.push(fn); },
+            kill: () => {},
+        };
+        setImmediate(() => {
+            const isFirst = argLog.length === 1;
+            const lines = isFirst
+                ? [
+                    JSON.stringify({
+                        type: "assistant.message",
+                        timestamp: "2026-01-01T00:00:00.000Z",
+                        data: {
+                            content: [
+                                '[WORKITEM_START: {"kind":"issue","ref":1,"title":"a"}]',
+                                '[WORKITEM_END: {"kind":"issue","ref":1,"closesN":1}]',
+                                '[WORKITEM_START: {"kind":"issue","ref":2,"title":"b"}]',
+                                '[WORKITEM_END: {"kind":"issue","ref":2,"closesN":1}]',
+                            ].join("\n"),
+                        },
+                    }),
+                    JSON.stringify({ type: "result", success: true, result: { sessionId: "first-sess" } }),
+                ]
+                : [
+                    JSON.stringify({ type: "assistant.message", data: { content: "COMPLETE" } }),
+                    JSON.stringify({ type: "result", success: true, result: { sessionId: "second-sess" } }),
+                ];
+            for (const fn of handlers.stdout) fn(Buffer.from(lines.join("\n") + "\n"));
+            for (const fn of handlers.close) fn(0);
+        });
+        return child;
+    };
     await runRalphTui({
         mode: "self-improve",
-        contextMode: "fresh",
-        max: 1,
+        resetOn: "workitem",
+        max: 2,
         env: makeEnv(),
         spawn,
         eventEmitter,
-        gitExec: null,
     });
-    const iterEnds = events.filter((e) => e.type === "iteration_end");
-    assert.equal(iterEnds.length, 1);
-    assert.equal(iterEnds[0].filesChanged, undefined,
-        "field omitted when gitExec is null so Timeline cell stays hidden");
-});
+    const ends = events.filter((e) => e.type === "workitem_end");
+    assert.equal(ends.length, 2, "both WORKITEM_END markers surfaced as workitem_end events");
+    assert.ok(!argLog[1].some((a) => typeof a === "string" && a.startsWith("--resume=")),
+        "iter 2 must not resume — sessionId dropped at iter exit (workitem boundary)");});


### PR DESCRIPTION
## Summary

Replaces the binary `--continue` / `--fresh` context-reset flag with `--reset-on={workitem|iter|never}` (default `workitem`). Stages within a single work item share one Copilot session; each new work item (or any iter exit) starts a fresh session — so unrelated backlog items don't cross-pollinate, but the agent's reasoning chain across the SDLC stages of one work item stays intact.

Closes #51.

## Behaviour

| Value | Reset boundary |
| --- | --- |
| `workitem` (default) | New Copilot session at every `[WORKITEM_END]` marker (or any iter exit) |
| `iter` | New session every iter (status-quo `--fresh`) |
| `never` | Same session for the whole run (status-quo `--continue`) |

## Backward compatibility

- `--continue` → alias for `--reset-on=never` (one-shot stderr deprecation notice on first use).
- `--fresh` → alias for `--reset-on=iter` (one-shot stderr deprecation notice on first use).
- Legacy `contextMode: "continue"|"fresh"` parameter on `runRalphTui()` keeps working too — mapped via the new exported `legacyContextModeToResetOn()` helper.
- `armed` events carry both the legacy `contextMode` value and the new `resetOn` field so back-compat consumers (`autopilot list`, `autopilot run --status`) keep rendering.

The `workitem` default is a behaviour change for users who relied on `--continue`'s implicit "always continue" semantics — they need `--reset-on=never` to keep the old behaviour. Called out in CHANGELOG `### Breaking`.

## Test plan

- [x] `npm test` from repo root — green (538 tests, 470 pass, 0 fail, 68 pre-existing skips)
- [x] `npm run check` from repo root — green
- [x] `node packages/tui/bin/tui.mjs --help` — `--reset-on` documented; `--continue` / `--fresh` shown as deprecated aliases
- [x] `node packages/tui/bin/tui.mjs run --reset-on=foo --self-improve` — exits 2 with clear error: `"expected one of workitem, iter, never (got 'foo')"`
- [x] `node packages/tui/bin/tui.mjs run --self-improve --continue --max 1` — prints deprecation notice on stderr (`"--continue is deprecated; use --reset-on=never instead."`) then proceeds
- [x] `node -e "import('./packages/tui/src/runner.mjs')..."` — module loads with `runRalphTui`, `legacyContextModeToResetOn`, `RESET_ON_VALUES` exports
- [x] New runner tests pin: each `resetOn` value's resume behaviour, the legacy `contextMode` mapping, validation rejection, the workitem-mode session reset for both clean (WORKITEM_END marker) and implicit (iter exit without marker) boundaries, and multi-workitem-per-iter behaviour
- [x] New bin tests pin: `--reset-on` parsing (= and space forms), USAGE doc, the deprecation notice firing exactly once per process per flag, invalid value rejection, and combining the new flag with a legacy alias

## Files

- `packages/tui/src/runner.mjs` — new `resetOn` parameter (back-compat with legacy `contextMode`); workitem-mode sessionId capture/drop logic
- `packages/tui/bin/tui.mjs` — new `--reset-on` flag; `--continue` / `--fresh` aliases with deprecation notice
- `packages/tui/test/runner.test.mjs` — new `resetOn` test coverage (13 tests)
- `packages/tui/test/bin.test.mjs` — new `--reset-on` test coverage (10 tests); updated bare-invocation banner pin
- `packages/tui/README.md` — documents `--reset-on` and the legacy aliases
- `README.md` — same; updates the Usage section to lead with `--reset-on`
- `CHANGELOG.md` — `### Breaking` and `### Features` entries for issue #51