### PR TITLE
feat(runner): per-iter git worktree; tear down at END iff merged (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Features
+- Runner now executes each iter in a per-iter git worktree under `$RALPH_TUI_RUNS_DIR/<runId>/worktrees/iter-<N>/` for `--self-improve` and `--grow-project` (`--worktree` opts in for `--prompt`); merged iters tear down on END, unmerged ones are preserved on disk and emit a `worktree_kept` event with the absolute path. (#66)
+
+### Internal
+- Startup sweep removes orphan worktrees from prior `terminated` runs (~200 ms budget). (#66)
+
 ### Breaking
 - Binary renamed `ralph-tui` → `autopilot`. Bare invocation now starts `run --self-improve --fresh` (was: print help). Use `autopilot --help` for the previous help output. (#65)
 - Issue #50 — Removed the in-session Copilot CLI extension.

--- a/packages/tui/bin/tui.mjs
+++ b/packages/tui/bin/tui.mjs
@@ -103,6 +103,12 @@ OPTIONS
   --abort-promise TOKEN  For \`run\`: substring whose presence signals
               an early abort. Defaults to the baked abort token of the
               chosen prompt mode (or none for --prompt).
+  --worktree  For \`run --prompt\`: opt in to per-iter git worktree
+              isolation (default-on for --self-improve and
+              --grow-project; merged iters tear down on END,
+              unmerged ones are preserved on disk).
+  --no-worktree  For \`run\`: disable per-iter worktree even for the
+              modes where it is on by default.
   --help, -h  Show this help.
   --version, -V  Print the autopilot package version and exit.
 
@@ -153,6 +159,8 @@ export function parseArgv(argv) {
         if (a === "--version" || a === "-V") { out.flags.version = true; continue; }
         if (a === "--plain") { out.flags.plain = true; continue; }
         if (a === "--no-plain") { out.flags.plain = false; continue; }
+        if (a === "--worktree") { out.flags.worktree = true; continue; }
+        if (a === "--no-worktree") { out.flags.worktree = false; continue; }
         if (a.startsWith("--")) {
             const eq = a.indexOf("=");
             if (eq !== -1) {
@@ -622,6 +630,14 @@ export async function cmdRun(flags) {
     const abortPromise = (typeof flags["abort-promise"] === "string" && flags["abort-promise"].trim())
         ? flags["abort-promise"] : undefined; // undefined → runner picks per-mode default
 
+    // Issue #66 D5 — per-iter git worktree mode. Default-on for
+    // `self-improve` / `grow-project` (both end with the COMMIT →
+    // PUSH → END pinned tail), opt-in for `--prompt`. Explicit
+    // `--worktree` / `--no-worktree` overrides the default.
+    const worktree = typeof flags.worktree === "boolean"
+        ? flags.worktree
+        : (mode === "self-improve" || mode === "grow-project");
+
     let stopOnce = false;
     const installSignal = (sig) => {
         const handler = () => {
@@ -718,6 +734,7 @@ export async function cmdRun(flags) {
             max,
             completionPromise,
             abortPromise: abortPromise ?? undefined,
+            worktree,
             // When the TUI is mounted, Ink owns the terminal — any
             // `runRalphTui` writes to stdout (e.g. the `# iter N/M`
             // banner) interleave with Ink's frames and corrupt the

--- a/packages/tui/src/components/LastCommit.mjs
+++ b/packages/tui/src/components/LastCommit.mjs
@@ -44,16 +44,41 @@ export function countCoAuthors(trailers) {
     return n;
 }
 
+// Worktree paths can run long (`/home/user/.copilot/ralph-tui/runs/
+// <runId>/worktrees/iter-<N>`). Ellipsize from the front so the
+// distinguishing iter-N tail stays visible.
+const WORKTREE_PATH_MAX = 60;
+
+function clipPath(p) {
+    if (typeof p !== "string") return "";
+    if (p.length <= WORKTREE_PATH_MAX) return p;
+    return "…" + p.slice(p.length - WORKTREE_PATH_MAX + 1);
+}
+
 export default function LastCommit({ snapshot }) {
     const last = snapshot?.lastCommit ?? null;
+    // Issue #66 — per-iter worktree status row. Surface the active
+    // worktree path for in-flight iters and a "kept N at <path>" tag
+    // when one or more prior iters left their sandboxes preserved.
+    // Single-line, dim — same visual weight as the trailer count
+    // badge so the row stays scannable.
+    const activeWt = snapshot?.activeWorktree ?? null;
+    const keptCount = Array.isArray(snapshot?.keptWorktrees) ? snapshot.keptWorktrees.length : 0;
+    const lastKept = keptCount > 0 ? snapshot.keptWorktrees[keptCount - 1] : null;
     if (!last || typeof last.sha !== "string") {
         return h(Box, {
             borderStyle: "single",
             borderColor: "gray",
             paddingX: 1,
-            flexDirection: "row",
+            flexDirection: "column",
         },
             h(Text, { dimColor: true }, "last commit: (none yet)"),
+            activeWt
+                ? h(Text, { dimColor: true }, "worktree: " + clipPath(activeWt.path))
+                : null,
+            lastKept
+                ? h(Text, { dimColor: true }, "kept " + String(keptCount) + ": " + clipPath(lastKept.path))
+                : null,
         );
     }
     const sha7 = last.sha.length >= 7 ? last.sha.slice(0, 7) : last.sha;
@@ -64,16 +89,24 @@ export default function LastCommit({ snapshot }) {
         borderStyle: "single",
         borderColor: "gray",
         paddingX: 1,
-        flexDirection: "row",
+        flexDirection: "column",
     },
-        h(Text, { color: "yellow", bold: true }, sha7),
-        h(Text, null, "  "),
-        h(Text, null, subject),
-        totalTrailers > 0
-            ? h(Text, { dimColor: true }, "   " + String(totalTrailers) + " trailer" + (totalTrailers === 1 ? "" : "s"))
+        h(Box, { flexDirection: "row" },
+            h(Text, { color: "yellow", bold: true }, sha7),
+            h(Text, null, "  "),
+            h(Text, null, subject),
+            totalTrailers > 0
+                ? h(Text, { dimColor: true }, "   " + String(totalTrailers) + " trailer" + (totalTrailers === 1 ? "" : "s"))
+                : null,
+            coAuthors > 0
+                ? h(Text, { color: "magenta" }, " (" + String(coAuthors) + " co-author" + (coAuthors === 1 ? "" : "s") + ")")
+                : null,
+        ),
+        activeWt
+            ? h(Text, { dimColor: true }, "worktree: " + clipPath(activeWt.path))
             : null,
-        coAuthors > 0
-            ? h(Text, { color: "magenta" }, " (" + String(coAuthors) + " co-author" + (coAuthors === 1 ? "" : "s") + ")")
+        lastKept
+            ? h(Text, { dimColor: true }, "kept " + String(keptCount) + ": " + clipPath(lastKept.path))
             : null,
     );
 }

--- a/packages/tui/src/events.mjs
+++ b/packages/tui/src/events.mjs
@@ -108,6 +108,17 @@ export const EVENT_TYPES = Object.freeze([
     // a Copilot CLI session id is captured for the active iter, so
     // the TUI can mount a tail against the per-session log file.
     "session_attached",
+    // Issue #66 — per-iter git worktree lifecycle events. Strictly
+    // additive (appended at end). `worktree_created` fires before
+    // `iteration_start` for each iter that runs in a fresh worktree;
+    // `worktree_removed` fires after `[STAGE: END]` when the iter's
+    // changes were merged into the base ref; `worktree_kept` fires
+    // when the iter ended without its changes being merged (aborted,
+    // failed, or the agent didn't push), so the user can inspect
+    // the leftover sandbox at the recorded path.
+    "worktree_created",
+    "worktree_removed",
+    "worktree_kept",
 ]);
 
 /** Recognised L1 work-item kinds — the categorisation used in the
@@ -140,6 +151,18 @@ export const PINNED_TAIL_STAGES = Object.freeze(["COMMIT", "PUSH", "END"]);
  *  silently corrupt outcome reporting in the TUI's task pane. */
 export const TASK_OUTCOMES = Object.freeze(["ok", "fail", "skip"]);
 const TASK_OUTCOME_SET = new Set(TASK_OUTCOMES);
+
+/** Issue #66 — set of per-iter worktree-lifecycle event types. Used
+ *  by the serializer / fold / plain renderer to gate path/branch
+ *  field validation. Pinned at module scope so a future event type
+ *  with an unrelated `path` field can't accidentally pick up the
+ *  validation. */
+export const WORKTREE_EVENT_TYPES = Object.freeze([
+    "worktree_created",
+    "worktree_removed",
+    "worktree_kept",
+]);
+const WORKTREE_EVENT_TYPE_SET = new Set(WORKTREE_EVENT_TYPES);
 
 /** Normalize a candidate stage list so the pinned tail (`COMMIT → PUSH
  *  → END`) is always present, in the canonical order, at the end.
@@ -526,6 +549,30 @@ export function serializeEvent(ev) {
         out.sessionId = safeSliceChars(ev.sessionId, 64);
     }
 
+    // Issue #66 — per-iter git worktree lifecycle events. All three
+    // share a `path` (capped at 1024 chars; well above any real
+    // `$RALPH_TUI_RUNS_DIR/<runId>/worktrees/iter-<N>/`) and a
+    // `branch` (capped at 200 chars; canonical `autopilot/<runId>/
+    // iter-<N>` is ~60 chars). `worktree_created` carries `baseRef`
+    // so replay can audit which ref the iter forked from.
+    if (WORKTREE_EVENT_TYPE_SET.has(ev.type)) {
+        if (typeof ev.path !== "string" || !ev.path) {
+            throw new TypeError(
+                `serializeEvent: ${ev.type} requires a non-empty path string`,
+            );
+        }
+        if (typeof ev.branch !== "string" || !ev.branch) {
+            throw new TypeError(
+                `serializeEvent: ${ev.type} requires a non-empty branch string`,
+            );
+        }
+        out.path = safeSliceChars(ev.path, 1024);
+        out.branch = safeSliceChars(ev.branch, 200);
+        if (ev.type === "worktree_created" && typeof ev.baseRef === "string" && ev.baseRef) {
+            out.baseRef = safeSliceChars(ev.baseRef, 200);
+        }
+    }
+
     const line = JSON.stringify(out);
     if (Buffer.byteLength(line, "utf8") > MAX_EVENT_LINE_BYTES) {
         throw new RangeError(
@@ -679,6 +726,15 @@ export function foldEvents(events) {
         taskInFlight: null,
         recentTasks: [],
         lastCommit: null,
+        // Issue #66 — per-iter git worktree state for the LastCommit /
+        // DetailPane row. `activeWorktree` tracks the in-flight iter's
+        // sandbox path / branch / baseRef; nulls out on
+        // `worktree_removed` (merged + cleaned up). `keptWorktrees`
+        // is the run-local log of preserved sandboxes — each
+        // `worktree_kept` event appends an entry so the TUI can show
+        // "kept N: <path>" lines below the active row.
+        activeWorktree: null,
+        keptWorktrees: [],
     };
 
     for (const ev of events) {
@@ -717,6 +773,8 @@ export function foldEvents(events) {
                 snap.taskInFlight = null;
                 snap.recentTasks = [];
                 snap.lastCommit = null;
+                snap.activeWorktree = null;
+                snap.keptWorktrees = [];
                 break;
             case "iteration_start":
                 if (Number.isFinite(ev.iteration)) {
@@ -1065,6 +1123,52 @@ export function foldEvents(events) {
                 if (typeof ev.sessionId !== "string" || !ev.sessionId) break;
                 if (ev.sessionId.length > 64) break;
                 snap.sessionId = ev.sessionId;
+                break;
+            }
+            // Issue #66 — per-iter git worktree lifecycle. Each iter
+            // that runs in worktree mode emits `worktree_created` at
+            // the top of its `iteration_start` block, then either
+            // `worktree_removed` (changes merged into base ref →
+            // sandbox + branch deleted) or `worktree_kept` (changes
+            // not merged → sandbox preserved on disk for inspection).
+            // Defensive shape validation mirrors the serializer.
+            case "worktree_created": {
+                if (typeof ev.path !== "string" || !ev.path) break;
+                if (typeof ev.branch !== "string" || !ev.branch) break;
+                snap.activeWorktree = {
+                    path: ev.path,
+                    branch: ev.branch,
+                    baseRef: typeof ev.baseRef === "string" && ev.baseRef ? ev.baseRef : null,
+                    iteration: Number.isFinite(ev.iteration) ? ev.iteration : null,
+                    startedAt: ev.ts,
+                };
+                break;
+            }
+            case "worktree_removed": {
+                if (typeof ev.path !== "string" || !ev.path) break;
+                if (
+                    snap.activeWorktree
+                    && snap.activeWorktree.path === ev.path
+                ) {
+                    snap.activeWorktree = null;
+                }
+                break;
+            }
+            case "worktree_kept": {
+                if (typeof ev.path !== "string" || !ev.path) break;
+                if (typeof ev.branch !== "string" || !ev.branch) break;
+                snap.keptWorktrees.push({
+                    path: ev.path,
+                    branch: ev.branch,
+                    iteration: Number.isFinite(ev.iteration) ? ev.iteration : null,
+                    ts: ev.ts,
+                });
+                if (
+                    snap.activeWorktree
+                    && snap.activeWorktree.path === ev.path
+                ) {
+                    snap.activeWorktree = null;
+                }
                 break;
             }
             default:

--- a/packages/tui/src/plain.mjs
+++ b/packages/tui/src/plain.mjs
@@ -9,7 +9,9 @@
 // log line. No I/O, no ANSI. Tests pin the exact wording for the
 // snapshot suite.
 
-import { safeSliceChars } from "./events.mjs";
+import { safeSliceChars, WORKTREE_EVENT_TYPES } from "./events.mjs";
+
+const WORKTREE_EVENT_TYPE_SET = new Set(WORKTREE_EVENT_TYPES);
 
 const PAD2 = (n) => String(n).padStart(2, "0");
 const PAD3 = (n) => String(n).padStart(3, "0");
@@ -77,6 +79,13 @@ const VERB = {
     // result (premiumRequests) lands during an iter, carrying
     // cumulative-for-the-run counters.
     usage_update: "usage",
+    // Issue #66 — per-iter git worktree lifecycle. 5-char verbs so the
+    // column layout under awk/grep stays uniform with the existing
+    // vocabulary. `wt+ ` / `wt- ` follow the iter+/- family; `wtkep`
+    // signals the kept-on-disk variant.
+    worktree_created: "wt+  ",
+    worktree_removed: "wt-  ",
+    worktree_kept: "wtkep",
 };
 
 /**
@@ -193,6 +202,23 @@ export function formatEventLine(ev) {
         // exploding when a commit has multiple Co-authored-by lines.
         // The TUI reads trailers from the JSONL event directly.
         parts.push(`trailers=${ev.trailers.length}`);
+    }
+    // Issue #66 — per-iter git worktree fields. `path` and `branch`
+    // are JSON-stringified because absolute paths and branch names
+    // can contain spaces (rare but legal); `baseRef` is unquoted
+    // because refs are token-shaped.
+    if (WORKTREE_EVENT_TYPE_SET.has(ev.type)) {
+        if (typeof ev.path === "string" && ev.path) {
+            const collapsed = safeSliceChars(ev.path.replace(/\s+/g, " "), 200);
+            parts.push(`path=${JSON.stringify(collapsed)}`);
+        }
+        if (typeof ev.branch === "string" && ev.branch) {
+            const collapsed = safeSliceChars(ev.branch.replace(/\s+/g, " "), 200);
+            parts.push(`branch=${JSON.stringify(collapsed)}`);
+        }
+        if (typeof ev.baseRef === "string" && ev.baseRef && ev.type === "worktree_created") {
+            parts.push(`baseRef=${ev.baseRef}`);
+        }
     }
     if (typeof ev.reason === "string" && ev.reason) {
         // JSON.stringify the reason iff it contains whitespace, so a

--- a/packages/tui/src/runner.mjs
+++ b/packages/tui/src/runner.mjs
@@ -27,7 +27,7 @@
 
 import { spawn as nodeSpawn, spawnSync as nodeSpawnSync } from "node:child_process";
 import { homedir } from "node:os";
-import { mkdirSync, readFileSync, writeFileSync, renameSync, existsSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync, renameSync, existsSync, rmSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 
@@ -538,7 +538,7 @@ export function looksLikeGitCommit(command) {
  *
  *  Tests inject their own `gitExec` to stub repo state without
  *  shelling out — see `runRalphTui({ gitExec, … })`. */
-function defaultGitExec({ args, cwd, env }) {
+function defaultGitExec({ args, cwd, env, timeoutMs }) {
     try {
         const r = nodeSpawnSync("git", args, {
             cwd,
@@ -551,14 +551,233 @@ function defaultGitExec({ args, cwd, env }) {
             // helper) silently delaying the run.start path; the
             // emitCommitObservedFromHead caller already swallows null,
             // so a timeout just means "skip the LastCommit pane on
-            // mount" rather than crash.
-            timeout: 200,
+            // mount" rather than crash. Issue #66 — `worktree add` /
+            // `fetch` need a longer ceiling (network + filesystem
+            // copy), so callers may opt in via `timeoutMs`. Default
+            // stays at 200 ms for read-only probes.
+            timeout: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 200,
         });
         if (r.status !== 0) return null;
         return typeof r.stdout === "string" ? r.stdout : null;
     } catch {
         return null;
     }
+}
+
+// ─── Per-iter git worktree lifecycle (issue #66) ──────────────────
+
+/** Issue #66 — default base ref each iter forks from. `main` HEAD at
+ *  iter start so iter N+1 sees iter N's merged work. The runner
+ *  resolves this against the parent repo (cwd) before each iter so
+ *  the base is the most-recent committed state, not a pinned
+ *  arm-time SHA. */
+export const DEFAULT_WORKTREE_BASE_REF = "main";
+
+/** Issue #66 — per-iter timeout for `git worktree add` / `git fetch`
+ *  / `git merge-base --is-ancestor`. 5s gives slow filesystems and
+ *  one-shot `git fetch` operations enough headroom while still
+ *  capping the worst-case wait. The read-only probes used by
+ *  commit_observed (rev-parse / log) keep the 200 ms default in
+ *  `defaultGitExec`. */
+export const WORKTREE_GIT_TIMEOUT_MS = 5000;
+
+/** Compose the canonical worktree path for an iter under a run's
+ *  state directory. Pure / no I/O — exported for tests. */
+export function worktreePathFor({ runsRoot, runId, iter }) {
+    if (typeof runsRoot !== "string" || !runsRoot) {
+        throw new TypeError("worktreePathFor: runsRoot must be a non-empty string");
+    }
+    if (typeof runId !== "string" || !runId) {
+        throw new TypeError("worktreePathFor: runId must be a non-empty string");
+    }
+    if (!Number.isInteger(iter) || iter < 1) {
+        throw new TypeError("worktreePathFor: iter must be a positive integer");
+    }
+    return join(runsRoot, runId, "worktrees", `iter-${iter}`);
+}
+
+/** Compose the canonical iter branch name. Stable prefix
+ *  (`autopilot/<runId>/iter-<N>`) so a `git branch | grep autopilot/`
+ *  cleanup catches everything from previous worktree-mode runs. */
+export function worktreeBranchFor({ runId, iter }) {
+    if (typeof runId !== "string" || !runId) {
+        throw new TypeError("worktreeBranchFor: runId must be a non-empty string");
+    }
+    if (!Number.isInteger(iter) || iter < 1) {
+        throw new TypeError("worktreeBranchFor: iter must be a positive integer");
+    }
+    return `autopilot/${runId}/iter-${iter}`;
+}
+
+/** Create a fresh per-iter worktree at the canonical path, branched
+ *  from `baseRef` in the parent `cwd` repo. Returns `{ path, branch }`
+ *  on success or `null` on any git error (no repo, lock file held,
+ *  baseRef missing, worktree already exists, etc) — caller falls
+ *  back to running the iter in the parent cwd.
+ *
+ *  Side effects (success path):
+ *  - Creates `<runsRoot>/<runId>/worktrees/` if missing.
+ *  - `git worktree add -b <branch> <path> <baseRef>` from `cwd`.
+ *
+ *  All git invocations go through the injected `gitExec` so unit
+ *  tests can stub the binary out. Pure I/O — exported for tests.
+ *
+ *  @param {object} opts
+ *  @param {string} opts.runId
+ *  @param {number} opts.iter        1-indexed.
+ *  @param {string} opts.baseRef     ref to fork from (default "main").
+ *  @param {string} opts.runsRoot    `$RALPH_TUI_RUNS_DIR` value.
+ *  @param {string} opts.cwd         parent repo path (the user's
+ *                                   working tree).
+ *  @param {object} [opts.env]
+ *  @param {(req: {args: string[], cwd: string, env: object, timeoutMs?: number}) => string|null} opts.gitExec
+ *  @param {(dir: string, opts: object) => void} [opts.mkdir]   tests inject.
+ *  @returns {{path: string, branch: string}|null}
+ */
+export function createIterWorktree({ runId, iter, baseRef, runsRoot, cwd, env, gitExec, mkdir = mkdirSync }) {
+    if (typeof gitExec !== "function") return null;
+    const branch = worktreeBranchFor({ runId, iter });
+    const path = worktreePathFor({ runsRoot, runId, iter });
+    const ref = (typeof baseRef === "string" && baseRef) ? baseRef : DEFAULT_WORKTREE_BASE_REF;
+    // Ensure the parent `worktrees/` dir exists. `git worktree add`
+    // would create the leaf dir itself, but the parent must already
+    // exist or git errors out. Mirrors initState's mkdir-for-runId
+    // pattern.
+    try {
+        mkdir(join(runsRoot, runId, "worktrees"), { recursive: true });
+    } catch {
+        return null;
+    }
+    // `git worktree add -b <branch> <path> <baseRef>` creates the
+    // branch from baseRef AND checks it out into the new worktree
+    // in one step. If the branch already exists (collision after a
+    // previous failed run), git refuses and we return null — the
+    // caller falls back to the parent cwd.
+    const out = gitExec({
+        args: ["worktree", "add", "-b", branch, path, ref],
+        cwd,
+        env,
+        timeoutMs: WORKTREE_GIT_TIMEOUT_MS,
+    });
+    if (out === null) return null;
+    return { path, branch };
+}
+
+/** Tear down an iter worktree + its branch. Best-effort: if either
+ *  step errors, we log nothing and return false so the caller can
+ *  decide whether to surface a `worktree_kept` event. Returns true
+ *  iff both `worktree remove` and `branch -D` succeeded.
+ *
+ *  Uses `--force` on `worktree remove` to handle the common case
+ *  where the iter left modified-but-uncommitted files (a half-
+ *  finished tier b commit, a `.npm` cache, etc); the branch is
+ *  already known to be merged at the call site. */
+export function removeIterWorktree({ path, branch, cwd, env, gitExec }) {
+    if (typeof gitExec !== "function") return false;
+    if (typeof path !== "string" || !path) return false;
+    const removed = gitExec({
+        args: ["worktree", "remove", "--force", path],
+        cwd,
+        env,
+        timeoutMs: WORKTREE_GIT_TIMEOUT_MS,
+    });
+    if (removed === null) return false;
+    if (typeof branch === "string" && branch) {
+        const branchDeleted = gitExec({
+            args: ["branch", "-D", branch],
+            cwd,
+            env,
+            timeoutMs: WORKTREE_GIT_TIMEOUT_MS,
+        });
+        if (branchDeleted === null) return false;
+    }
+    return true;
+}
+
+/** D1 — "merged" means `git merge-base --is-ancestor <branch>
+ *  <baseRef>` after a preceding `git fetch` (so a CI-merged push
+ *  shows up locally). Returns:
+ *    - true  if the branch is reachable from baseRef.
+ *    - false if it isn't, or if either git call errored.
+ *
+ *  Both calls are best-effort — a fetch failure (offline, auth)
+ *  falls back to the local merge-base check, which still catches
+ *  the "agent committed locally and merged" case.
+ *
+ *  We use `gitExec` for `merge-base --is-ancestor` even though it's
+ *  an exit-code-only check (no stdout): `defaultGitExec` returns
+ *  null on non-zero exit (i.e. NOT an ancestor). A successful
+ *  invocation returns "" (empty stdout, status 0) so we treat any
+ *  non-null return as "merged". */
+export function verifyMerged({ branch, baseRef, cwd, env, gitExec }) {
+    if (typeof gitExec !== "function") return false;
+    if (typeof branch !== "string" || !branch) return false;
+    const ref = (typeof baseRef === "string" && baseRef) ? baseRef : DEFAULT_WORKTREE_BASE_REF;
+    // Best-effort fetch; ignore errors (offline / no remote / auth).
+    gitExec({
+        args: ["fetch", "--quiet"],
+        cwd,
+        env,
+        timeoutMs: WORKTREE_GIT_TIMEOUT_MS,
+    });
+    const out = gitExec({
+        args: ["merge-base", "--is-ancestor", branch, ref],
+        cwd,
+        env,
+        timeoutMs: WORKTREE_GIT_TIMEOUT_MS,
+    });
+    return out !== null;
+}
+
+/** D7 startup sweep — scan `<runsRoot>/<runId>/worktrees/` for orphan
+ *  iter-N dirs whose parent run's state.json is `terminated`, and
+ *  `git worktree remove --force` them. Bounded to ~200 ms total via
+ *  per-call short-circuit; if the budget runs out we just stop.
+ *  Returns the count of removed orphans (for tests). Best-effort —
+ *  any error short-circuits silently. */
+export function sweepOrphanWorktrees({ runsRoot, cwd, env, gitExec, now = () => Date.now(), budgetMs = 200, readState: readStateFn = readState }) {
+    if (typeof gitExec !== "function") return 0;
+    if (typeof runsRoot !== "string" || !runsRoot) return 0;
+    if (!existsSync(runsRoot)) return 0;
+    let removed = 0;
+    const start = now();
+    let runIds;
+    try {
+        runIds = readdirSync(runsRoot, { withFileTypes: true })
+            .filter((d) => d.isDirectory())
+            .map((d) => d.name);
+    } catch {
+        return 0;
+    }
+    for (const runId of runIds) {
+        if (now() - start >= budgetMs) break;
+        const wtRoot = join(runsRoot, runId, "worktrees");
+        if (!existsSync(wtRoot)) continue;
+        // Only sweep terminated runs — an in-flight run owns its
+        // worktrees and removing them mid-iter would orphan the
+        // copilot subprocess's cwd.
+        const state = readStateFn(runId, env);
+        if (!state || !state.terminated) continue;
+        let entries;
+        try {
+            entries = readdirSync(wtRoot, { withFileTypes: true })
+                .filter((d) => d.isDirectory());
+        } catch {
+            continue;
+        }
+        for (const entry of entries) {
+            if (now() - start >= budgetMs) break;
+            const wtPath = join(wtRoot, entry.name);
+            const out = gitExec({
+                args: ["worktree", "remove", "--force", wtPath],
+                cwd,
+                env,
+                timeoutMs: WORKTREE_GIT_TIMEOUT_MS,
+            });
+            if (out !== null) removed += 1;
+        }
+    }
+    return removed;
 }
 
 /** Run `git rev-parse --short HEAD` + `git log -1
@@ -1044,6 +1263,20 @@ export async function runRalphTui(opts) {
         // a runtime without git installed (or a non-repo cwd) falls
         // back to no commit narration.
         gitExec = defaultGitExec,
+        // Issue #66 — opt-in per-iter git worktree mode. Default-on
+        // for `self-improve` and `grow-project` (both follow the
+        // COMMIT → PUSH → END pinned tail), opt-in for `--prompt`.
+        // When true, each iter spawns in a fresh worktree at
+        // `<runsRoot>/<runId>/worktrees/iter-<N>/` branched from
+        // `worktreeBaseRef`; the worktree is removed on END iff its
+        // changes are merged into the base ref, otherwise a
+        // `worktree_kept` event records the absolute path.
+        worktree = (mode === "self-improve" || mode === "grow-project"),
+        // Issue #66 D4 — base ref each iter forks from. `main` HEAD
+        // at iter start so iter N+1 sees iter N's merged work. The
+        // value is a ref string (`main`, `develop`, an SHA, …);
+        // resolved against `cwd` (the parent repo) at iter time.
+        worktreeBaseRef = DEFAULT_WORKTREE_BASE_REF,
     } = opts;
 
     if (mode !== "self-improve" && mode !== "grow-project" && mode !== "prompt") {
@@ -1088,6 +1321,26 @@ export async function runRalphTui(opts) {
         sessionId: null,
         totalPausedMs: 0,
     }, env);
+
+    // Issue #66 D7 — startup sweep. Scan
+    // `<runsRoot>/<runId>/worktrees/` for orphan dirs whose parent
+    // run's `state.json` says `terminated`, and `git worktree
+    // remove --force` them. Bounded to ~200 ms total via
+    // `sweepOrphanWorktrees`'s budget so a wedged git on a single
+    // orphan can't delay the new run's arm path. Best-effort: any
+    // failure short-circuits silently. Only meaningful in worktree
+    // mode (the helper is gitExec-gated anyway).
+    if (worktree) {
+        try {
+            sweepOrphanWorktrees({
+                runsRoot: resolveStateRoot(env),
+                cwd,
+                env,
+                gitExec,
+                now,
+            });
+        } catch { /* swallow */ }
+    }
 
     // Emit the canonical `armed` event so `ralph-tui list/stats`
     // pick up this run.
@@ -1176,6 +1429,43 @@ export async function runRalphTui(opts) {
         }
         if (stopRequested) break;
 
+        // Issue #66 — per-iter git worktree. When opted in (and the
+        // runner has a `gitExec`), build a fresh sandbox at
+        // `<runsRoot>/<runId>/worktrees/iter-<N>/` BEFORE
+        // `iteration_start` so a `worktree_created` event can land
+        // first, then point the iter's spawn cwd + commit_observed
+        // probes at it. On any failure (no git, no parent repo, branch
+        // collision, etc), fall back to the parent cwd silently —
+        // the iter still runs, just without isolation.
+        let iterWorktree = null;
+        let iterCwd = cwd;
+        if (worktree) {
+            iterWorktree = createIterWorktree({
+                runId,
+                iter,
+                baseRef: worktreeBaseRef,
+                runsRoot: resolveStateRoot(env),
+                cwd,
+                env,
+                gitExec,
+            });
+            if (iterWorktree) {
+                iterCwd = iterWorktree.path;
+                try {
+                    emitter.write({
+                        type: "worktree_created",
+                        ts: now(),
+                        runId,
+                        label,
+                        iteration: iter,
+                        path: iterWorktree.path,
+                        branch: iterWorktree.branch,
+                        baseRef: worktreeBaseRef,
+                    });
+                } catch { /* serializer rejection — fall back to cwd */ }
+            }
+        }
+
         emitter.write({
             type: "iteration_start",
             ts: now(),
@@ -1227,6 +1517,12 @@ export async function runRalphTui(opts) {
         // explicitly called this out: per-call idempotence beats
         // post-hoc range scans for happy-path simplicity.
         const commitObservedToolCallIds = new Set();
+        // Issue #66 — set when the runner sees `[STAGE: END]` for
+        // this iter so the worktree-cleanup probe at iter close
+        // knows whether the agent reached the canonical end of its
+        // SDLC (vs aborted mid-stage). Drives the merge-or-keep
+        // decision per D1.
+        let sawEndStage = false;
         // Active workitem reference carried across iters so a
         // `[WORKITEM_END: {…}]` without an explicit ref/title can
         // backfill from the in-flight item rather than fail
@@ -1236,8 +1532,12 @@ export async function runRalphTui(opts) {
             // Best-effort: shell out to git for the SHA + subject +
             // trailers of HEAD. If the runner has no gitExec (or
             // the repo isn't there), silently skip — the LastCommit
-            // pane just doesn't update for this iter.
-            const head = readHeadCommit({ gitExec, cwd, env });
+            // pane just doesn't update for this iter. Issue #66 —
+            // probe HEAD against the iter's worktree (if any) so the
+            // SHA we surface is the agent's commit on the iter
+            // branch, not whatever the parent cwd happens to point
+            // at.
+            const head = readHeadCommit({ gitExec, cwd: iterCwd, env });
             if (!head) return;
             try {
                 emitter.write({
@@ -1280,6 +1580,12 @@ export async function runRalphTui(opts) {
                     });
                     liveActiveMarker = item;
                     liveSubstageIdx = 0;
+                    // Issue #66 — pin the END-stage gate for the
+                    // post-iter worktree cleanup. Idempotent: a
+                    // duplicate `[STAGE: END]` marker (rare but
+                    // possible if the agent fumbles) just re-asserts
+                    // the flag.
+                    if (item.name === "END") sawEndStage = true;
                 } else if (item.kind === "tool_complete") {
                     liveSubstageIdx += 1;
                     emitter.write({
@@ -1601,7 +1907,12 @@ export async function runRalphTui(opts) {
                 sessionName: sessionNameForIter,
                 spawn,
                 copilotBin,
-                cwd,
+                // Issue #66 — when worktree mode is on and we
+                // successfully created a sandbox for this iter, run
+                // the copilot subprocess inside it. Otherwise the
+                // parent cwd (the user's working tree) is the cwd
+                // exactly as before.
+                cwd: iterCwd,
                 env,
                 onLine,
             });
@@ -1755,6 +2066,41 @@ export async function runRalphTui(opts) {
         if (onIteration) {
             try { onIteration({ iter, excerpt, sessionId: capturedSessionId, exitCode: result.exitCode }); }
             catch { /* swallow */ }
+        }
+
+        // Issue #66 — END-stage merge probe + cleanup. Decide whether
+        // to remove the worktree (changes merged into base ref) or
+        // preserve it (aborted, failed, or the agent didn't push).
+        // sawEndStage=false → preserve unconditionally so the user
+        // can inspect the partial state. Removal is best-effort: if
+        // the rm itself fails (lock file, permission), fall through
+        // to the kept emit so the user still sees the path on disk.
+        if (iterWorktree) {
+            const merged = sawEndStage && verifyMerged({
+                branch: iterWorktree.branch,
+                baseRef: worktreeBaseRef,
+                cwd,
+                env,
+                gitExec,
+            });
+            const removedOk = merged && removeIterWorktree({
+                path: iterWorktree.path,
+                branch: iterWorktree.branch,
+                cwd,
+                env,
+                gitExec,
+            });
+            try {
+                emitter.write({
+                    type: removedOk ? "worktree_removed" : "worktree_kept",
+                    ts: now(),
+                    runId,
+                    label,
+                    iteration: iter,
+                    path: iterWorktree.path,
+                    branch: iterWorktree.branch,
+                });
+            } catch { /* serializer rejection — skip */ }
         }
 
         if (result.exitCode !== 0) {

--- a/packages/tui/test/events.test.mjs
+++ b/packages/tui/test/events.test.mjs
@@ -59,6 +59,13 @@ test("EVENT_TYPES is the closed set documented in the issue", () => {
         // replay through this reader unchanged; the panel just shows
         // its "(waiting for session)" empty state.
         "session_attached",
+        // Issue #66 — per-iter git worktree lifecycle. Strictly
+        // additive (appended below the slice-3 / slice-9 / #57
+        // entries above); historical events.jsonl files keep
+        // replaying through this reader unchanged.
+        "worktree_created",
+        "worktree_removed",
+        "worktree_kept",
     ]);
 });
 
@@ -1495,4 +1502,135 @@ test("foldEvents: malformed session_attached (empty sessionId) is a no-op", () =
     ];
     const snap = foldEvents(events);
     assert.equal(snap.sessionId, "good");
+});
+
+// ─── Issue #66 — per-iter git worktree events ──────────────────────
+
+test("serializeEvent: worktree_created round-trips through parseEventLine with path / branch / baseRef", () => {
+    const ev = {
+        type: "worktree_created",
+        ts: 100,
+        runId: "r-1",
+        label: "ralph-tui-self-improve",
+        iteration: 3,
+        path: "/runs/r-1/worktrees/iter-3",
+        branch: "autopilot/r-1/iter-3",
+        baseRef: "main",
+    };
+    const back = parseEventLine(serializeEvent(ev));
+    assert.deepEqual(back, ev);
+});
+
+test("serializeEvent: worktree_removed round-trips with path / branch (no baseRef)", () => {
+    const ev = {
+        type: "worktree_removed",
+        ts: 200,
+        runId: "r-1",
+        iteration: 3,
+        path: "/runs/r-1/worktrees/iter-3",
+        branch: "autopilot/r-1/iter-3",
+    };
+    const back = parseEventLine(serializeEvent(ev));
+    assert.deepEqual(back, ev);
+});
+
+test("serializeEvent: worktree_kept round-trips with path / branch", () => {
+    const ev = {
+        type: "worktree_kept",
+        ts: 300,
+        runId: "r-1",
+        iteration: 4,
+        path: "/runs/r-1/worktrees/iter-4",
+        branch: "autopilot/r-1/iter-4",
+    };
+    const back = parseEventLine(serializeEvent(ev));
+    assert.deepEqual(back, ev);
+});
+
+test("serializeEvent: worktree_created rejects missing path / branch", () => {
+    assert.throws(
+        () => serializeEvent({ type: "worktree_created", ts: 1, runId: "r", branch: "b" }),
+        /requires a non-empty path/,
+    );
+    assert.throws(
+        () => serializeEvent({ type: "worktree_created", ts: 1, runId: "r", path: "/p" }),
+        /requires a non-empty branch/,
+    );
+});
+
+test("serializeEvent: worktree events truncate oversized path/branch", () => {
+    const longPath = "/" + "x".repeat(2000);
+    const longBranch = "y".repeat(500);
+    const line = serializeEvent({
+        type: "worktree_kept",
+        ts: 1,
+        runId: "r",
+        path: longPath,
+        branch: longBranch,
+    });
+    const obj = JSON.parse(line);
+    assert.equal(obj.path.length, 1024);
+    assert.equal(obj.branch.length, 200);
+});
+
+test("foldEvents: worktree_created sets activeWorktree, worktree_removed clears it", () => {
+    const events = [
+        { type: "armed", ts: 1, runId: "r", label: "a", maxIterations: 1 },
+        { type: "worktree_created", ts: 2, runId: "r", iteration: 1, path: "/p1", branch: "b1", baseRef: "main" },
+    ];
+    let snap = foldEvents(events);
+    assert.deepEqual(snap.activeWorktree, {
+        path: "/p1",
+        branch: "b1",
+        baseRef: "main",
+        iteration: 1,
+        startedAt: 2,
+    });
+    events.push({ type: "worktree_removed", ts: 3, runId: "r", iteration: 1, path: "/p1", branch: "b1" });
+    snap = foldEvents(events);
+    assert.equal(snap.activeWorktree, null);
+    // No keptWorktree entry — removed iters don't get kept.
+    assert.equal(snap.keptWorktrees.length, 0);
+});
+
+test("foldEvents: worktree_kept appends to keptWorktrees AND clears activeWorktree", () => {
+    const events = [
+        { type: "armed", ts: 1, runId: "r", label: "a", maxIterations: 2 },
+        { type: "worktree_created", ts: 2, runId: "r", iteration: 1, path: "/p1", branch: "b1", baseRef: "main" },
+        { type: "worktree_kept", ts: 3, runId: "r", iteration: 1, path: "/p1", branch: "b1" },
+    ];
+    const snap = foldEvents(events);
+    assert.equal(snap.activeWorktree, null);
+    assert.equal(snap.keptWorktrees.length, 1);
+    assert.deepEqual(snap.keptWorktrees[0], {
+        path: "/p1",
+        branch: "b1",
+        iteration: 1,
+        ts: 3,
+    });
+});
+
+test("foldEvents: a fresh `armed` resets activeWorktree + keptWorktrees", () => {
+    const events = [
+        { type: "armed", ts: 1, runId: "r1", label: "a", maxIterations: 1 },
+        { type: "worktree_created", ts: 2, runId: "r1", iteration: 1, path: "/p1", branch: "b1", baseRef: "main" },
+        { type: "worktree_kept", ts: 3, runId: "r1", iteration: 1, path: "/p1", branch: "b1" },
+        { type: "armed", ts: 10, runId: "r2", label: "a", maxIterations: 1 },
+    ];
+    const snap = foldEvents(events);
+    assert.equal(snap.activeWorktree, null);
+    assert.deepEqual(snap.keptWorktrees, []);
+});
+
+test("foldEvents: malformed worktree_created (missing fields) is a no-op", () => {
+    // Defence in depth: the serializer rejects malformed events but
+    // a hand-edited events.jsonl could carry them. The fold silently
+    // skips rather than poisoning the snapshot.
+    const events = [
+        { type: "armed", ts: 1, runId: "r", label: "a", maxIterations: 1 },
+        { type: "worktree_created", ts: 2, runId: "r", iteration: 1, branch: "b1" }, // no path
+        { type: "worktree_created", ts: 3, runId: "r", iteration: 1, path: "/p1" },  // no branch
+    ];
+    const snap = foldEvents(events);
+    assert.equal(snap.activeWorktree, null);
 });

--- a/packages/tui/test/runner-worktree.test.mjs
+++ b/packages/tui/test/runner-worktree.test.mjs
@@ -1,0 +1,657 @@
+// Tests for issue #66 — per-iter git worktree lifecycle helpers in
+// `runner.mjs`. Covers:
+//   - createIterWorktree path / branch composition + invocation shape
+//   - removeIterWorktree happy path + branch deletion
+//   - verifyMerged ancestor check (true / false / git error)
+//   - sweepOrphanWorktrees skips active runs, removes terminated ones
+//   - end-to-end: an iter that COMPLETEs spawns + tears down a worktree
+//   - end-to-end: an iter that fails BEFORE END preserves the worktree
+//
+// All tests use an injected `gitExec` so no real `git` is invoked.
+// One stretch-goal e2e exercises `git --version`-gated real worktree
+// creation in a tmp repo; it is `t.skip()`-ed when git is unavailable.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+    mkdtempSync,
+    mkdirSync,
+    rmSync,
+    existsSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+
+import {
+    runRalphTui,
+    createIterWorktree,
+    removeIterWorktree,
+    verifyMerged,
+    sweepOrphanWorktrees,
+    worktreePathFor,
+    worktreeBranchFor,
+    DEFAULT_WORKTREE_BASE_REF,
+} from "../src/runner.mjs";
+
+function tmp() {
+    return mkdtempSync(join(tmpdir(), "ralph-tui-worktree-"));
+}
+
+function makeEnv(extra = {}) {
+    return {
+        RALPH_TUI_RUNS_DIR: extra.RALPH_TUI_RUNS_DIR ?? tmp(),
+        ...extra,
+    };
+}
+
+// Mock spawn that returns scripted stdout/exitCode for each call.
+function makeMockSpawn(scripts) {
+    let i = 0;
+    return function mockSpawn(_bin, args) {
+        const script = scripts[i++] ?? scripts[scripts.length - 1];
+        const handlers = { stdout: [], stderr: [], close: [], error: [] };
+        const child = {
+            stdout: { on: (ev, fn) => handlers.stdout.push(fn) },
+            stderr: { on: (ev, fn) => handlers.stderr.push(fn) },
+            on: (ev, fn) => { if (ev === "close") handlers.close.push(fn); if (ev === "error") handlers.error.push(fn); },
+            kill: () => {},
+            __args: args,
+        };
+        setImmediate(() => {
+            for (const fn of handlers.stdout) fn(Buffer.from(script.stdout ?? ""));
+            for (const fn of handlers.close) fn(script.exitCode ?? 0);
+        });
+        return child;
+    };
+}
+
+// ───────────── Pure helpers ─────────────
+
+test("worktreePathFor: composes the canonical iter path under the runs root", () => {
+    const out = worktreePathFor({
+        runsRoot: "/runs",
+        runId: "ralph-tui-self-improve-1700000000000",
+        iter: 5,
+    });
+    assert.equal(out, "/runs/ralph-tui-self-improve-1700000000000/worktrees/iter-5");
+});
+
+test("worktreePathFor: rejects bad input", () => {
+    assert.throws(() => worktreePathFor({ runsRoot: "", runId: "r", iter: 1 }), /runsRoot/);
+    assert.throws(() => worktreePathFor({ runsRoot: "/r", runId: "", iter: 1 }), /runId/);
+    assert.throws(() => worktreePathFor({ runsRoot: "/r", runId: "r", iter: 0 }), /positive integer/);
+    assert.throws(() => worktreePathFor({ runsRoot: "/r", runId: "r", iter: -1 }), /positive integer/);
+});
+
+test("worktreeBranchFor: composes the canonical autopilot/<runId>/iter-<N> branch", () => {
+    assert.equal(
+        worktreeBranchFor({ runId: "ralph-tui-grow-project-1700000000000", iter: 12 }),
+        "autopilot/ralph-tui-grow-project-1700000000000/iter-12",
+    );
+});
+
+test("DEFAULT_WORKTREE_BASE_REF is `main`", () => {
+    assert.equal(DEFAULT_WORKTREE_BASE_REF, "main");
+});
+
+// ───────────── createIterWorktree ─────────────
+
+test("createIterWorktree: invokes `git worktree add -b <branch> <path> <baseRef>`", () => {
+    const calls = [];
+    const gitExec = (req) => {
+        calls.push(req);
+        return ""; // success
+    };
+    const out = createIterWorktree({
+        runId: "r-1",
+        iter: 3,
+        baseRef: "main",
+        runsRoot: "/runs",
+        cwd: "/repo",
+        env: { X: "y" },
+        gitExec,
+        mkdir: () => {},
+    });
+    assert.deepEqual(out, {
+        path: "/runs/r-1/worktrees/iter-3",
+        branch: "autopilot/r-1/iter-3",
+    });
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].args, [
+        "worktree", "add", "-b",
+        "autopilot/r-1/iter-3",
+        "/runs/r-1/worktrees/iter-3",
+        "main",
+    ]);
+    assert.equal(calls[0].cwd, "/repo");
+});
+
+test("createIterWorktree: defaults baseRef to main when missing", () => {
+    const calls = [];
+    const gitExec = (req) => { calls.push(req); return ""; };
+    createIterWorktree({
+        runId: "r-1",
+        iter: 1,
+        runsRoot: "/runs",
+        cwd: "/repo",
+        env: {},
+        gitExec,
+        mkdir: () => {},
+    });
+    assert.equal(calls[0].args[5], "main");
+});
+
+test("createIterWorktree: returns null when gitExec returns null (git missing / branch collision)", () => {
+    const out = createIterWorktree({
+        runId: "r-1",
+        iter: 1,
+        runsRoot: "/runs",
+        cwd: "/repo",
+        env: {},
+        gitExec: () => null,
+        mkdir: () => {},
+    });
+    assert.equal(out, null);
+});
+
+test("createIterWorktree: returns null when gitExec is missing", () => {
+    const out = createIterWorktree({
+        runId: "r-1",
+        iter: 1,
+        runsRoot: "/runs",
+        cwd: "/repo",
+        env: {},
+    });
+    assert.equal(out, null);
+});
+
+test("createIterWorktree: returns null when mkdir throws", () => {
+    const out = createIterWorktree({
+        runId: "r-1",
+        iter: 1,
+        runsRoot: "/runs",
+        cwd: "/repo",
+        env: {},
+        gitExec: () => "",
+        mkdir: () => { throw new Error("EACCES"); },
+    });
+    assert.equal(out, null);
+});
+
+// ───────────── removeIterWorktree ─────────────
+
+test("removeIterWorktree: invokes `git worktree remove --force` then `git branch -D`", () => {
+    const calls = [];
+    const gitExec = (req) => { calls.push(req); return ""; };
+    const ok = removeIterWorktree({
+        path: "/runs/r-1/worktrees/iter-3",
+        branch: "autopilot/r-1/iter-3",
+        cwd: "/repo",
+        env: {},
+        gitExec,
+    });
+    assert.equal(ok, true);
+    assert.equal(calls.length, 2);
+    assert.deepEqual(calls[0].args, ["worktree", "remove", "--force", "/runs/r-1/worktrees/iter-3"]);
+    assert.deepEqual(calls[1].args, ["branch", "-D", "autopilot/r-1/iter-3"]);
+});
+
+test("removeIterWorktree: false when worktree remove fails", () => {
+    const ok = removeIterWorktree({
+        path: "/p",
+        branch: "b",
+        cwd: "/repo",
+        env: {},
+        gitExec: () => null,
+    });
+    assert.equal(ok, false);
+});
+
+test("removeIterWorktree: false when branch delete fails (worktree was removed but branch still around)", () => {
+    let n = 0;
+    const gitExec = () => (++n === 1 ? "" : null);
+    const ok = removeIterWorktree({
+        path: "/p",
+        branch: "b",
+        cwd: "/repo",
+        env: {},
+        gitExec,
+    });
+    assert.equal(ok, false);
+    assert.equal(n, 2, "both calls attempted");
+});
+
+test("removeIterWorktree: skips branch deletion when branch is empty (only removes worktree)", () => {
+    const calls = [];
+    const gitExec = (req) => { calls.push(req); return ""; };
+    const ok = removeIterWorktree({
+        path: "/p",
+        branch: "",
+        cwd: "/repo",
+        env: {},
+        gitExec,
+    });
+    assert.equal(ok, true);
+    assert.equal(calls.length, 1);
+});
+
+// ───────────── verifyMerged ─────────────
+
+test("verifyMerged: returns true when merge-base --is-ancestor exits 0", () => {
+    const calls = [];
+    const gitExec = (req) => {
+        calls.push(req.args.join(" "));
+        return ""; // success on every call
+    };
+    assert.equal(
+        verifyMerged({ branch: "autopilot/r/iter-1", baseRef: "main", cwd: "/repo", env: {}, gitExec }),
+        true,
+    );
+    // First a fetch, then merge-base.
+    assert.equal(calls[0], "fetch --quiet");
+    assert.equal(calls[1], "merge-base --is-ancestor autopilot/r/iter-1 main");
+});
+
+test("verifyMerged: returns false when merge-base returns null", () => {
+    let n = 0;
+    const gitExec = () => (++n === 1 ? "" : null); // fetch ok, merge-base says NO
+    assert.equal(
+        verifyMerged({ branch: "b", baseRef: "main", cwd: "/repo", env: {}, gitExec }),
+        false,
+    );
+});
+
+test("verifyMerged: tolerates fetch failure (offline/auth) and still runs merge-base", () => {
+    let n = 0;
+    const calls = [];
+    const gitExec = (req) => {
+        calls.push(req.args[0]);
+        n += 1;
+        if (n === 1) return null; // fetch fails
+        return "";                 // merge-base succeeds
+    };
+    assert.equal(
+        verifyMerged({ branch: "b", baseRef: "main", cwd: "/repo", env: {}, gitExec }),
+        true,
+    );
+    assert.deepEqual(calls, ["fetch", "merge-base"]);
+});
+
+test("verifyMerged: returns false when gitExec missing or branch empty", () => {
+    assert.equal(verifyMerged({ branch: "b", baseRef: "main", cwd: "/r", env: {} }), false);
+    assert.equal(verifyMerged({ branch: "", baseRef: "main", cwd: "/r", env: {}, gitExec: () => "" }), false);
+});
+
+// ───────────── sweepOrphanWorktrees (D7) ─────────────
+
+test("sweepOrphanWorktrees: removes orphan dirs whose state.json says terminated", () => {
+    const root = tmp();
+    const runId = "ralph-tui-self-improve-1";
+    mkdirSync(join(root, runId, "worktrees", "iter-1"), { recursive: true });
+    writeFileSync(
+        join(root, runId, "state.json"),
+        JSON.stringify({ terminated: true, runId, mode: "self-improve" }),
+    );
+    const calls = [];
+    const gitExec = (req) => { calls.push(req); return ""; };
+    const removed = sweepOrphanWorktrees({
+        runsRoot: root,
+        cwd: "/repo",
+        env: { RALPH_TUI_RUNS_DIR: root },
+        gitExec,
+    });
+    rmSync(root, { recursive: true, force: true });
+    assert.equal(removed, 1);
+    assert.deepEqual(calls[0].args, ["worktree", "remove", "--force", join(root, runId, "worktrees", "iter-1")]);
+});
+
+test("sweepOrphanWorktrees: leaves worktrees of in-flight (non-terminated) runs alone", () => {
+    const root = tmp();
+    const runId = "ralph-tui-self-improve-2";
+    mkdirSync(join(root, runId, "worktrees", "iter-1"), { recursive: true });
+    writeFileSync(
+        join(root, runId, "state.json"),
+        JSON.stringify({ terminated: false, runId, mode: "self-improve" }),
+    );
+    const calls = [];
+    const gitExec = (req) => { calls.push(req); return ""; };
+    const removed = sweepOrphanWorktrees({
+        runsRoot: root,
+        cwd: "/repo",
+        env: { RALPH_TUI_RUNS_DIR: root },
+        gitExec,
+    });
+    rmSync(root, { recursive: true, force: true });
+    assert.equal(removed, 0);
+    assert.equal(calls.length, 0);
+});
+
+test("sweepOrphanWorktrees: returns 0 when runsRoot does not exist", () => {
+    const root = join(tmp(), "nope");
+    const removed = sweepOrphanWorktrees({
+        runsRoot: root,
+        cwd: "/repo",
+        env: {},
+        gitExec: () => "",
+    });
+    assert.equal(removed, 0);
+});
+
+test("sweepOrphanWorktrees: stops when budgetMs exhausted", () => {
+    const root = tmp();
+    for (const r of ["a", "b"]) {
+        mkdirSync(join(root, r, "worktrees", "iter-1"), { recursive: true });
+        writeFileSync(join(root, r, "state.json"),
+            JSON.stringify({ terminated: true, runId: r, mode: "self-improve" }));
+    }
+    let nowMs = 1000;
+    const calls = [];
+    const gitExec = (req) => { calls.push(req); nowMs += 500; return ""; };
+    const removed = sweepOrphanWorktrees({
+        runsRoot: root,
+        cwd: "/repo",
+        env: { RALPH_TUI_RUNS_DIR: root },
+        gitExec,
+        budgetMs: 200,
+        now: () => nowMs,
+    });
+    rmSync(root, { recursive: true, force: true });
+    // First call drains the budget; second run dir gets skipped.
+    assert.equal(removed, 1);
+});
+
+// ───────────── End-to-end: runRalphTui with worktree on ─────────────
+
+test("runRalphTui: COMPLETE iter with worktree=true triggers create + remove + worktree_removed event", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "wt-complete",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    // gitExec stub: handle worktree add, fetch, merge-base, worktree
+    // remove, branch -D. Returns "" (success) for all.
+    const gitCalls = [];
+    const gitExec = ({ args }) => {
+        gitCalls.push(args.join(" "));
+        return "";
+    };
+    const stdout = [
+        JSON.stringify({ type: "assistant.message", timestamp: "2026-01-01T00:00:00.000Z",
+            data: { content: "[STAGE: ORIENT]\n[STAGE: COMMIT]\n[STAGE: PUSH]\n[STAGE: END]\nCOMPLETE" } }),
+        JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+    ].join("\n") + "\n";
+    const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+        gitExec,
+        // worktree default-on for self-improve, but be explicit.
+        worktree: true,
+    });
+    // worktree_created emitted at iter start.
+    const created = events.filter((e) => e.type === "worktree_created");
+    assert.equal(created.length, 1);
+    assert.equal(created[0].iteration, 1);
+    assert.match(created[0].path, /worktrees\/iter-1$/);
+    assert.match(created[0].branch, /autopilot\/.+\/iter-1$/);
+    // worktree_removed (not _kept) — END seen + verifyMerged true.
+    const removed = events.filter((e) => e.type === "worktree_removed");
+    assert.equal(removed.length, 1);
+    assert.equal(events.filter((e) => e.type === "worktree_kept").length, 0);
+    // Subprocess cwd was the worktree path (iter cwd != process.cwd()).
+    // We can check this by ensuring the spawn arg log saw it via the
+    // mock's __args (cwd is opts, not args; check via the post-iter
+    // commit_observed cwd if possible). Since our mock doesn't capture
+    // opts here, assert the worktree_created event's path was non-empty
+    // — that's the same value the runner passed as cwd.
+    assert.ok(created[0].path);
+});
+
+test("runRalphTui: iter without END marker keeps worktree (worktree_kept event with absolute path)", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "wt-keep",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    const gitExec = () => ""; // every git call succeeds
+    // No [STAGE: END] marker — agent emits ABORT_NO_IMPROVEMENTS so
+    // the iter terminates without reaching the canonical end.
+    const stdout = [
+        JSON.stringify({ type: "assistant.message", timestamp: "2026-01-01T00:00:00.000Z",
+            data: { content: "[STAGE: ORIENT]\nABORT_NO_IMPROVEMENTS" } }),
+        JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+    ].join("\n") + "\n";
+    const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+        gitExec,
+        worktree: true,
+    });
+    const created = events.filter((e) => e.type === "worktree_created");
+    const kept = events.filter((e) => e.type === "worktree_kept");
+    const removed = events.filter((e) => e.type === "worktree_removed");
+    assert.equal(created.length, 1, "worktree_created emitted on iter start");
+    assert.equal(removed.length, 0, "no worktree_removed because END not seen");
+    assert.equal(kept.length, 1, "worktree_kept records the preserved sandbox");
+    assert.equal(kept[0].path, created[0].path);
+    assert.equal(kept[0].branch, created[0].branch);
+    // Worktree path is absolute under the runs root.
+    assert.ok(kept[0].path.startsWith("/") || /^[A-Z]:/.test(kept[0].path),
+        "worktree path is absolute");
+});
+
+test("runRalphTui: END seen but verifyMerged false → worktree_kept (changes not merged)", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "wt-not-merged",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    // gitExec: succeed at create + fetch, FAIL at merge-base
+    // (returns null = "not an ancestor"). The runner should treat
+    // the iter as not-merged and emit worktree_kept.
+    const gitExec = ({ args }) => {
+        if (args[0] === "merge-base") return null; // not merged
+        return "";
+    };
+    const stdout = [
+        JSON.stringify({ type: "assistant.message", timestamp: "2026-01-01T00:00:00.000Z",
+            data: { content: "[STAGE: COMMIT]\n[STAGE: PUSH]\n[STAGE: END]\nCOMPLETE" } }),
+        JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+    ].join("\n") + "\n";
+    const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+        gitExec,
+        worktree: true,
+    });
+    assert.equal(events.filter((e) => e.type === "worktree_removed").length, 0);
+    assert.equal(events.filter((e) => e.type === "worktree_kept").length, 1);
+});
+
+test("runRalphTui: worktree=false (explicit opt-out) skips worktree machinery entirely", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "wt-disabled",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    const gitCalls = [];
+    const gitExec = ({ args }) => {
+        gitCalls.push(args.join(" "));
+        return null; // every call returns null so no commit_observed fires
+    };
+    const stdout = [
+        JSON.stringify({ type: "assistant.message", timestamp: "2026-01-01T00:00:00.000Z",
+            data: { content: "[STAGE: END]\nCOMPLETE" } }),
+        JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+    ].join("\n") + "\n";
+    const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+        gitExec,
+        worktree: false,
+    });
+    assert.equal(events.filter((e) => e.type === "worktree_created").length, 0);
+    assert.equal(events.filter((e) => e.type === "worktree_kept").length, 0);
+    assert.equal(events.filter((e) => e.type === "worktree_removed").length, 0);
+    // No worktree-add / fetch / merge-base / worktree-remove calls.
+    assert.equal(gitCalls.filter((c) => c.startsWith("worktree")).length, 0);
+    assert.equal(gitCalls.filter((c) => c.startsWith("merge-base")).length, 0);
+});
+
+test("runRalphTui: --prompt mode defaults worktree=false (opt-in only)", async () => {
+    const events = [];
+    const eventEmitter = {
+        runId: "wt-prompt-default",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    const gitExec = () => null;
+    const stdout = [
+        JSON.stringify({ type: "assistant.message", data: { content: "COMPLETE" } }),
+        JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+    ].join("\n") + "\n";
+    const spawn = makeMockSpawn([{ stdout, exitCode: 0 }]);
+    await runRalphTui({
+        mode: "prompt",
+        prompt: "do thing",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        spawn,
+        eventEmitter,
+        gitExec,
+        // worktree omitted → defaults to false for --prompt mode.
+    });
+    assert.equal(events.filter((e) => e.type === "worktree_created").length, 0);
+});
+
+test("runRalphTui: iter cwd != process.cwd() when worktree mode is on (regression pin)", async () => {
+    // Capture the cwd actually passed to the spawn call.
+    let spawnCwd = null;
+    const spawn = function (_bin, _args, opts) {
+        spawnCwd = opts?.cwd;
+        const handlers = { stdout: [], close: [] };
+        const child = {
+            stdout: { on: (ev, fn) => handlers.stdout.push(fn) },
+            stderr: { on: () => {} },
+            on: (ev, fn) => { if (ev === "close") handlers.close.push(fn); },
+            kill: () => {},
+        };
+        setImmediate(() => {
+            for (const fn of handlers.stdout) {
+                fn(Buffer.from([
+                    JSON.stringify({ type: "assistant.message", data: { content: "[STAGE: END]\nCOMPLETE" } }),
+                    JSON.stringify({ type: "result", success: true, result: { sessionId: "s" } }),
+                ].join("\n") + "\n"));
+            }
+            for (const fn of handlers.close) fn(0);
+        });
+        return child;
+    };
+    const events = [];
+    const eventEmitter = {
+        runId: "wt-cwd-pin",
+        eventsPath: "/dev/null",
+        write: (ev) => events.push(ev),
+        close: () => {},
+    };
+    await runRalphTui({
+        mode: "self-improve",
+        contextMode: "fresh",
+        max: 1,
+        env: makeEnv(),
+        cwd: "/parent/repo",
+        spawn,
+        eventEmitter,
+        gitExec: () => "", // every git call succeeds → worktree created OK
+        worktree: true,
+    });
+    assert.ok(spawnCwd, "spawn cwd captured");
+    assert.notEqual(spawnCwd, "/parent/repo",
+        "iter cwd is the worktree path, NOT the parent repo cwd");
+    assert.match(spawnCwd, /worktrees\/iter-1$/);
+});
+
+// ───────────── End-to-end: real git (skipped when git missing) ─────
+
+const GIT_AVAILABLE = (() => {
+    try {
+        execSync("git --version", { stdio: "ignore", timeout: 2000 });
+        return true;
+    } catch {
+        return false;
+    }
+})();
+
+test("e2e: real git create+remove worktree round-trip in a tmp repo", { skip: !GIT_AVAILABLE }, () => {
+    const repoRoot = tmp();
+    try {
+        execSync("git init -q -b main", { cwd: repoRoot, stdio: "ignore" });
+        execSync("git config user.email t@e", { cwd: repoRoot, stdio: "ignore" });
+        execSync("git config user.name tester", { cwd: repoRoot, stdio: "ignore" });
+        writeFileSync(join(repoRoot, "x"), "hello\n");
+        execSync("git add x", { cwd: repoRoot, stdio: "ignore" });
+        execSync("git commit -q -m initial", { cwd: repoRoot, stdio: "ignore" });
+
+        const runsRoot = tmp();
+        const runId = "real-1";
+        // Use the production gitExec implementation by passing
+        // the runner without injecting a stub.
+        const gitExec = ({ args, cwd, env, timeoutMs }) => {
+            try {
+                return execSync(`git ${args.map((a) => JSON.stringify(a)).join(" ")}`, {
+                    cwd, env, encoding: "utf8", timeout: timeoutMs ?? 5000,
+                    stdio: ["ignore", "pipe", "pipe"],
+                });
+            } catch {
+                return null;
+            }
+        };
+        const created = createIterWorktree({
+            runId, iter: 1, baseRef: "main", runsRoot, cwd: repoRoot, env: process.env, gitExec,
+        });
+        assert.ok(created, "createIterWorktree returned a path");
+        assert.ok(existsSync(created.path), "worktree dir exists on disk");
+        assert.ok(existsSync(join(created.path, "x")), "worktree contains the base ref's files");
+
+        const removed = removeIterWorktree({
+            path: created.path, branch: created.branch, cwd: repoRoot, env: process.env, gitExec,
+        });
+        assert.equal(removed, true);
+        assert.equal(existsSync(created.path), false, "worktree dir is gone after remove");
+
+        rmSync(runsRoot, { recursive: true, force: true });
+    } finally {
+        rmSync(repoRoot, { recursive: true, force: true });
+    }
+});

--- a/packages/tui/test/runner.test.mjs
+++ b/packages/tui/test/runner.test.mjs
@@ -1683,6 +1683,12 @@ test("runRalphTui: failed git commit substage does NOT trigger commit_observed",
         spawn,
         eventEmitter,
         gitExec,
+        // Issue #66 — disable per-iter worktree mode so this test
+        // remains a focused pin on the commit_observed gitExec
+        // count. Worktree mode adds a few extra git invocations
+        // (createIterWorktree, verifyMerged) that would otherwise
+        // make the count assertion brittle.
+        worktree: false,
     });
     assert.equal(events.filter((e) => e.type === "commit_observed").length, 0);
     // Arm-time replay-on-mount calls gitExec once (rev-parse).
@@ -2209,6 +2215,12 @@ test("runRalphTui smoke: full marker stream surfaces stage_plan + task_list + ta
         spawn,
         eventEmitter,
         gitExec,
+        // Issue #66 — disable per-iter worktree mode so the gitCalls
+        // count below stays focused on the commit_observed path.
+        // Worktree mode adds extra git invocations (worktree add /
+        // remove / merge-base / fetch) that would otherwise inflate
+        // the count.
+        worktree: false,
     });
     assert.equal(result.terminationReason, "complete");
 


### PR DESCRIPTION
## Summary

Closes #66. Each iter of `--self-improve` and `--grow-project` now spawns in a fresh `<runsRoot>/<runId>/worktrees/iter-<N>/` git worktree branched from `main`, so:

- A half-finished change from iter N can no longer poison iter N+1's BASELINE/TEST stages.
- An aborted iter no longer dirties the user's working tree.
- The agent's commit is its own ref, cleaning up `commit_observed` semantics.

After `[STAGE: END]`, the runner does `git fetch` + `git merge-base --is-ancestor <iter-branch> <baseRef>` (D1). On true → `git worktree remove --force` + `git branch -D` and emit `worktree_removed`; on false (or any iter that bails before END) → preserve on disk and emit `worktree_kept` with the absolute path so the user can inspect.

### Decisions baked in (D1–D7 from issue body)

- D1: merged = `merge-base --is-ancestor` after `git fetch`.
- D2: `<runsRoot>/<runId>/worktrees/iter-<N>/` so prune covers it.
- D3: `autopilot/<runId>/iter-<N>` branch prefix.
- D4: `main` HEAD at iter start.
- D5: default-on for `--self-improve` / `--grow-project`; `--worktree` opts in for `--prompt`.
- D6: smoke-tested only — `--continue` resumes by sessionId, independent of cwd.
- D7: startup sweep runs `git worktree remove --force` on orphans whose parent run's `state.json` is `terminated`, bounded to 200 ms total.

### What's new on the wire

Three strictly-additive event types (`worktree_created`, `worktree_removed`, `worktree_kept`) round-trip through `events.mjs` serializer + fold and render in `plain.mjs`. Old `events.jsonl` files keep replaying unchanged.

### What's new in the TUI

`LastCommit.mjs` gains a dim `worktree: <path>` row when one is active and a `kept N: <path>` row when prior iters left preserved sandboxes.

### CLI flags

- `--worktree`     opt in for `--prompt` mode.
- `--no-worktree`  opt out (overrides default-on).

## Test plan

- [x] `npm test` from repo root — 483 pass / 68 skipped / 0 fail.
- [x] `npm run check` from repo root — 22 .mjs files syntax-checked.
- [x] `node packages/tui/bin/tui.mjs --help` — exit 0; `--worktree` / `--no-worktree` listed.
- [x] Module-load smoke: `runRalphTui`, `createIterWorktree`, `removeIterWorktree`, `verifyMerged`, `sweepOrphanWorktrees` all export as functions.
- [x] Real-git e2e (`runner-worktree.test.mjs`): creates a worktree in a tmp repo, asserts files copied, removes, asserts gone. Auto-skipped when `git --version` fails.
- [ ] e2e: live `--self-improve` run that observes `worktree_created` / `worktree_removed` cycle in real `events.jsonl` — deferred (needs live Copilot CLI run).

## Files

- `packages/tui/src/runner.mjs` — `createIterWorktree` / `removeIterWorktree` / `verifyMerged` / `sweepOrphanWorktrees` helpers + iter-loop wiring + END-stage cleanup probe.
- `packages/tui/src/events.mjs` — `worktree_created` / `worktree_removed` / `worktree_kept` event types + serializer + fold + new `WORKTREE_EVENT_TYPES` export.
- `packages/tui/src/plain.mjs` — `wt+ ` / `wt- ` / `wtkep` verbs + path/branch/baseRef field rendering.
- `packages/tui/src/components/LastCommit.mjs` — active worktree path + kept-count badge.
- `packages/tui/bin/tui.mjs` — `--worktree` / `--no-worktree` flag.
- `packages/tui/test/runner-worktree.test.mjs` — new (28 tests).
- `packages/tui/test/events.test.mjs` — round-trip + fold cases for the 3 new event types.
- `packages/tui/test/runner.test.mjs` — unaffected pre-existing tests opt out via `worktree: false`.
- `CHANGELOG.md` — `## Unreleased` entry under Features + Internal.