### PR TITLE
test(runner): pin armed→iteration_start skeleton with worktree:false

### DIFF
--- a/packages/tui/test/runner.test.mjs
+++ b/packages/tui/test/runner.test.mjs
@@ -632,6 +632,16 @@ test("runRalphTui: emits armed → iteration_start → iteration_end → termina
         env: makeEnv(),
         spawn,
         eventEmitter,
+        // Issue #66 — disable per-iter worktree mode so this skeleton
+        // pin stays focused on the iteration-lifecycle contract. With
+        // `worktree: true` (the self-improve default) the runner's
+        // default `gitExec` would shell out to real `git worktree add`
+        // and emit a `worktree_created` event before `iteration_start`
+        // — clean-state CI passes, but a contributor with a leftover
+        // branch from a prior run sees the worktree add fail silently
+        // and the skeleton match through luck. Opt out so the test is
+        // env-stable.
+        worktree: false,
     });
     // The skeleton sequence is armed → iteration_start →
     // (any number of usage_update for live tokens / excerpt


### PR DESCRIPTION
## Summary

Fix the failing CI test `runRalphTui: emits armed → iteration_start → iteration_end → terminal sequence` introduced by #100 (per-iter git worktree).

## Root cause

The pin asserts a 5-event skeleton without a `worktree_created` event. With `mode: "self-improve"`, worktree mode defaults ON (issue #66). The test doesn't inject `gitExec`, so the runner falls back to `defaultGitExec` and shells out to real `git worktree add`. On clean-state CI that succeeds and emits a 6th event (`worktree_created`) before `iteration_start`, breaking the `deepEqual`.

Locally on contributor machines it stayed green by accident: a leftover `autopilot/test-run-fixed/iter-1` branch from a prior run makes `git worktree add` exit 255, `createIterWorktree` returns `null`, and the `worktree_created` path silently no-ops.

## Fix

Opt this skeleton pin out of worktree mode (`worktree: false`). The assertion stays focused on the base iteration-lifecycle contract; a separate test can pin the worktree-mode skeleton if needed.

## Test plan

- [x] `npm test` 560/560 pass on a fresh clone (no leftover branches).
- [x] `npm test` 560/560 pass on a polluted local checkout.
- [x] `npm run check` clean.

Refs #100.