### PR TITLE
fix(claude): pass --verbose alongside --output-format=stream-json

### DIFF
--- a/packages/tui/src/agents/claude.mjs
+++ b/packages/tui/src/agents/claude.mjs
@@ -67,7 +67,12 @@ export function resolveBin({ override, env = process.env } = {}) {
  *  prompt) so it's intentionally unused here.
  */
 export function spawnArgs(prompt, { resumeSessionId, sessionName: _sessionName, extraArgs = [] } = {}) {
-    const args = ["-p", prompt, "--dangerously-skip-permissions", "--output-format", "stream-json"];
+    // Claude Code requires `--verbose` whenever `-p` (--print) is paired
+    // with `--output-format stream-json`; without it the CLI exits with
+    // "Error: When using --print, --output-format=stream-json requires
+    // --verbose". The flag is silent at runtime and only affects the
+    // event stream's verbosity envelope.
+    const args = ["-p", prompt, "--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose"];
     if (resumeSessionId) args.push("--resume", resumeSessionId);
     for (const a of extraArgs) args.push(a);
     return { args, env: undefined };

--- a/packages/tui/test/agents.test.mjs
+++ b/packages/tui/test/agents.test.mjs
@@ -170,11 +170,11 @@ test("copilot.resolveBin: legacy deprecation notice fires only once across multi
 
 // ─── Claude adapter ────────────────────────────────────────────────
 
-test("claude.spawnArgs: bare prompt produces canonical --dangerously-skip-permissions / --output-format stream-json argv", () => {
+test("claude.spawnArgs: bare prompt produces canonical --dangerously-skip-permissions / --output-format stream-json / --verbose argv", () => {
     const { args, env } = claude.spawnArgs("Do the thing", {});
     assert.deepEqual(
         args,
-        ["-p", "Do the thing", "--dangerously-skip-permissions", "--output-format", "stream-json"],
+        ["-p", "Do the thing", "--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose"],
     );
     assert.equal(env, undefined);
 });


### PR DESCRIPTION
## Summary

Hotfix to issue #83. Claude Code's CLI requires \`--verbose\` whenever \`--print\` is paired with \`--output-format=stream-json\`; without it the subprocess exits immediately with:

\`\`\`
Error: When using --print, --output-format=stream-json requires --verbose
\`\`\`

This was caught by an actual \`autopilot claude --prompt …\` run in a throwaway repo right after #101 landed.

## Test plan

- Updated the existing spawnArgs drift-pin in \`agents.test.mjs\`.
- Verified live: \`autopilot claude --prompt "Reply COMPLETE." --reset-on=iter --max=1 --headless --no-worktree\` now completes the iter cleanly (banner fires, events stream, abort=max_iterations).

## Discovered during testing

Separately, the installed GitHub Copilot CLI (v0.0.354) no longer accepts \`--output-format json\`. That predates this batch and affects the existing copilot adapter; will file as a follow-up issue.