### PR TITLE
chore(pkg)!: rename root + sub-package to autopilot (refs #49)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "copilot-ralph-extension",
+  "name": "autopilot",
   "version": "0.7.0",
-  "description": "Ralph Wiggum-style autonomous iterative loop for GitHub Copilot CLI, packaged as the autopilot standalone TUI app.",
+  "description": "Autonomous iterative loop for GitHub Copilot CLI, packaged as the autopilot standalone TUI app.",
   "type": "module",
   "private": true,
   "author": "Taras Kloba",
@@ -16,7 +16,6 @@
   "keywords": [
     "github-copilot",
     "copilot-cli",
-    "ralph-wiggum",
     "agent",
     "iterative-loop",
     "autonomous",

--- a/packages/tui/package-lock.json
+++ b/packages/tui/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@copilot-ralph-extension/tui",
+  "name": "@autopilot/tui",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@copilot-ralph-extension/tui",
+      "name": "@autopilot/tui",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,15 +1,13 @@
 {
-  "name": "@copilot-ralph-extension/tui",
+  "name": "@autopilot/tui",
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Terminal UI for visualizing live ralph_loop / self_improve / grow_project runs (issue #22).",
+  "description": "Terminal UI for visualizing live autopilot run / self_improve / grow_project runs (issue #22).",
   "author": "Taras Kloba",
   "keywords": [
     "github-copilot",
     "copilot-cli",
-    "extension",
-    "ralph-wiggum",
     "tui",
     "ink",
     "observability"


### PR DESCRIPTION
## Summary
- Rename root npm package `copilot-ralph-extension` → `autopilot` and the workspace package `@copilot-ralph-extension/tui` → `@autopilot/tui`.
- Drop `ralph-wiggum` (and `extension`) keywords; flip the root description to `Autonomous iterative loop for GitHub Copilot CLI, packaged as the autopilot standalone TUI app.` and replace `ralph_loop` in the TUI description with `autopilot run`.
- Regenerate `packages/tui/package-lock.json` so the lockfile carries the new name (no dep changes — `up to date in 389ms`).

The `bin` entry stays `autopilot`, the `Co-authored-by: copilot-ralph` trailer literal is preserved verbatim wherever it appears, and the upstream Anthropic plugin attribution links remain untouched.

Repository / bugs / homepage URLs already pointed at `kloba/autopilot` — verified, no flips needed.

## Test plan
- [x] `npm install --no-audit --no-fund` — `up to date in 384ms`
- [x] `npm test` — `# pass 560` (0 fails)
- [x] `npm run check` — `Syntax-checked 26 .mjs files.` (header now reads `autopilot@0.7.0`)
- [x] `node packages/tui/bin/tui.mjs --help` — banner reads `autopilot`
- [x] `grep -c 'copilot-ralph-extension\|@copilot-ralph-extension' packages/tui/package-lock.json` → `0`

Refs #49.