### PR TITLE
docs: rebrand AGENTS.md + SECURITY.md to autopilot (refs #49)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — Development Guide for Humans and AI Agents
 
 This file is the authoritative process guide for anyone (human or AI) making
-changes to **copilot-ralph-extension**. It pins the three conventions that
+changes to **autopilot**. It pins the three conventions that
 keep the project releasable without drama: **Semantic Versioning** for the
 public surface, **Keep a Changelog** for `CHANGELOG.md`, and **Conventional
 Commits** for git history. Together they let us cut a release by tagging
@@ -68,7 +68,7 @@ what makes automated changelog generation possible.
 
 Use the package or directory name when it narrows the change:
 `tui`, `tui-run`, `release`, `docs`, `prompt`, or a subcommand name
-(`grow-project`, `self-improve`, `replay`, …). Scope is optional but
+(`run`, `watch`, `replay`, …). Scope is optional but
 encouraged — it lands in changelog grouping.
 
 ### Breaking changes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you believe you've found a security issue in `copilot-ralph-extension` — such as a prompt-injection vector, a path-traversal in the JSONL writer/reader, an unsafe shell construction in a baked prompt, or any other credential / data-exposure risk — please report it **privately** rather than opening a public issue.
+If you believe you've found a security issue in `autopilot` — such as a prompt-injection vector, a path-traversal in the JSONL writer/reader, an unsafe shell construction in a baked prompt, or any other credential / data-exposure risk — please report it **privately** rather than opening a public issue.
 
 Use GitHub's [private vulnerability reporting](https://github.com/kloba/autopilot/security/advisories/new) form to file a confidential security advisory. We'll triage and respond as soon as we can. Public-issue reports for credible vulnerabilities will be redacted on request.
 


### PR DESCRIPTION
## Summary
- Flip `copilot-ralph-extension` -> `autopilot` in the lead paragraph of AGENTS.md (L4) and SECURITY.md (L5).
- Refresh the AGENTS.md Conventional Commits "scopes" example: drop retired in-session subcommand names (`grow-project`, `self-improve`) and replace with autopilot-shipped subcommands (`run`, `watch`, `replay`).
- Intentionally preserved per the coordinator brief:
  - The `Co-authored-by: copilot-ralph <copilot-ralph@users.noreply.github.com>` trailer literal and the trailer-rules section that documents the dual `Copilot` / `copilot-ralph` trailers.
  - The `RALPH_NO_ATTRIBUTION` env-var mention in the changelog per-entry rules — kept as the legacy/fallback-deprecation note that the brief calls out.
- `tui-run` (a Conventional Commit scope, not the retired `ralph-tui` extension) stays — it's used in current commit history.

Refs #49.

## Test plan
- [x] `grep -nE 'copilot-ralph-extension|ralph-tui\b' AGENTS.md SECURITY.md` returns zero hits.
- [x] `npm install --no-audit --no-fund` clean.
- [x] `npm test` — 560 pass, 0 fail (93 skipped, no regressions).
- [x] `npm run check` — syntax-checked 26 .mjs files.
- [x] `mkdocs build --strict` — same 18 pre-existing warnings as `origin/main`; no new link rot introduced by the prose flips (AGENTS.md / SECURITY.md aren't in the docs nav, as the brief notes).