### PR TITLE
test(runner): opt out of worktree mode in iteration-lifecycle skeleton test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@
 ### Internal
 - Startup sweep removes orphan worktrees from prior `terminated` runs (~200 ms budget). (#66)
 
+### Tests
+- `runRalphTui: emits armed → iteration_start → iteration_end →
+  terminal sequence` opts out of per-iter worktree mode
+  (`worktree: false`) so the iteration-lifecycle skeleton assertion
+  is deterministic regardless of the test runtime's git state. The
+  test was env-dependent: passed locally when the iter branch
+  already existed (worktree create silently failed, no extra events)
+  and failed in fresh CI checkouts (worktree create succeeded,
+  injecting `worktree_created` / `worktree_kept` events the strict
+  `deepEqual` rejected). Worktree lifecycle has its own dedicated
+  tests in `events.test.mjs`. (#66)
+
 ### Breaking
 - Issue #51 — Replaced `ralph-tui run --continue` / `--fresh` with
   `--reset-on={workitem|iter|never}` (default `workitem`). The old

--- a/packages/tui/test/runner.test.mjs
+++ b/packages/tui/test/runner.test.mjs
@@ -632,6 +632,17 @@ test("runRalphTui: emits armed → iteration_start → iteration_end → termina
         env: makeEnv(),
         spawn,
         eventEmitter,
+        // Issue #66 — disable per-iter worktree mode so this test
+        // stays focused on the iteration-lifecycle skeleton. Worktree
+        // mode (default-on for self-improve) injects `worktree_created`
+        // before iteration_start and `worktree_kept` / `worktree_removed`
+        // before `complete`, both of which depend on the test's cwd
+        // being a writable git repo (succeeds on fresh CI checkout,
+        // fails locally if the test branch already exists from a
+        // prior run). The worktree lifecycle has its own dedicated
+        // tests in events.test.mjs / runner.test.mjs; here we only
+        // pin the iteration-lifecycle contract.
+        worktree: false,
     });
     // The skeleton sequence is armed → iteration_start →
     // (any number of usage_update for live tokens / excerpt


### PR DESCRIPTION
Heals red CI on `main` after #100 (`feat(runner): per-iter git worktree; tear down at END iff merged`) shipped without updating the iteration-lifecycle skeleton assertion.

## Root cause

`runRalphTui: emits armed → iteration_start → iteration_end → terminal sequence` (test 487) was environment-dependent:

- **Locally** it passed because the synthetic iter branch (`autopilot/test-run-fixed/iter-1`) had been left over from a previous test run. `createIterWorktree` then ran `git worktree add -b <existing-branch>`, which silently failed → `null` → no `worktree_created` event → assertion happy.
- **In CI** the fresh checkout has no leftover branch, so the worktree creation succeeded → `worktree_created` fired before `iteration_start` and `worktree_kept` fired before `complete`, both rejected by the strict `deepEqual`.

## Fix

Pass `worktree: false` to disable per-iter worktree mode for this specific test. Mirrors the same opt-out at lines 1692 and 2230 of `runner.test.mjs`. The test's stated intent is the iteration-lifecycle skeleton; worktree lifecycle has dedicated round-trip + behaviour tests in `events.test.mjs` and other runner tests.

## Side benefit

The test no longer creates a real on-disk worktree + branch as a test side effect. Previously every CI run leaked `autopilot/test-run-fixed/iter-1` (verifyMerged → false → removeIterWorktree skipped → branch persists).

## Test plan

- [x] `npm test` 559/559 pass on three consecutive local runs (no flakes).
- [x] `npm run check` clean.
- [ ] CI green on Node 20 + Node 22 once this lands.