### PR TITLE
feat(tui)!: prefer AUTOPILOT_* env vars + ~/.copilot/autopilot/runs default with legacy fallback (closes #49)

### DIFF
--- a/packages/tui/bin/tui.mjs
+++ b/packages/tui/bin/tui.mjs
@@ -152,18 +152,19 @@ YOLO BY DEFAULT (issue #83)
   not really an autopilot.
 
 ENV
-  RALPH_TUI_RUNS_DIR  Override the runs root (default
-                    ~/.copilot/ralph-tui/runs). Holds events.jsonl,
-                    index.jsonl, and per-run state.json.
+  AUTOPILOT_RUNS_DIR  Override the runs root (default
+                    ~/.copilot/autopilot/runs). Holds events.jsonl,
+                    index.jsonl, and per-run state.json. On first run,
+                    if the new default does not exist but
+                    ~/.copilot/ralph-tui/runs does, autopilot reads
+                    from the legacy path (with a one-shot stderr
+                    migration notice).
   AUTOPILOT_COPILOT_BIN  Override the \`copilot\` executable used by
                     \`autopilot copilot\` / \`autopilot run\` (default
-                    \`copilot\` on $PATH). Replaces the legacy
-                    RALPH_TUI_COPILOT_BIN — the old name still works
-                    for one release with a deprecation notice.
+                    \`copilot\` on $PATH).
   AUTOPILOT_CLAUDE_BIN   Override the \`claude\` executable used by
                     \`autopilot claude\` (default \`claude\` on $PATH).
-  RALPH_TUI_COPILOT_BIN  Deprecated alias for AUTOPILOT_COPILOT_BIN.
-                    Read with a one-shot stderr deprecation notice.
+  Legacy RALPH_TUI_* names are still read for one release with a one-line stderr deprecation notice.
 `;
 
 /** Minimal argv parser. Returns { cmd, positional[], flags{} }.
@@ -538,7 +539,7 @@ export function cmdDoctor() {
     if (!healthy) {
         process.stderr.write(
             `autopilot doctor: critical problem detected (root=${root}). `
-            + `Check filesystem permissions and RALPH_TUI_RUNS_DIR.\n`,
+            + `Check filesystem permissions and AUTOPILOT_RUNS_DIR.\n`,
         );
         return 1;
     }

--- a/packages/tui/src/events-emit.mjs
+++ b/packages/tui/src/events-emit.mjs
@@ -5,9 +5,14 @@
 // is full, the path is unwritable, or the user nuked the runs root
 // mid-run. The TUI only consumes whatever lines do land on disk.
 
-import { homedir } from "node:os";
 import { mkdirSync, appendFileSync } from "node:fs";
 import { join } from "node:path";
+
+import {
+    resolveRunsRoot as sharedResolveRunsRoot,
+    touchMigrationSentinel,
+    __resetLegacyWarnGuards as sharedResetGuards,
+} from "./runs-root.mjs";
 
 // Hard cap on a single serialized event line. Excerpts/tokens are
 // truncated to fit so a runaway prompt can't blow up the JSONL file.
@@ -25,29 +30,19 @@ const MAX_EVENT_LINE_BYTES = 16 * 1024;
 // and asserts they agree.
 const MAX_EXCERPT_CHARS = 500;
 
-/** Resolve the runs root, honoring $RALPH_TUI_RUNS_DIR.
- *
- * The env-var path is `.trim()`-ed before being returned: shells routinely
- * leak trailing whitespace into env vars (heredoc redirects, copy-pasted
- * lines, `RALPH_TUI_RUNS_DIR="$HOME/runs "` from a Makefile), and a path
- * with stray leading/trailing spaces would silently create a runs root
- * with literal spaces in its name — surprising the user and breaking the
- * matching `ralph-tui list` glob. Trimming makes the override robust to
- * that common-shell-papercut without affecting any legitimate use case
- * (paths with intentional surrounding whitespace are essentially never
- * real).
- *
- * Mirrors `resolveStateRoot` in `./runner.mjs` so events.jsonl,
- * index.jsonl and state.json for a single run land in the same per-run
- * directory.
+/** Resolve the runs root. Thin wrapper over the shared resolver in
+ *  `./runs-root.mjs`; preserves this module's `(env, deps)` signature
+ *  so existing callers (and the test suite) don't churn. See
+ *  `runs-root.mjs::resolveRunsRoot` for the precedence + legacy
+ *  fallback contract.
  */
-export function resolveRunsRoot(env = process.env) {
-    const override = env?.RALPH_TUI_RUNS_DIR;
-    if (override && typeof override === "string" && override.trim()) {
-        return override.trim();
-    }
-    return join(homedir(), ".copilot", "ralph-tui", "runs");
+export function resolveRunsRoot(env = process.env, deps = {}) {
+    return sharedResolveRunsRoot(env, deps);
 }
+
+/** Re-export so tests can reset the shared one-shot dedup guards
+ *  between cases that exercise the legacy-fallback paths. */
+export const __resetLegacyWarnGuards = sharedResetGuards;
 
 /** `${label}-${startedAt}` — stable, sortable, file-system safe.
  *
@@ -121,7 +116,8 @@ function serialize(ev) {
 export function createEventEmitter({ label, startedAt, env, fs } = {}) {
     const _mkdir = fs?.mkdirSync ?? mkdirSync;
     const _append = fs?.appendFileSync ?? appendFileSync;
-    const root = resolveRunsRoot(env ?? process.env);
+    const _env = env ?? process.env;
+    const root = sharedResolveRunsRoot(_env, { fs });
     const runId = makeRunId(label, startedAt);
     const dir = join(root, runId);
     const eventsPath = join(dir, "events.jsonl");
@@ -130,7 +126,11 @@ export function createEventEmitter({ label, startedAt, env, fs } = {}) {
     let dirReady = false;
     const ensureDir = () => {
         if (dirReady) return;
-        try { _mkdir(dir, { recursive: true }); dirReady = true; } catch { /* swallow */ }
+        try {
+            _mkdir(dir, { recursive: true });
+            dirReady = true;
+            touchMigrationSentinel(_env, { fs });
+        } catch { /* swallow */ }
     };
 
     const write = (ev) => {

--- a/packages/tui/src/runner.mjs
+++ b/packages/tui/src/runner.mjs
@@ -34,7 +34,6 @@
 // it to finish naturally before honoring pause/stop.
 
 import { spawn as nodeSpawn, spawnSync as nodeSpawnSync } from "node:child_process";
-import { homedir } from "node:os";
 import { mkdirSync, readFileSync, writeFileSync, renameSync, existsSync, rmSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -55,6 +54,11 @@ import {
     WORKITEM_KINDS,
     TASK_OUTCOMES,
 } from "./events.mjs";
+import {
+    resolveRunsRoot as sharedResolveRunsRoot,
+    touchMigrationSentinel,
+    __resetLegacyWarnGuards as sharedResetGuards,
+} from "./runs-root.mjs";
 // Issue #83 — backend adapter abstraction. The runner is agent-
 // agnostic; it asks the chosen adapter to build the spawn argv and
 // resolve the binary, then parses the JSONL stream the same way
@@ -96,13 +100,56 @@ const MAX_LOCK_RETRIES = 200; // 5s worst-case
 
 // ─── State-file CAS ────────────────────────────────────────────────
 
-/** Resolve the state-files root, honoring $RALPH_TUI_RUNS_DIR. */
-export function resolveStateRoot(env = process.env) {
-    const override = env?.RALPH_TUI_RUNS_DIR;
-    if (override && typeof override === "string" && override.trim()) {
-        return override.trim();
+/** Resolve the state-files root. Thin wrapper over the shared
+ *  resolver in `./runs-root.mjs`; preserves this module's
+ *  `(env, deps)` signature so existing callers don't churn. See
+ *  `runs-root.mjs::resolveRunsRoot` for the precedence + legacy
+ *  fallback contract.
+ */
+export function resolveStateRoot(env = process.env, deps = {}) {
+    return sharedResolveRunsRoot(env, deps);
+}
+
+// One-shot guard for the legacy $RALPH_TUI_COPILOT_BIN deprecation
+// notice in the inline-fallback bin resolver below. Distinct from the
+// runs-root guards (which live in `./runs-root.mjs`) because COPILOT_BIN
+// is a separate concern that resets independently from run-root state.
+let warnedLegacyCopilotBin = false;
+
+/** Test seam — reset all one-shot deprecation/migration guards: both
+ *  the shared run-root guards in `./runs-root.mjs` AND this module's
+ *  COPILOT_BIN guard. Tests that toggle the legacy paths call this
+ *  before each case so ordering doesn't bleed state. */
+export function __resetLegacyWarnGuards() {
+    sharedResetGuards();
+    warnedLegacyCopilotBin = false;
+}
+
+/** Inline-fallback bin resolver when an injected `agent` adapter
+ *  doesn't expose `resolveBin`. Honors the same precedence + legacy
+ *  fallback contract as `agents/copilot.mjs::resolveBin`:
+ *    1. caller-supplied override (`copilotBin`)
+ *    2. $AUTOPILOT_COPILOT_BIN (preferred)
+ *    3. $RALPH_TUI_COPILOT_BIN (legacy; one-shot stderr deprecation)
+ *    4. agent.defaultBin (or the literal "copilot")
+ */
+function resolveCopilotBinLegacy({ copilotBin, agent, env, stderr = process.stderr }) {
+    if (copilotBin) return copilotBin;
+    if (env?.AUTOPILOT_COPILOT_BIN) return env.AUTOPILOT_COPILOT_BIN;
+    const legacy = env?.RALPH_TUI_COPILOT_BIN;
+    if (legacy) {
+        if (!warnedLegacyCopilotBin) {
+            warnedLegacyCopilotBin = true;
+            try {
+                stderr.write?.(
+                    "[autopilot] note: $RALPH_TUI_COPILOT_BIN is deprecated; "
+                    + "prefer $AUTOPILOT_COPILOT_BIN (still honored)\n",
+                );
+            } catch { /* swallow */ }
+        }
+        return legacy;
     }
-    return join(homedir(), ".copilot", "ralph-tui", "runs");
+    return agent?.defaultBin ?? "copilot";
 }
 
 /** Path to a run's state.json. */
@@ -178,6 +225,7 @@ function initState(runId, initial, env = process.env) {
     const statePath = resolveStatePath(runId, env);
     const dir = join(resolveStateRoot(env), runId);
     mkdirSync(dir, { recursive: true });
+    touchMigrationSentinel(env);
     const lockPath = acquireLock(statePath);
     try {
         const seed = { version: 1, ...initial };
@@ -646,7 +694,9 @@ export function worktreeBranchFor({ runId, iter }) {
  *  @param {string} opts.runId
  *  @param {number} opts.iter        1-indexed.
  *  @param {string} opts.baseRef     ref to fork from (default "main").
- *  @param {string} opts.runsRoot    `$RALPH_TUI_RUNS_DIR` value.
+ *  @param {string} opts.runsRoot    `$AUTOPILOT_RUNS_DIR` value (or
+ *                                   the legacy `$RALPH_TUI_RUNS_DIR`
+ *                                   read-fallback when unset).
  *  @param {string} opts.cwd         parent repo path (the user's
  *                                   working tree).
  *  @param {object} [opts.env]
@@ -1219,7 +1269,7 @@ export function runOneIteration({
 }) {
     const bin = (agent.resolveBin
         ? agent.resolveBin({ override: copilotBin, env })
-        : (copilotBin ?? env[agent.binEnvVar] ?? agent.defaultBin));
+        : resolveCopilotBinLegacy({ copilotBin, agent, env }));
     const { args: agentArgs, env: agentEnv } = agent.spawnArgs(prompt, {
         resumeSessionId,
         sessionName,

--- a/packages/tui/src/runs-root.mjs
+++ b/packages/tui/src/runs-root.mjs
@@ -1,0 +1,120 @@
+// Shared resolver for the on-disk runs root. Three call sites
+// (`writer.mjs::resolveRunsRoot`, `events-emit.mjs::resolveRunsRoot`,
+// `runner.mjs::resolveStateRoot`) all need the same precedence +
+// legacy-fallback contract; centralising the logic here means a future
+// hardening pass (a fourth env-var name, a different sentinel path,
+// etc.) lands in one place instead of three.
+//
+// Stdlib-only. All filesystem / clock dependencies are injected so
+// tests can pin behaviour against tmp dirs and fake stderrs.
+
+import { homedir as defaultHomedir } from "node:os";
+import {
+    existsSync as defaultExistsSync,
+    mkdirSync as defaultMkdirSync,
+    writeFileSync as defaultWriteFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+const LEGACY_ENV_NOTICE =
+    "[autopilot] note: $RALPH_TUI_RUNS_DIR is deprecated; "
+    + "prefer $AUTOPILOT_RUNS_DIR (still honored)\n";
+
+const LEGACY_PATH_NOTICE =
+    "[autopilot] note: reading runs from legacy "
+    + "~/.copilot/ralph-tui/runs (default is now "
+    + "~/.copilot/autopilot/runs)\n";
+
+const SENTINEL_NAME = ".migrated-from-ralph-tui";
+
+// Module-level dedup flags (one-shot per process). Resets via
+// `__resetLegacyWarnGuards` for tests that exercise the side-effecting
+// branches and need a clean baseline.
+let warnedLegacyEnvVar = false;
+let warnedLegacyPath = false;
+
+export function __resetLegacyWarnGuards() {
+    warnedLegacyEnvVar = false;
+    warnedLegacyPath = false;
+}
+
+function safeWrite(stderr, msg) {
+    try { stderr.write?.(msg); } catch { /* swallow — never crash the loop */ }
+}
+
+/** Resolve the runs root.
+ *
+ * Precedence:
+ *   1. $AUTOPILOT_RUNS_DIR (preferred).
+ *   2. $RALPH_TUI_RUNS_DIR (legacy; one-shot stderr deprecation notice).
+ *   3. `${HOME}/.copilot/autopilot/runs`, with a one-shot stderr
+ *      migration notice + read-fallback to `${HOME}/.copilot/ralph-tui/runs`
+ *      when the new default doesn't yet exist but the legacy one does.
+ *
+ * Env-var values are `.trim()`-ed: shells routinely leak surrounding
+ * whitespace into env vars (heredocs, Makefile interpolation,
+ * copy-paste) and a path with stray spaces creates a runs root with
+ * literal spaces in its name, breaking the matching `autopilot list`
+ * glob.
+ */
+export function resolveRunsRoot(env = process.env, deps = {}) {
+    const existsSync = deps.fs?.existsSync ?? defaultExistsSync;
+    const stderr = deps.stderr ?? process.stderr;
+    const homedir = deps.os?.homedir ?? defaultHomedir;
+
+    const primary = env?.AUTOPILOT_RUNS_DIR;
+    if (typeof primary === "string" && primary.trim()) return primary.trim();
+
+    const legacy = env?.RALPH_TUI_RUNS_DIR;
+    if (typeof legacy === "string" && legacy.trim()) {
+        if (!warnedLegacyEnvVar) {
+            warnedLegacyEnvVar = true;
+            safeWrite(stderr, LEGACY_ENV_NOTICE);
+        }
+        return legacy.trim();
+    }
+
+    const home = homedir();
+    const newDefault = join(home, ".copilot", "autopilot", "runs");
+    const legacyDefault = join(home, ".copilot", "ralph-tui", "runs");
+
+    let newExists = false;
+    try { newExists = existsSync(newDefault); } catch { /* swallow */ }
+    if (newExists) return newDefault;
+
+    let legacyExists = false;
+    try { legacyExists = existsSync(legacyDefault); } catch { /* swallow */ }
+    if (legacyExists) {
+        if (!warnedLegacyPath) {
+            warnedLegacyPath = true;
+            safeWrite(stderr, LEGACY_PATH_NOTICE);
+        }
+        return legacyDefault;
+    }
+    return newDefault;
+}
+
+/** Best-effort touch of `<NEW_DEFAULT_ROOT>/.migrated-from-ralph-tui`
+ *  after a successful new-root mkdir, so subsequent process invocations
+ *  no longer print the legacy-path migration notice. Skipped when the
+ *  user has overridden the runs root via either env var: the migration
+ *  story only applies to the unconfigured default. Failures are
+ *  swallowed; the worst case is one re-printed notice on the next
+ *  invocation.
+ */
+export function touchMigrationSentinel(env = process.env, deps = {}) {
+    if (!env) return;
+    if ((typeof env.AUTOPILOT_RUNS_DIR === "string" && env.AUTOPILOT_RUNS_DIR.length > 0)
+        || (typeof env.RALPH_TUI_RUNS_DIR === "string" && env.RALPH_TUI_RUNS_DIR.length > 0)) {
+        return;
+    }
+    const mkdir = deps.fs?.mkdirSync ?? defaultMkdirSync;
+    const writeFile = deps.fs?.writeFileSync ?? defaultWriteFileSync;
+    const homedir = deps.os?.homedir ?? defaultHomedir;
+    const newDefault = join(homedir(), ".copilot", "autopilot", "runs");
+    const sentinel = join(newDefault, SENTINEL_NAME);
+    try {
+        mkdir(newDefault, { recursive: true });
+        writeFile(sentinel, "");
+    } catch { /* swallow */ }
+}

--- a/packages/tui/src/writer.mjs
+++ b/packages/tui/src/writer.mjs
@@ -23,22 +23,27 @@ import pathDefault from "node:path";
 import osDefault from "node:os";
 
 import { MAX_EVENT_LINE_BYTES, makeRunId, serializeEvent } from "./events.mjs";
+import {
+    resolveRunsRoot as sharedResolveRunsRoot,
+    touchMigrationSentinel as sharedTouchSentinel,
+    __resetLegacyWarnGuards,
+} from "./runs-root.mjs";
 
 /**
- * Resolve the on-disk root for ralph TUI run metadata.
- *
- *   $RALPH_TUI_RUNS_DIR if set (absolute path expected; surfaced
- *   verbatim so users can pin a tmp dir in CI).
- *   else `${HOME}/.copilot/ralph-tui/runs`.
- *
- * Shared with `resolveRunsRoot` in `./events-emit.mjs` and
- * `resolveStateRoot` in `./runner.mjs` so events.jsonl, index.jsonl
- * and state.json all land under the same per-run directory.
+ * Resolve the on-disk root for autopilot run metadata. Thin adapter
+ * over the shared resolver in `./runs-root.mjs` that preserves this
+ * module's existing single-options-bag signature so internal callers
+ * (which thread `path`/`os`/`fs` through together) keep working
+ * without churn. See `runs-root.mjs::resolveRunsRoot` for the
+ * precedence + legacy fallback contract.
  */
-export function resolveRunsRoot({ env = process.env, os = osDefault, path = pathDefault } = {}) {
-    const override = env.RALPH_TUI_RUNS_DIR;
-    if (typeof override === "string" && override.length > 0) return override;
-    return path.join(os.homedir(), ".copilot", "ralph-tui", "runs");
+export function resolveRunsRoot({
+    env = process.env,
+    os = osDefault,
+    fs = fsDefault,
+    stderr = process.stderr,
+} = {}) {
+    return sharedResolveRunsRoot(env, { fs, os, stderr });
 }
 
 /**
@@ -176,7 +181,7 @@ export function createEventWriter({
     // keeps the read + write + delete paths in lockstep.
     assertSafeRunId("createEventWriter", runId);
 
-    const root = resolveRunsRoot({ env, os, path });
+    const root = resolveRunsRoot({ env, os, path, fs });
     const runDir = path.join(root, runId);
     const eventsPath = path.join(runDir, "events.jsonl");
     const indexPath = path.join(root, "index.jsonl");
@@ -189,6 +194,7 @@ export function createEventWriter({
     // emit will fail — better to know now.
     try {
         fs.mkdirSync(runDir, { recursive: true });
+        sharedTouchSentinel(env, { fs, os });
     } catch (err) {
         onError(err);
     }
@@ -300,7 +306,11 @@ export { makeRunId };
 // declaration above) so consumers cannot couple to it; the
 // `__test__` bag is the project-wide convention for "tests can
 // reach in but library users should not".
-export const __test__ = { iterJsonlRows };
+export const __test__ = { iterJsonlRows, __resetLegacyWarnGuards };
+
+// Re-export so tests / downstream modules can drop the migration
+// sentinel without depending on ./runs-root.mjs directly.
+export { touchMigrationSentinel } from "./runs-root.mjs";
 
 /**
  * Aggregate stats across all recorded runs. Returns:

--- a/packages/tui/test/bin.test.mjs
+++ b/packages/tui/test/bin.test.mjs
@@ -366,21 +366,43 @@ test("bin list (no --limit): all runs preserved", () => {
 });
 
 test("bin where: prints default runs root", () => {
-    const r = runBin(["where"], { RALPH_TUI_RUNS_DIR: "" });  // empty -> default
+    // Override HOME to a clean tmp dir so the legacy-path read-fallback
+    // (which kicks in when ~/.copilot/ralph-tui/runs exists but
+    // ~/.copilot/autopilot/runs doesn't) cannot fire from real on-disk
+    // state on the developer's machine.
+    const fakeHome = tmp();
+    const r = runBin(
+        ["where"],
+        {
+            AUTOPILOT_RUNS_DIR: "",
+            RALPH_TUI_RUNS_DIR: "",
+            HOME: fakeHome,
+        },
+    );
     assert.equal(r.status, 0);
-    assert.match(r.stdout, /\.copilot\/ralph-tui\/runs\n$/);
+    assert.match(r.stdout, /\.copilot\/autopilot\/runs\n$/);
+    rmSync(fakeHome, { recursive: true, force: true });
 });
 
-test("bin where: honours RALPH_TUI_RUNS_DIR override", () => {
+test("bin where: honours AUTOPILOT_RUNS_DIR override", () => {
     const dir = tmp();
-    const r = runBin(["where"], { RALPH_TUI_RUNS_DIR: dir });
+    const r = runBin(["where"], { AUTOPILOT_RUNS_DIR: dir });
     assert.equal(r.status, 0);
     assert.equal(r.stdout, dir + "\n");
     rmSync(dir, { recursive: true, force: true });
 });
 
+test("bin where: honours legacy RALPH_TUI_RUNS_DIR override (with deprecation notice)", () => {
+    const dir = tmp();
+    const r = runBin(["where"], { AUTOPILOT_RUNS_DIR: "", RALPH_TUI_RUNS_DIR: dir });
+    assert.equal(r.status, 0);
+    assert.equal(r.stdout, dir + "\n");
+    assert.match(r.stderr, /RALPH_TUI_RUNS_DIR is deprecated/);
+    rmSync(dir, { recursive: true, force: true });
+});
+
 test("bin where: works even when directory does not exist", () => {
-    const r = runBin(["where"], { RALPH_TUI_RUNS_DIR: "/tmp/ralph-tui-does-not-exist-zz" });
+    const r = runBin(["where"], { AUTOPILOT_RUNS_DIR: "/tmp/ralph-tui-does-not-exist-zz" });
     assert.equal(r.status, 0);
     assert.equal(r.stdout, "/tmp/ralph-tui-does-not-exist-zz\n");
 });
@@ -1083,10 +1105,10 @@ test("USAGE: documents AUTOPILOT_COPILOT_BIN and AUTOPILOT_CLAUDE_BIN env vars",
     assert.match(r.stdout, /AUTOPILOT_CLAUDE_BIN/);
 });
 
-test("USAGE: documents the legacy RALPH_TUI_COPILOT_BIN deprecation", () => {
+test("USAGE: documents the legacy RALPH_TUI_* deprecation", () => {
     const r = runBin(["--help"]);
     assert.equal(r.status, 0);
-    assert.match(r.stdout, /RALPH_TUI_COPILOT_BIN/);
+    assert.match(r.stdout, /RALPH_TUI_\*/);
     assert.match(r.stdout, /[Dd]eprecat/);
 });
 

--- a/packages/tui/test/events-emit.test.mjs
+++ b/packages/tui/test/events-emit.test.mjs
@@ -12,25 +12,106 @@ import {
     resolveRunsRoot,
     makeRunId,
     createEventEmitter,
+    __resetLegacyWarnGuards,
 } from "../src/events-emit.mjs";
 
-test("resolveRunsRoot: defaults to $HOME/.copilot/ralph-tui/runs", () => {
-    assert.equal(resolveRunsRoot({}), join(homedir(), ".copilot", "ralph-tui", "runs"));
+// Each resolveRunsRoot test that flips a one-shot deprecation/migration
+// notice resets the module-level dedup flags so case ordering doesn't
+// bleed state. Tests that don't touch the legacy paths still default to
+// the new $HOME/.copilot/autopilot/runs root and need a stub `existsSync`
+// returning false so the legacy-path read-fallback never fires from
+// real on-disk state on the developer's machine.
+const noFs = { existsSync: () => false };
+
+test("resolveRunsRoot: defaults to $HOME/.copilot/autopilot/runs", () => {
+    __resetLegacyWarnGuards();
+    assert.equal(
+        resolveRunsRoot({}, { fs: noFs }),
+        join(homedir(), ".copilot", "autopilot", "runs"),
+    );
 });
 
-test("resolveRunsRoot: honours RALPH_TUI_RUNS_DIR override", () => {
-    assert.equal(resolveRunsRoot({ RALPH_TUI_RUNS_DIR: "/tmp/ralph" }), "/tmp/ralph");
+test("resolveRunsRoot: honours AUTOPILOT_RUNS_DIR override", () => {
+    __resetLegacyWarnGuards();
+    assert.equal(
+        resolveRunsRoot({ AUTOPILOT_RUNS_DIR: "/tmp/autopilot" }, { fs: noFs }),
+        "/tmp/autopilot",
+    );
+});
+
+test("resolveRunsRoot: legacy RALPH_TUI_RUNS_DIR fallback emits one-shot deprecation notice", () => {
+    __resetLegacyWarnGuards();
+    const writes = [];
+    const stderr = { write: (s) => writes.push(s) };
+    assert.equal(
+        resolveRunsRoot({ RALPH_TUI_RUNS_DIR: "/tmp/ralph" }, { fs: noFs, stderr }),
+        "/tmp/ralph",
+    );
+    // Second call: same legacy env → no second notice (per-process dedup).
+    assert.equal(
+        resolveRunsRoot({ RALPH_TUI_RUNS_DIR: "/tmp/ralph" }, { fs: noFs, stderr }),
+        "/tmp/ralph",
+    );
+    assert.equal(writes.length, 1);
+    assert.match(writes[0], /RALPH_TUI_RUNS_DIR is deprecated/);
+    assert.match(writes[0], /AUTOPILOT_RUNS_DIR/);
+});
+
+test("resolveRunsRoot: AUTOPILOT_RUNS_DIR wins over RALPH_TUI_RUNS_DIR with no notice", () => {
+    __resetLegacyWarnGuards();
+    const writes = [];
+    const stderr = { write: (s) => writes.push(s) };
+    assert.equal(
+        resolveRunsRoot(
+            { AUTOPILOT_RUNS_DIR: "/tmp/new", RALPH_TUI_RUNS_DIR: "/tmp/legacy" },
+            { fs: noFs, stderr },
+        ),
+        "/tmp/new",
+    );
+    assert.equal(writes.length, 0);
+});
+
+test("resolveRunsRoot: legacy-path read fallback when new default missing + legacy default present", () => {
+    __resetLegacyWarnGuards();
+    const writes = [];
+    const stderr = { write: (s) => writes.push(s) };
+    const legacyDefault = join(homedir(), ".copilot", "ralph-tui", "runs");
+    const fakeFs = {
+        existsSync: (p) => p === legacyDefault,
+    };
+    const root = resolveRunsRoot({}, { fs: fakeFs, stderr });
+    assert.equal(root, legacyDefault);
+    // Second call within the same process: dedup keeps stderr quiet.
+    const root2 = resolveRunsRoot({}, { fs: fakeFs, stderr });
+    assert.equal(root2, legacyDefault);
+    assert.equal(writes.length, 1);
+    assert.match(writes[0], /reading runs from legacy/);
+    assert.match(writes[0], /~\/\.copilot\/autopilot\/runs/);
+});
+
+test("resolveRunsRoot: when new default exists, returns new default with no legacy notice", () => {
+    __resetLegacyWarnGuards();
+    const writes = [];
+    const stderr = { write: (s) => writes.push(s) };
+    // Both directories "exist"; new default wins (sentinel semantics:
+    // once the new root is created, the legacy notice never reprints).
+    const fakeFs = { existsSync: () => true };
+    const newDefault = join(homedir(), ".copilot", "autopilot", "runs");
+    assert.equal(resolveRunsRoot({}, { fs: fakeFs, stderr }), newDefault);
+    assert.equal(writes.length, 0);
 });
 
 test("resolveRunsRoot: ignores empty / whitespace override and falls back to default", () => {
-    const def = join(homedir(), ".copilot", "ralph-tui", "runs");
-    assert.equal(resolveRunsRoot({ RALPH_TUI_RUNS_DIR: "" }), def);
-    assert.equal(resolveRunsRoot({ RALPH_TUI_RUNS_DIR: "   " }), def);
+    __resetLegacyWarnGuards();
+    const def = join(homedir(), ".copilot", "autopilot", "runs");
+    assert.equal(resolveRunsRoot({ AUTOPILOT_RUNS_DIR: "" }, { fs: noFs }), def);
+    assert.equal(resolveRunsRoot({ AUTOPILOT_RUNS_DIR: "   " }, { fs: noFs }), def);
 });
 
 test("resolveRunsRoot: tolerates missing env arg", () => {
+    __resetLegacyWarnGuards();
     // Should not throw even when env is undefined; falls back to homedir-based default.
-    assert.match(resolveRunsRoot(undefined), /\.copilot[/\\]ralph-tui[/\\]runs$/);
+    assert.match(resolveRunsRoot(undefined, { fs: noFs }), /\.copilot[/\\]autopilot[/\\]runs$/);
 });
 
 test("makeRunId: composes ${label}-${startedAt}", () => {
@@ -77,7 +158,7 @@ test("createEventEmitter: write appends one JSONL line per call", () => {
     const e = createEventEmitter({
         label: "ralph_loop",
         startedAt: 1234,
-        env: { RALPH_TUI_RUNS_DIR: "/tmp/r" },
+        env: { AUTOPILOT_RUNS_DIR: "/tmp/r" },
         fs: fakeFs,
     });
     e.write({ type: "iteration_start", runId: e.runId, ts: 1, iteration: 1 });
@@ -95,7 +176,7 @@ test("createEventEmitter: armed event also writes a line to the run index", () =
     const e = createEventEmitter({
         label: "self_improve",
         startedAt: 99,
-        env: { RALPH_TUI_RUNS_DIR: "/tmp/r" },
+        env: { AUTOPILOT_RUNS_DIR: "/tmp/r" },
         fs: fakeFs,
     });
     e.write({ type: "armed", runId: e.runId, ts: 0, maxIterations: 100, minIterations: 5 });
@@ -132,10 +213,10 @@ test("createEventEmitter: index entry round-trips through TUI's readRunIndex", a
         const e = createEventEmitter({
             label: "ralph_loop",
             startedAt: 12345,
-            env: { RALPH_TUI_RUNS_DIR: root },
+            env: { AUTOPILOT_RUNS_DIR: root },
         });
         e.write({ type: "armed", runId: e.runId, ts: 0, maxIterations: 7, minIterations: 1 });
-        const entries = readRunIndex({ env: { RALPH_TUI_RUNS_DIR: root } });
+        const entries = readRunIndex({ env: { AUTOPILOT_RUNS_DIR: root } });
         assert.equal(entries.length, 1, "TUI's readRunIndex must surface the runner-emitted run");
         assert.equal(entries[0].runId, "ralph_loop-12345");
         assert.equal(entries[0].label, "ralph_loop");
@@ -154,7 +235,7 @@ test("createEventEmitter: non-armed events do NOT touch the index", () => {
     const e = createEventEmitter({
         label: "ralph_loop",
         startedAt: 1,
-        env: { RALPH_TUI_RUNS_DIR: "/tmp/r" },
+        env: { AUTOPILOT_RUNS_DIR: "/tmp/r" },
         fs: fakeFs,
     });
     e.write({ type: "iteration_end", runId: e.runId, ts: 1, iteration: 1 });
@@ -167,7 +248,7 @@ test("createEventEmitter: ignores non-object / falsy events instead of writing j
     const e = createEventEmitter({
         label: "ralph_loop",
         startedAt: 1,
-        env: { RALPH_TUI_RUNS_DIR: "/tmp/r" },
+        env: { AUTOPILOT_RUNS_DIR: "/tmp/r" },
         fs: { mkdirSync: () => {}, appendFileSync: (p, l) => lines.push({ p, l }) },
     });
     e.write(null);
@@ -182,7 +263,7 @@ test("createEventEmitter: long excerpt is clipped to <= 500 chars + trailing ell
     const e = createEventEmitter({
         label: "ralph_loop",
         startedAt: 1,
-        env: { RALPH_TUI_RUNS_DIR: "/tmp/r" },
+        env: { AUTOPILOT_RUNS_DIR: "/tmp/r" },
         fs: {
             mkdirSync: () => {},
             appendFileSync: (_, line) => captured.push(line),
@@ -200,7 +281,7 @@ test("createEventEmitter: write swallows mkdir + append errors so the loop never
     const e = createEventEmitter({
         label: "ralph_loop",
         startedAt: 1,
-        env: { RALPH_TUI_RUNS_DIR: "/tmp/r" },
+        env: { AUTOPILOT_RUNS_DIR: "/tmp/r" },
         fs: {
             mkdirSync: () => { throw new Error("EROFS"); },
             appendFileSync: () => { throw new Error("ENOSPC"); },
@@ -216,7 +297,7 @@ test("createEventEmitter: mkdir is called once across many writes (memoised)", (
     const e = createEventEmitter({
         label: "ralph_loop",
         startedAt: 1,
-        env: { RALPH_TUI_RUNS_DIR: "/tmp/r" },
+        env: { AUTOPILOT_RUNS_DIR: "/tmp/r" },
         fs: {
             mkdirSync: () => { mkdirCalls += 1; },
             appendFileSync: () => {},
@@ -232,7 +313,7 @@ test("createEventEmitter: close() is a no-op safe to call repeatedly", () => {
     const e = createEventEmitter({
         label: "ralph_loop",
         startedAt: 1,
-        env: { RALPH_TUI_RUNS_DIR: "/tmp/r" },
+        env: { AUTOPILOT_RUNS_DIR: "/tmp/r" },
         fs: { mkdirSync: () => {}, appendFileSync: () => {} },
     });
     assert.doesNotThrow(() => { e.close(); e.close(); });
@@ -243,7 +324,7 @@ test("createEventEmitter: oversize event line is dropped after stripping excerpt
     const e = createEventEmitter({
         label: "ralph_loop",
         startedAt: 1,
-        env: { RALPH_TUI_RUNS_DIR: "/tmp/r" },
+        env: { AUTOPILOT_RUNS_DIR: "/tmp/r" },
         fs: {
             mkdirSync: () => {},
             appendFileSync: (_, line) => captured.push(line),
@@ -268,7 +349,7 @@ test("createEventEmitter: BigInt / circular ref events are dropped, not thrown",
     const e = createEventEmitter({
         label: "ralph_loop",
         startedAt: 1,
-        env: { RALPH_TUI_RUNS_DIR: "/tmp/r" },
+        env: { AUTOPILOT_RUNS_DIR: "/tmp/r" },
         fs: {
             mkdirSync: () => {},
             appendFileSync: (_, line) => captured.push(line),
@@ -289,21 +370,25 @@ test("createEventEmitter: BigInt / circular ref events are dropped, not thrown",
     assert.equal(captured.length, 1);
 });
 
-// Iter 105 — RALPH_TUI_RUNS_DIR routinely picks up stray surrounding
-// whitespace from shell heredocs, Makefile interpolation, copy-paste,
-// etc. Without trimming, the override path was returned verbatim, so
-// `RALPH_TUI_RUNS_DIR=" /tmp/runs "` created `runs` directories whose
+// Env-var values routinely pick up stray surrounding whitespace from
+// shell heredocs, Makefile interpolation, copy-paste, etc. Without
+// trimming, the override path was returned verbatim, so
+// `AUTOPILOT_RUNS_DIR=" /tmp/runs "` created `runs` directories whose
 // name literally contained leading + trailing spaces and broke the
 // matching `autopilot list` glob. Pin that the override is trimmed at
 // resolve time so a future regression cannot reintroduce that
 // papercut.
-test("resolveRunsRoot: trims surrounding whitespace from RALPH_TUI_RUNS_DIR override", () => {
-    assert.equal(resolveRunsRoot({ RALPH_TUI_RUNS_DIR: "  /tmp/ralph-runs  " }), "/tmp/ralph-runs");
-    assert.equal(resolveRunsRoot({ RALPH_TUI_RUNS_DIR: "/tmp/ralph-runs\n" }), "/tmp/ralph-runs");
-    assert.equal(resolveRunsRoot({ RALPH_TUI_RUNS_DIR: "\t/tmp/ralph-runs" }), "/tmp/ralph-runs");
+test("resolveRunsRoot: trims surrounding whitespace from AUTOPILOT_RUNS_DIR override", () => {
+    __resetLegacyWarnGuards();
+    assert.equal(resolveRunsRoot({ AUTOPILOT_RUNS_DIR: "  /tmp/ralph-runs  " }, { fs: noFs }), "/tmp/ralph-runs");
+    assert.equal(resolveRunsRoot({ AUTOPILOT_RUNS_DIR: "/tmp/ralph-runs\n" }, { fs: noFs }), "/tmp/ralph-runs");
+    assert.equal(resolveRunsRoot({ AUTOPILOT_RUNS_DIR: "\t/tmp/ralph-runs" }, { fs: noFs }), "/tmp/ralph-runs");
     // Internal whitespace (paths with literal spaces, like macOS volumes)
     // is preserved — only the SURROUNDING whitespace is stripped.
-    assert.equal(resolveRunsRoot({ RALPH_TUI_RUNS_DIR: "  /Volumes/My Drive/runs  " }), "/Volumes/My Drive/runs");
+    assert.equal(
+        resolveRunsRoot({ AUTOPILOT_RUNS_DIR: "  /Volumes/My Drive/runs  " }, { fs: noFs }),
+        "/Volumes/My Drive/runs",
+    );
 });
 
 // Iter 115 — clipExcerpt's slice boundary must not split a UTF-16
@@ -322,7 +407,7 @@ test("createEventEmitter: clipExcerpt does not produce lone high surrogates at t
     const e = createEventEmitter({
         label: "ralph_loop",
         startedAt: 1,
-        env: { RALPH_TUI_RUNS_DIR: "/tmp/r" },
+        env: { AUTOPILOT_RUNS_DIR: "/tmp/r" },
         fs: {
             mkdirSync: () => {},
             appendFileSync: (_, line) => captured.push(line),
@@ -448,7 +533,7 @@ test("createEventEmitter: serialize salvages an oversize event by stripping exce
     const e = createEventEmitter({
         label: "ralph_loop",
         startedAt: 1,
-        env: { RALPH_TUI_RUNS_DIR: "/tmp/r" },
+        env: { AUTOPILOT_RUNS_DIR: "/tmp/r" },
         fs: {
             mkdirSync: () => {},
             appendFileSync: (_, line) => captured.push(line),

--- a/packages/tui/test/runner.test.mjs
+++ b/packages/tui/test/runner.test.mjs
@@ -4,7 +4,7 @@
 //   - Pure helpers (validateFocus, composePrompt, reduceCopilotEvents)
 //     get straightforward unit tests.
 //   - State-file CAS (initState/updateState/pauseRun/resumeRun/stopRun)
-//     gets isolated tmp-dir tests via $RALPH_TUI_RUNS_DIR.
+//     gets isolated tmp-dir tests via $AUTOPILOT_RUNS_DIR.
 //   - End-to-end loop tests use a Node-script "fake copilot" shim that
 //     emits scripted JSONL on stdout. The shim is parameterised by a
 //     SCRIPT env var (path to a JSON file describing the iter's
@@ -15,7 +15,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, chmodSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { tmpdir, homedir } from "node:os";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -41,6 +41,7 @@ import {
     MAX_FOCUS_CHARS,
     DEFAULT_MAX_ITERATIONS,
     MAX_ALLOWED_ITERATIONS,
+    __resetLegacyWarnGuards,
 } from "../src/runner.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
@@ -52,7 +53,7 @@ function tmp() {
 
 function makeEnv(extra = {}) {
     return {
-        RALPH_TUI_RUNS_DIR: extra.RALPH_TUI_RUNS_DIR ?? tmp(),
+        AUTOPILOT_RUNS_DIR: extra.AUTOPILOT_RUNS_DIR ?? tmp(),
         ...extra,
     };
 }
@@ -191,17 +192,68 @@ test("reduceCopilotEvents: premiumRequests is null when result is missing or mal
 
 // ───────────── State root + path ─────────────
 
-test("resolveStateRoot: honors $RALPH_TUI_RUNS_DIR", () => {
-    assert.equal(resolveStateRoot({ RALPH_TUI_RUNS_DIR: "/tmp/whatever" }), "/tmp/whatever");
+test("resolveStateRoot: honors $AUTOPILOT_RUNS_DIR", () => {
+    assert.equal(resolveStateRoot({ AUTOPILOT_RUNS_DIR: "/tmp/whatever" }), "/tmp/whatever");
 });
 
-test("resolveStateRoot: defaults under ~/.copilot/ralph-tui/runs", () => {
-    const r = resolveStateRoot({});
-    assert.match(r, /\.copilot\/ralph-tui\/runs$/);
+test("resolveStateRoot: defaults under ~/.copilot/autopilot/runs", () => {
+    // Stub fs so the legacy-path read-fallback can't trip on real
+    // home-dir state.
+    const fakeFs = { existsSync: () => false };
+    const r = resolveStateRoot({}, { fs: fakeFs });
+    assert.match(r, /\.copilot\/autopilot\/runs$/);
+});
+
+test("resolveStateRoot: legacy $RALPH_TUI_RUNS_DIR fallback emits one-shot deprecation notice", () => {
+    __resetLegacyWarnGuards();
+    const writes = [];
+    const stderr = { write: (s) => writes.push(s) };
+    const fakeFs = { existsSync: () => false };
+    assert.equal(
+        resolveStateRoot({ RALPH_TUI_RUNS_DIR: "/tmp/legacy" }, { fs: fakeFs, stderr }),
+        "/tmp/legacy",
+    );
+    // Second call same legacy env: dedup keeps stderr quiet.
+    assert.equal(
+        resolveStateRoot({ RALPH_TUI_RUNS_DIR: "/tmp/legacy" }, { fs: fakeFs, stderr }),
+        "/tmp/legacy",
+    );
+    assert.equal(writes.length, 1);
+    assert.match(writes[0], /RALPH_TUI_RUNS_DIR is deprecated/);
+});
+
+test("resolveStateRoot: $AUTOPILOT_RUNS_DIR wins over legacy with no notice", () => {
+    __resetLegacyWarnGuards();
+    const writes = [];
+    const stderr = { write: (s) => writes.push(s) };
+    const fakeFs = { existsSync: () => false };
+    assert.equal(
+        resolveStateRoot(
+            { AUTOPILOT_RUNS_DIR: "/tmp/new", RALPH_TUI_RUNS_DIR: "/tmp/legacy" },
+            { fs: fakeFs, stderr },
+        ),
+        "/tmp/new",
+    );
+    assert.equal(writes.length, 0);
+});
+
+test("resolveStateRoot: legacy-path read-fallback emits one-shot migration notice", () => {
+    __resetLegacyWarnGuards();
+    const writes = [];
+    const stderr = { write: (s) => writes.push(s) };
+    const legacyDefault = join(homedir(), ".copilot", "ralph-tui", "runs");
+    const fakeFs = { existsSync: (p) => p === legacyDefault };
+    const r = resolveStateRoot({}, { fs: fakeFs, stderr });
+    assert.equal(r, legacyDefault);
+    // Second call: dedup.
+    const r2 = resolveStateRoot({}, { fs: fakeFs, stderr });
+    assert.equal(r2, legacyDefault);
+    assert.equal(writes.length, 1);
+    assert.match(writes[0], /reading runs from legacy/);
 });
 
 test("resolveStatePath: joins root + runId + state.json", () => {
-    const env = { RALPH_TUI_RUNS_DIR: "/tmp/r" };
+    const env = { AUTOPILOT_RUNS_DIR: "/tmp/r" };
     assert.equal(resolveStatePath("foo-1", env), "/tmp/r/foo-1/state.json");
 });
 
@@ -209,20 +261,20 @@ test("resolveStatePath: joins root + runId + state.json", () => {
 
 test("updateState: throws TypeError when state.json missing", () => {
     const dir = tmp();
-    const env = { RALPH_TUI_RUNS_DIR: dir };
+    const env = { AUTOPILOT_RUNS_DIR: dir };
     assert.throws(() => updateState("nonexistent", (s) => s, env), TypeError);
     rmSync(dir, { recursive: true, force: true });
 });
 
 test("readState: returns null when state.json missing", () => {
     const dir = tmp();
-    assert.equal(readState("nope", { RALPH_TUI_RUNS_DIR: dir }), null);
+    assert.equal(readState("nope", { AUTOPILOT_RUNS_DIR: dir }), null);
     rmSync(dir, { recursive: true, force: true });
 });
 
 test("pauseRun → resumeRun: idempotent + accumulates totalPausedMs", () => {
     const dir = tmp();
-    const env = { RALPH_TUI_RUNS_DIR: dir };
+    const env = { AUTOPILOT_RUNS_DIR: dir };
     // Seed a state file directly.
     const runId = "test-1";
     mkdirSync(join(dir, runId), { recursive: true });
@@ -258,7 +310,7 @@ test("pauseRun → resumeRun: idempotent + accumulates totalPausedMs", () => {
 
 test("stopRun: sets stopRequested + stopReason, idempotent on terminated runs", () => {
     const dir = tmp();
-    const env = { RALPH_TUI_RUNS_DIR: dir };
+    const env = { AUTOPILOT_RUNS_DIR: dir };
     const runId = "test-2";
     mkdirSync(join(dir, runId), { recursive: true });
     writeFileSync(join(dir, runId, "state.json"),
@@ -277,13 +329,13 @@ test("stopRun: sets stopRequested + stopReason, idempotent on terminated runs", 
 
 test("statusRun: throws TypeError on missing", () => {
     const dir = tmp();
-    assert.throws(() => statusRun("missing", { env: { RALPH_TUI_RUNS_DIR: dir } }), TypeError);
+    assert.throws(() => statusRun("missing", { env: { AUTOPILOT_RUNS_DIR: dir } }), TypeError);
     rmSync(dir, { recursive: true, force: true });
 });
 
 test("updateState: increments version monotonically under sequential writes", () => {
     const dir = tmp();
-    const env = { RALPH_TUI_RUNS_DIR: dir };
+    const env = { AUTOPILOT_RUNS_DIR: dir };
     const runId = "v";
     mkdirSync(join(dir, runId), { recursive: true });
     writeFileSync(join(dir, runId, "state.json"), JSON.stringify({ version: 1, runId, n: 0 }));
@@ -2568,4 +2620,107 @@ test("runRalphTui: accepts an `agent` param and threads it through to runOneIter
         "runRalphTui must thread the chosen agent through to runOneIteration");
     assert.ok(!spawnedArgs.includes("--allow-all-tools"),
         "Copilot's flag must NOT leak when a different agent is selected");
+});
+
+// ───────────── Inline-fallback bin resolver (issue #49) ─────────────
+//
+// `runOneIteration` falls back to an inline resolver when the injected
+// agent doesn't expose `resolveBin` (e.g. test fixtures, downstream
+// wrappers). The fallback honours the same precedence + legacy-name
+// deprecation contract as the canonical `agents/copilot.mjs::resolveBin`.
+
+function makeBinCapturingSpawn(captureBin) {
+    return function (bin, _args) {
+        captureBin.bin = bin;
+        const handlers = { stdout: [], close: [] };
+        const child = {
+            stdout: { on: (ev, fn) => handlers.stdout.push(fn), pipe: () => {} },
+            stderr: { on: () => {}, pipe: () => {} },
+            on: (ev, fn) => { if (ev === "close") handlers.close.push(fn); },
+            kill: () => {},
+        };
+        setImmediate(() => {
+            for (const fn of handlers.stdout) fn(Buffer.from(""));
+            for (const fn of handlers.close) fn(0);
+        });
+        return child;
+    };
+}
+
+const noResolveAgent = {
+    name: "no-resolve",
+    defaultBin: "fallback-default",
+    binEnvVar: "AUTOPILOT_COPILOT_BIN",
+    spawnArgs: (prompt) => ({ args: [prompt], env: undefined }),
+};
+
+test("runOneIteration: inline fallback resolver prefers caller-supplied copilotBin", async () => {
+    const captured = {};
+    await runOneIteration({
+        prompt: "p",
+        spawn: makeBinCapturingSpawn(captured),
+        agent: noResolveAgent,
+        env: { AUTOPILOT_COPILOT_BIN: "/should/not/win", RALPH_TUI_COPILOT_BIN: "/legacy/no" },
+        copilotBin: "/explicit/win",
+    });
+    assert.equal(captured.bin, "/explicit/win");
+});
+
+test("runOneIteration: inline fallback prefers $AUTOPILOT_COPILOT_BIN over $RALPH_TUI_COPILOT_BIN", async () => {
+    __resetLegacyWarnGuards();
+    const captured = {};
+    await runOneIteration({
+        prompt: "p",
+        spawn: makeBinCapturingSpawn(captured),
+        agent: noResolveAgent,
+        env: { AUTOPILOT_COPILOT_BIN: "/usr/bin/autopilot-copilot", RALPH_TUI_COPILOT_BIN: "/usr/bin/legacy" },
+    });
+    assert.equal(captured.bin, "/usr/bin/autopilot-copilot");
+});
+
+test("runOneIteration: inline fallback honors legacy $RALPH_TUI_COPILOT_BIN with one-shot deprecation notice", async () => {
+    __resetLegacyWarnGuards();
+    const writes = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk, ...rest) => {
+        const s = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+        writes.push(s);
+        return origWrite(chunk, ...rest);
+    };
+    try {
+        const captured = {};
+        await runOneIteration({
+            prompt: "p",
+            spawn: makeBinCapturingSpawn(captured),
+            agent: noResolveAgent,
+            env: { RALPH_TUI_COPILOT_BIN: "/usr/bin/legacy-copilot" },
+        });
+        assert.equal(captured.bin, "/usr/bin/legacy-copilot");
+        // Second call with same legacy env: no second notice (per-process dedup).
+        const captured2 = {};
+        await runOneIteration({
+            prompt: "p",
+            spawn: makeBinCapturingSpawn(captured2),
+            agent: noResolveAgent,
+            env: { RALPH_TUI_COPILOT_BIN: "/usr/bin/legacy-copilot" },
+        });
+        assert.equal(captured2.bin, "/usr/bin/legacy-copilot");
+        const matched = writes.filter((w) => /RALPH_TUI_COPILOT_BIN is deprecated/.test(w));
+        assert.equal(matched.length, 1, "deprecation notice should fire exactly once per process");
+        assert.match(matched[0], /AUTOPILOT_COPILOT_BIN/);
+    } finally {
+        process.stderr.write = origWrite;
+    }
+});
+
+test("runOneIteration: inline fallback returns agent.defaultBin when nothing else is set", async () => {
+    __resetLegacyWarnGuards();
+    const captured = {};
+    await runOneIteration({
+        prompt: "p",
+        spawn: makeBinCapturingSpawn(captured),
+        agent: noResolveAgent,
+        env: {},
+    });
+    assert.equal(captured.bin, "fallback-default");
 });

--- a/packages/tui/test/writer.test.mjs
+++ b/packages/tui/test/writer.test.mjs
@@ -11,8 +11,11 @@ import {
     resolveRunsRoot,
     aggregateRuns,
     pruneRuns,
+    __test__ as writerTestBag,
 } from "../src/writer.mjs";
 import { makeRunId } from "../src/events.mjs";
+
+const { __resetLegacyWarnGuards } = writerTestBag;
 
 function mkTmp() {
     return fs.mkdtempSync(path.join(os.tmpdir(), "ralph-tui-writer-"));
@@ -26,17 +29,85 @@ function readLines(filePath) {
         .map((l) => JSON.parse(l));
 }
 
-test("resolveRunsRoot honours $RALPH_TUI_RUNS_DIR", () => {
-    assert.equal(resolveRunsRoot({ env: { RALPH_TUI_RUNS_DIR: "/tmp/x" } }), "/tmp/x");
+test("resolveRunsRoot honours $AUTOPILOT_RUNS_DIR", () => {
+    assert.equal(resolveRunsRoot({ env: { AUTOPILOT_RUNS_DIR: "/tmp/x" } }), "/tmp/x");
 });
 
-test("resolveRunsRoot defaults to $HOME/.copilot/ralph-tui/runs", () => {
+test("resolveRunsRoot defaults to $HOME/.copilot/autopilot/runs", () => {
+    // Stub the fs so neither the new nor legacy default paths "exist"
+    // — the resolver will return the new default unmodified.
     const fakeOs = { homedir: () => "/h" };
-    assert.equal(resolveRunsRoot({ env: {}, os: fakeOs }), "/h/.copilot/ralph-tui/runs");
+    const fakeFs = { existsSync: () => false };
+    assert.equal(
+        resolveRunsRoot({ env: {}, os: fakeOs, fs: fakeFs }),
+        "/h/.copilot/autopilot/runs",
+    );
+});
+
+test("resolveRunsRoot: $RALPH_TUI_RUNS_DIR legacy fallback emits one-shot deprecation notice", () => {
+    __resetLegacyWarnGuards();
+    const writes = [];
+    const stderr = { write: (s) => writes.push(s) };
+    const env = { RALPH_TUI_RUNS_DIR: "/tmp/legacy-env" };
+    assert.equal(resolveRunsRoot({ env, stderr }), "/tmp/legacy-env");
+    // Second call in the same process: same env value, no second notice.
+    assert.equal(resolveRunsRoot({ env, stderr }), "/tmp/legacy-env");
+    assert.equal(writes.length, 1);
+    assert.match(writes[0], /RALPH_TUI_RUNS_DIR is deprecated/);
+    assert.match(writes[0], /AUTOPILOT_RUNS_DIR/);
+});
+
+test("resolveRunsRoot: AUTOPILOT_RUNS_DIR wins over RALPH_TUI_RUNS_DIR with no notice", () => {
+    const writes = [];
+    const stderr = { write: (s) => writes.push(s) };
+    __resetLegacyWarnGuards();
+    assert.equal(
+        resolveRunsRoot({
+            env: { AUTOPILOT_RUNS_DIR: "/tmp/new", RALPH_TUI_RUNS_DIR: "/tmp/legacy" },
+            stderr,
+        }),
+        "/tmp/new",
+    );
+    assert.equal(writes.length, 0);
+});
+
+test("resolveRunsRoot: legacy-path fallback when new default missing + legacy default present", () => {
+    const writes = [];
+    const stderr = { write: (s) => writes.push(s) };
+    __resetLegacyWarnGuards();
+    const fakeOs = { homedir: () => "/h" };
+    // Only the legacy default exists.
+    const fakeFs = {
+        existsSync: (p) => p === "/h/.copilot/ralph-tui/runs",
+    };
+    const root = resolveRunsRoot({ env: {}, os: fakeOs, fs: fakeFs, stderr });
+    assert.equal(root, "/h/.copilot/ralph-tui/runs");
+    // Second call within the same process: no reprint.
+    const root2 = resolveRunsRoot({ env: {}, os: fakeOs, fs: fakeFs, stderr });
+    assert.equal(root2, "/h/.copilot/ralph-tui/runs");
+    assert.equal(writes.length, 1);
+    assert.match(writes[0], /reading runs from legacy/);
+    assert.match(writes[0], /~\/\.copilot\/autopilot\/runs/);
+});
+
+test("resolveRunsRoot: when new default exists, returns new default without legacy notice", () => {
+    const writes = [];
+    const stderr = { write: (s) => writes.push(s) };
+    __resetLegacyWarnGuards();
+    const fakeOs = { homedir: () => "/h" };
+    // Both directories exist on disk; new default wins (sentinel
+    // semantics: once the new root is created, the legacy notice
+    // never reprints).
+    const fakeFs = { existsSync: () => true };
+    assert.equal(
+        resolveRunsRoot({ env: {}, os: fakeOs, fs: fakeFs, stderr }),
+        "/h/.copilot/autopilot/runs",
+    );
+    assert.equal(writes.length, 0);
 });
 
 test("resolveRunEventsPath joins runId under the runs root", () => {
-    const p = resolveRunEventsPath("ralph_loop-1", { env: { RALPH_TUI_RUNS_DIR: "/tmp/r" } });
+    const p = resolveRunEventsPath("ralph_loop-1", { env: { AUTOPILOT_RUNS_DIR: "/tmp/r" } });
     assert.equal(p, "/tmp/r/ralph_loop-1/events.jsonl");
 });
 
@@ -45,7 +116,7 @@ test("resolveRunEventsPath rejects empty runId", () => {
 });
 
 test("resolveRunEventsPath rejects path-traversal runIds", () => {
-    const env = { RALPH_TUI_RUNS_DIR: "/tmp/r" };
+    const env = { AUTOPILOT_RUNS_DIR: "/tmp/r" };
     for (const bad of ["..", ".", "../etc", "foo/../bar", "foo/bar", "foo\\bar", "..\\etc", "foo\0bar"]) {
         assert.throws(
             () => resolveRunEventsPath(bad, { env }),
@@ -56,7 +127,7 @@ test("resolveRunEventsPath rejects path-traversal runIds", () => {
 });
 
 test("resolveRunEventsPath accepts legitimately-shaped runIds", () => {
-    const env = { RALPH_TUI_RUNS_DIR: "/tmp/r" };
+    const env = { AUTOPILOT_RUNS_DIR: "/tmp/r" };
     // Emitter-produced shape: [A-Za-z0-9_-]+
     for (const ok of ["ralph_loop-1", "self_improve-1700000000000", "grow_project-42", "a-b_c-1"]) {
         assert.doesNotThrow(() => resolveRunEventsPath(ok, { env }));
@@ -69,7 +140,7 @@ test("createEventWriter: emits a valid armed line and creates the run dir", () =
     const w = createEventWriter({
         runId,
         label: "ralph_loop",
-        env: { RALPH_TUI_RUNS_DIR: root },
+        env: { AUTOPILOT_RUNS_DIR: root },
         now: () => 1700000000000,
     });
     w.emit({ type: "armed", maxIterations: 20, minIterations: 5 });
@@ -87,7 +158,7 @@ test("createEventWriter: index.jsonl gains a row only on armed events", () => {
     const w = createEventWriter({
         runId: "self_improve-2",
         label: "self_improve",
-        env: { RALPH_TUI_RUNS_DIR: root },
+        env: { AUTOPILOT_RUNS_DIR: root },
         now: () => 2,
     });
     w.emit({ type: "armed" });
@@ -104,7 +175,7 @@ test("createEventWriter: ts is auto-filled from injected clock when caller omits
     const ticks = [10, 20, 30];
     const w = createEventWriter({
         runId: "r-ts",
-        env: { RALPH_TUI_RUNS_DIR: root },
+        env: { AUTOPILOT_RUNS_DIR: root },
         now: () => ticks.shift(),
     });
     w.emit({ type: "armed" });
@@ -118,7 +189,7 @@ test("createEventWriter: caller-provided ts is preserved", () => {
     const root = mkTmp();
     const w = createEventWriter({
         runId: "r-ts2",
-        env: { RALPH_TUI_RUNS_DIR: root },
+        env: { AUTOPILOT_RUNS_DIR: root },
         now: () => 999,
     });
     w.emit({ type: "armed", ts: 1234 });
@@ -131,7 +202,7 @@ test("createEventWriter: serializer failures route through onError, not throw", 
     const errs = [];
     const w = createEventWriter({
         runId: "r-bad",
-        env: { RALPH_TUI_RUNS_DIR: root },
+        env: { AUTOPILOT_RUNS_DIR: root },
         now: () => 1,
         onError: (e) => errs.push(e),
     });
@@ -146,7 +217,7 @@ test("createEventWriter: close() makes subsequent emits no-ops", () => {
     const root = mkTmp();
     const w = createEventWriter({
         runId: "r-close",
-        env: { RALPH_TUI_RUNS_DIR: root },
+        env: { AUTOPILOT_RUNS_DIR: root },
         now: () => 1,
     });
     w.emit({ type: "armed" });
@@ -162,7 +233,7 @@ test("createEventWriter: rejects non-object events through onError (no throw)", 
     const errs = [];
     const w = createEventWriter({
         runId: "r-nono",
-        env: { RALPH_TUI_RUNS_DIR: root },
+        env: { AUTOPILOT_RUNS_DIR: root },
         onError: (e) => errs.push(e),
     });
     w.emit("oops");
@@ -172,7 +243,7 @@ test("createEventWriter: rejects non-object events through onError (no throw)", 
 
 test("createEventWriter: armed getter flips after first armed emit", () => {
     const root = mkTmp();
-    const w = createEventWriter({ runId: "r-armed", env: { RALPH_TUI_RUNS_DIR: root } });
+    const w = createEventWriter({ runId: "r-armed", env: { AUTOPILOT_RUNS_DIR: root } });
     assert.equal(w.armed, false);
     w.emit({ type: "armed" });
     assert.equal(w.armed, true);
@@ -180,18 +251,18 @@ test("createEventWriter: armed getter flips after first armed emit", () => {
 
 test("readRunIndex: empty when index.jsonl is missing", () => {
     const root = mkTmp();
-    assert.deepEqual(readRunIndex({ env: { RALPH_TUI_RUNS_DIR: root } }), []);
+    assert.deepEqual(readRunIndex({ env: { AUTOPILOT_RUNS_DIR: root } }), []);
 });
 
 test("readRunIndex: returns entries newest-first", () => {
     const root = mkTmp();
-    const w1 = createEventWriter({ runId: "r-1", label: "ralph_loop", env: { RALPH_TUI_RUNS_DIR: root }, now: () => 100 });
+    const w1 = createEventWriter({ runId: "r-1", label: "ralph_loop", env: { AUTOPILOT_RUNS_DIR: root }, now: () => 100 });
     w1.emit({ type: "armed" });
-    const w2 = createEventWriter({ runId: "r-2", label: "self_improve", env: { RALPH_TUI_RUNS_DIR: root }, now: () => 200 });
+    const w2 = createEventWriter({ runId: "r-2", label: "self_improve", env: { AUTOPILOT_RUNS_DIR: root }, now: () => 200 });
     w2.emit({ type: "armed" });
-    const w3 = createEventWriter({ runId: "r-3", label: "grow_project", env: { RALPH_TUI_RUNS_DIR: root }, now: () => 300 });
+    const w3 = createEventWriter({ runId: "r-3", label: "grow_project", env: { AUTOPILOT_RUNS_DIR: root }, now: () => 300 });
     w3.emit({ type: "armed" });
-    const entries = readRunIndex({ env: { RALPH_TUI_RUNS_DIR: root } });
+    const entries = readRunIndex({ env: { AUTOPILOT_RUNS_DIR: root } });
     assert.deepEqual(entries.map((e) => e.runId), ["r-3", "r-2", "r-1"]);
     assert.equal(entries[0].label, "grow_project");
 });
@@ -207,7 +278,7 @@ test("readRunIndex: skips malformed lines, keeps good ones", () => {
         JSON.stringify({ type: "weird", ts: 2, runId: "skip" }),
         JSON.stringify({ type: "armed", ts: 3, runId: "ok-2", label: "ralph_loop" }),
     ].join("\n") + "\n");
-    const entries = readRunIndex({ env: { RALPH_TUI_RUNS_DIR: root } });
+    const entries = readRunIndex({ env: { AUTOPILOT_RUNS_DIR: root } });
     assert.deepEqual(entries.map((e) => e.runId), ["ok-2", "ok-1"]);
 });
 
@@ -222,7 +293,7 @@ function writeRun(root, runId, label, lines) {
 
 test("aggregateRuns: empty index yields zero totals", () => {
     const root = mkTmp();
-    const r = aggregateRuns({ env: { RALPH_TUI_RUNS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_RUNS_DIR: root } });
     assert.equal(r.total, 0);
     assert.deepEqual(r.byTool, {});
     assert.deepEqual(r.byReason, {});
@@ -237,7 +308,7 @@ test("aggregateRuns: run with no terminal event counts toward total + byTool but
         { type: "iteration_start", ts: 2, runId: "ralph_loop-1", iteration: 1 },
         { type: "iteration_end", ts: 3, runId: "ralph_loop-1", iteration: 1 },
     ]);
-    const r = aggregateRuns({ env: { RALPH_TUI_RUNS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_RUNS_DIR: root } });
     assert.equal(r.total, 1);
     assert.deepEqual(r.byTool, { ralph_loop: 1 });
     assert.deepEqual(r.byReason, {});
@@ -254,7 +325,7 @@ test("aggregateRuns: last terminal event wins when multiple are present", () => 
         { type: "abort", ts: 2, runId: "self_improve-1", reason: "stagnation", iteration: 3 },
         { type: "complete", ts: 3, runId: "self_improve-1", reason: "completion_promise", iteration: 5 },
     ]);
-    const r = aggregateRuns({ env: { RALPH_TUI_RUNS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_RUNS_DIR: root } });
     assert.deepEqual(r.byReason, { "complete:completion_promise": 1 });
     assert.equal(r.iters.max, 5);
 });
@@ -264,7 +335,7 @@ test("aggregateRuns: skips runs whose events.jsonl is missing", () => {
     // Index claims a run exists, but no events.jsonl on disk.
     fs.writeFileSync(path.join(root, "index.jsonl"),
         JSON.stringify({ type: "armed", ts: 1, runId: "ghost-1", label: "ralph_loop" }) + "\n");
-    const r = aggregateRuns({ env: { RALPH_TUI_RUNS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_RUNS_DIR: root } });
     assert.equal(r.total, 1);
     assert.deepEqual(r.byTool, { ralph_loop: 1 });
     assert.deepEqual(r.byReason, {});
@@ -283,7 +354,7 @@ test("aggregateRuns: malformed JSONL lines are skipped silently", () => {
     ].join("\n") + "\n");
     fs.writeFileSync(path.join(root, "index.jsonl"),
         JSON.stringify({ type: "armed", ts: 1, runId: "rl-1", label: "ralph_loop" }) + "\n");
-    const r = aggregateRuns({ env: { RALPH_TUI_RUNS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_RUNS_DIR: root } });
     assert.equal(r.total, 1);
     assert.deepEqual(r.byReason, { "complete:completion_promise": 1 });
     assert.equal(r.iters.max, 4);
@@ -295,7 +366,7 @@ test("aggregateRuns: terminal event without reason buckets under bare type", () 
         { type: "armed", ts: 1, runId: "rl-2", label: "ralph_loop" },
         { type: "abort", ts: 2, runId: "rl-2", iteration: 2 },
     ]);
-    const r = aggregateRuns({ env: { RALPH_TUI_RUNS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_RUNS_DIR: root } });
     assert.deepEqual(r.byReason, { abort: 1 });
 });
 
@@ -309,7 +380,7 @@ test("aggregateRuns: mean is arithmetic over runs with iterations", () => {
         { type: "armed", ts: 3, runId: "a-2", label: "ralph_loop" },
         { type: "complete", ts: 4, runId: "a-2", reason: "completion_promise", iteration: 8 },
     ]);
-    const r = aggregateRuns({ env: { RALPH_TUI_RUNS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_RUNS_DIR: root } });
     assert.equal(r.total, 2);
     assert.equal(r.iters.max, 8);
     assert.equal(r.iters.mean, 5);
@@ -337,7 +408,7 @@ test("aggregateRuns: handles >150k recorded runs without blowing the call stack"
     };
     const r = aggregateRuns({
         fs: fakeFs,
-        env: { RALPH_TUI_RUNS_DIR: "/fake" },
+        env: { AUTOPILOT_RUNS_DIR: "/fake" },
     });
     assert.equal(r.total, N);
     assert.equal(r.iters.max, 42);
@@ -368,7 +439,7 @@ test("pruneRuns: refuses to delete entries whose runId contains traversal segmen
     const result = pruneRuns({
         olderThanMs: 10,
         now: () => 10_000,
-        env: { RALPH_TUI_RUNS_DIR: root },
+        env: { AUTOPILOT_RUNS_DIR: root },
     });
     // Only the legitimate run was removed.
     assert.deepEqual(result.removed.map((r) => r.runId), [goodId]);
@@ -400,7 +471,7 @@ test("pruneRuns: deletes only the per-run dir, leaves index for fresh runs", () 
     const result = pruneRuns({
         olderThanMs: 1_000,
         now: () => 10_000,
-        env: { RALPH_TUI_RUNS_DIR: root },
+        env: { AUTOPILOT_RUNS_DIR: root },
     });
     assert.equal(result.removed.length, 1);
     assert.equal(result.removed[0].runId, oldId);
@@ -423,7 +494,7 @@ test("pruneRuns: dryRun never touches the filesystem", () => {
         olderThanMs: 1,
         dryRun: true,
         now: () => 10_000,
-        env: { RALPH_TUI_RUNS_DIR: root },
+        env: { AUTOPILOT_RUNS_DIR: root },
     });
     assert.equal(result.removed.length, 1);
     assert.ok(fs.existsSync(path.join(root, oldId)), "dryRun must not delete");
@@ -440,7 +511,7 @@ test("pruneRuns: missing index.jsonl returns empty result", () => {
     const root = mkTmp();
     const result = pruneRuns({
         olderThanMs: 1,
-        env: { RALPH_TUI_RUNS_DIR: root },
+        env: { AUTOPILOT_RUNS_DIR: root },
     });
     assert.deepEqual(result, { removed: [], kept: 0 });
 });
@@ -466,7 +537,7 @@ test("createEventWriter: rejects path-traversal runIds (sandbox-escape guard)", 
     ];
     for (const { runId, label } of cases) {
         assert.throws(
-            () => createEventWriter({ runId, env: { RALPH_TUI_RUNS_DIR: "/tmp/ralph-test-traversal" } }),
+            () => createEventWriter({ runId, env: { AUTOPILOT_RUNS_DIR: "/tmp/ralph-test-traversal" } }),
             (err) => err instanceof TypeError && /path separators or traversal segments/.test(err.message),
             `runId ${JSON.stringify(runId)} (${label}) must throw a TypeError before any fs work`,
         );
@@ -478,7 +549,7 @@ test("createEventWriter: rejects path-traversal runIds (sandbox-escape guard)", 
     try {
         const w = createEventWriter({
             runId: "ralph_loop-deadbeef",
-            env: { RALPH_TUI_RUNS_DIR: tmp },
+            env: { AUTOPILOT_RUNS_DIR: tmp },
         });
         assert.equal(typeof w.emit, "function", "legitimate runIds must still construct successfully");
         w.close();
@@ -506,7 +577,7 @@ test("traversal-guard error message prefixes the calling function name (assertSa
         "resolveRunEventsPath must prefix its own name in the traversal-guard TypeError",
     );
     assert.throws(
-        () => createEventWriter({ runId: "../etc", env: { RALPH_TUI_RUNS_DIR: "/tmp/ralph-test-traversal-prefix" } }),
+        () => createEventWriter({ runId: "../etc", env: { AUTOPILOT_RUNS_DIR: "/tmp/ralph-test-traversal-prefix" } }),
         (err) => err instanceof TypeError
             && err.message.startsWith("createEventWriter:")
             && /path separators or traversal segments/.test(err.message),
@@ -546,7 +617,7 @@ test("aggregateRuns: hand-edited iteration=Infinity (1e500) row is skipped, not 
     fs.writeFileSync(path.join(root, "evil-1", "events.jsonl"), lines.join("\n") + "\n");
     fs.writeFileSync(path.join(root, "index.jsonl"),
         JSON.stringify({ type: "armed", ts: 1, runId: "evil-1", label: "ralph_loop" }) + "\n");
-    const r = aggregateRuns({ env: { RALPH_TUI_RUNS_DIR: root } });
+    const r = aggregateRuns({ env: { AUTOPILOT_RUNS_DIR: root } });
     assert.equal(Number.isFinite(r.iters.max), true,
         "iters.max must stay finite even with a hand-edited 1e500 iteration row");
     assert.equal(Number.isFinite(r.iters.mean), true,
@@ -591,7 +662,7 @@ test("pruneRuns: hand-edited empty-runId row does NOT delete the runs root (data
     const canary = path.join(root, "canary.txt");
     fs.writeFileSync(canary, "do-not-delete");
 
-    pruneRuns({ olderThanMs: 0, env: { RALPH_TUI_RUNS_DIR: root } });
+    pruneRuns({ olderThanMs: 0, env: { AUTOPILOT_RUNS_DIR: root } });
 
     assert.equal(fs.existsSync(root), true, "runs root must NOT be deleted by an empty-runId row");
     assert.equal(fs.existsSync(canary), true, "sibling files at runs root must NOT be deleted by an empty-runId row");
@@ -635,7 +706,7 @@ test("readRunIndex: empty-runId / missing-runId / non-string-runId rows are skip
         // isn't accidentally rejecting valid input.
         JSON.stringify({ type: "armed", ts: 5, runId: "real-1", label: "ralph_loop" }),
     ].join("\n") + "\n");
-    const entries = readRunIndex({ env: { RALPH_TUI_RUNS_DIR: root } });
+    const entries = readRunIndex({ env: { AUTOPILOT_RUNS_DIR: root } });
     assert.equal(entries.length, 1, "only the legitimate row should survive (4 invalid shapes rejected)");
     assert.equal(entries[0].runId, "real-1", "the surviving row must be the one with the non-empty string runId");
 });
@@ -668,7 +739,7 @@ test("pruneRuns: hand-edited ts=-Infinity row does NOT prematurely delete the ru
     const parsed = JSON.parse(corruptedRow);
     assert.equal(parsed.ts, -Infinity, "JSON.parse of the literal -1e500 must materialise as -Infinity");
 
-    const result = pruneRuns({ olderThanMs: 1, now: () => Date.now(), env: { RALPH_TUI_RUNS_DIR: root } });
+    const result = pruneRuns({ olderThanMs: 1, now: () => Date.now(), env: { AUTOPILOT_RUNS_DIR: root } });
 
     assert.equal(result.removed.length, 0, "ts=-Infinity row must NOT be marked for removal — finite-ts guard");
     assert.equal(fs.existsSync(liveRunDir), true, "the legitimate run dir must survive a corrupted-ts row in the index");


### PR DESCRIPTION
## Summary

Issue #49 last-mile work — flip the canonical env-var names to
`AUTOPILOT_*` and the default runs root to `~/.copilot/autopilot/runs`,
with one-release back-compat fallback to the legacy `RALPH_TUI_*` env
vars and `~/.copilot/ralph-tui/runs` path.

- New shared `packages/tui/src/runs-root.mjs` centralizes the resolver.
  `writer.mjs::resolveRunsRoot`, `events-emit.mjs::resolveRunsRoot`, and
  `runner.mjs::resolveStateRoot` are now thin adapters over it.
- Env-var precedence: `$AUTOPILOT_RUNS_DIR` → `$RALPH_TUI_RUNS_DIR`
  (legacy, one-shot stderr deprecation) → `~/.copilot/autopilot/runs`.
  Same shape for `$AUTOPILOT_COPILOT_BIN` / `$RALPH_TUI_COPILOT_BIN` in
  the runner's inline-fallback bin resolver.
- Path read-fallback: when the new default does not exist on disk but
  the legacy default does, return the legacy path AND emit a one-shot
  stderr migration notice. Reprint-gated by a sentinel
  `<NEW_ROOT>/.migrated-from-ralph-tui` that the writer/runner drop on
  the first successful new-root mkdir.
- ENV block in `bin/tui.mjs` updated: `AUTOPILOT_*` listed primary, with
  a single trailing line documenting the `RALPH_TUI_*` deprecation.
- Tests: existing pins flipped to canonical names; new tests cover the
  default path, AUTOPILOT override, legacy env-var deprecation
  (one-shot), legacy-path read-fallback (one-shot), `bin where:`
  default + legacy override, and `runOneIteration` inline-fallback bin
  resolver (caller > AUTOPILOT > RALPH_TUI > defaultBin).

Closes #49.

## Test plan

- [x] `npm test` (576 pass, 93 skipped, 0 fail)
- [x] `npm run check` (27 .mjs files syntax-checked)
- [x] `node packages/tui/bin/tui.mjs --help` — ENV block lists
  AUTOPILOT_* primary with the legacy deprecation footer
- [x] `grep -n 'RALPH_TUI_RUNS_DIR\|RALPH_TUI_COPILOT_BIN\|\.copilot/ralph-tui/runs' packages/tui/src/*.mjs packages/tui/bin/*.mjs`
  surfaces hits ONLY in the legacy-fallback shim sites