### PR TITLE
test(runner): pin lifecycle test to worktree:false, fix red CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Internal
 - Startup sweep removes orphan worktrees from prior `terminated` runs (~200 ms budget). (#66)
 
+### Tests
+- Pin `runRalphTui: emits armed → iteration_start → iteration_end → terminal sequence` to non-worktree mode by passing `worktree: false`, matching the convention established for two other gitExec-count-sensitive tests in #66. The lifecycle skeleton assertion no longer flakes on a fresh checkout (CI), where `git worktree add` succeeds and otherwise injects `worktree_created` / `worktree_kept` events into the recorded sequence. Worktree-aware lifecycle continues to be covered by `runner-worktree.test.mjs`.
+
 ### Breaking
 - Issue #51 — Replaced `ralph-tui run --continue` / `--fresh` with
   `--reset-on={workitem|iter|never}` (default `workitem`). The old

--- a/packages/tui/test/runner.test.mjs
+++ b/packages/tui/test/runner.test.mjs
@@ -632,6 +632,21 @@ test("runRalphTui: emits armed → iteration_start → iteration_end → termina
         env: makeEnv(),
         spawn,
         eventEmitter,
+        // Issue #66 — disable per-iter worktree mode so the
+        // skeleton stays focused on the canonical non-worktree
+        // iteration lifecycle. With worktree on (the default for
+        // self-improve), the runner additionally emits
+        // `worktree_created` after `armed` and `worktree_kept`
+        // before `complete`, which are covered by the dedicated
+        // `runner-worktree.test.mjs` file. Without this opt-out
+        // the test is environment-dependent: on a fresh checkout
+        // (CI) `git worktree add` succeeds and the extra events
+        // fire, while on a repo where the deterministic
+        // `autopilot/test-run-fixed/iter-1` branch already exists
+        // (a prior local run) `createIterWorktree` silently
+        // returns null and the test would pass — a flake we
+        // explicitly close here.
+        worktree: false,
     });
     // The skeleton sequence is armed → iteration_start →
     // (any number of usage_update for live tokens / excerpt


### PR DESCRIPTION
## Summary

The `runRalphTui: emits armed → iteration_start → iteration_end → terminal sequence` test (`packages/tui/test/runner.test.mjs:611`) asserts the canonical lifecycle skeleton `['armed', 'iteration_start', 'session_attached', 'iteration_end', 'complete']` for a `mode: "self-improve"` run. After #66 made worktree mode default-on for `self-improve` / `grow-project`, the runner injects `worktree_created` after `armed` and `worktree_kept` before `complete` whenever `git worktree add` succeeds — failing the deepEqual on every CI run since the merge.

## Why

The most recent CI runs on `main` are all red on this single test (e.g. run [25257317114](https://github.com/kloba/autopilot/actions/runs/25257317114)), blocking releases and silently breaking all downstream consumers who watch the green bar.

## Fix

Pass `worktree: false` to the failing test, matching the convention #66 itself established for two other gitExec-count-sensitive tests in the same file:

- `runRalphTui: failed git commit substage does NOT trigger commit_observed`
- `runRalphTui smoke: full marker stream surfaces stage_plan + task_list + task_start/end + commit_observed + workitem_start/end`

Worktree-aware lifecycle is comprehensively covered by the dedicated 657-line `runner-worktree.test.mjs` so we lose no coverage.

## Verification

- `npm test` -> 559 pass, 0 fail (same as baseline).
- Verified deterministic pass both with and without the orphan local `autopilot/test-run-fixed/iter-1` branch present (locally the orphan branch was masking the regression because `git worktree add` silently returns null on collision).
