### PR TITLE
fix(copilot): probe Copilot CLI version + warn on too-old binary (closes #105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 - Runner now executes each iter in a per-iter git worktree under `$RALPH_TUI_RUNS_DIR/<runId>/worktrees/iter-<N>/` for `--self-improve` and `--grow-project` (`--worktree` opts in for `--prompt`); merged iters tear down on END, unmerged ones are preserved on disk and emit a `worktree_kept` event with the absolute path. (#66)
 
+### Fixes
+- `autopilot run` now probes the Copilot CLI's `--version` output before starting the loop and prints a clear upgrade hint (`copilot CLI: 0.0.354 is older than 1.0.0 — upgrade with \`npm i -g @github/copilot\``) when the resolved binary is older than 1.0.0, missing, or non-executable. The same probe also surfaces in `autopilot doctor` as a `copilot CLI: …` status line so users can confirm the planned run will accept `--output-format json` before kicking off an iter. The check is warn-only (the loop still starts) and can be skipped with `AUTOPILOT_SKIP_CLI_VERSION_CHECK=1`. (#105)
+
 ### Internal
 - Startup sweep removes orphan worktrees from prior `terminated` runs (~200 ms budget). (#66)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,11 +7,13 @@ and a second terminal tailing it live.
 ## Prerequisites
 
 - **Node.js >= 20.** Check with `node --version`.
-- **GitHub Copilot CLI** on your `$PATH`. Check with `copilot --version`. If
-  the binary is missing, follow the upstream
-  [Copilot CLI install guide](https://github.com/github/gh-copilot) first —
-  autopilot drives `copilot -p ...` once per iteration and cannot start
-  without it.
+- **GitHub Copilot CLI >= 1.0.0** on your `$PATH`. Check with
+  `copilot --version`. If the binary is missing or the reported
+  version is older, install / upgrade with `npm i -g @github/copilot`
+  — autopilot drives `copilot -p ... --output-format json` once per
+  iteration and the `--output-format` flag was re-introduced in the
+  1.0.0 line (see issue #105). After installing, run
+  `autopilot doctor` to confirm the resolved version is recognised.
 - **`git`** (any modern version) — autopilot inspects your working tree to
   signal progress between iterations.
 

--- a/packages/tui/bin/tui.mjs
+++ b/packages/tui/bin/tui.mjs
@@ -480,7 +480,7 @@ async function cmdWatch(runId, opts) {
     return 0;
 }
 
-export function cmdDoctor() {
+export async function cmdDoctor() {
     const root = resolveRunsRoot();
     const indexPath = nodePath.join(root, "index.jsonl");
     let healthy = true;
@@ -534,6 +534,26 @@ export function cmdDoctor() {
     // node + tui version
     lines.push(`node: ${process.version}`);
     lines.push(`tui version: ${readTuiVersion()}`);
+
+    // Issue #105 — Copilot CLI version probe. Informational only:
+    // doctor's exit code stays gated on filesystem health (the
+    // critical-path autopilot setup). A user running doctor before
+    // installing Copilot CLI shouldn't get a non-zero exit for a
+    // soft dependency, and a user who picked the Claude backend
+    // doesn't care if Copilot is missing. The probe still surfaces
+    // the version + status so operators can see at a glance whether
+    // the planned Copilot run will hit issue #105's "unknown option
+    // '--output-format'" failure. Skipped when
+    // `AUTOPILOT_SKIP_CLI_VERSION_CHECK=1` is set.
+    if (process.env.AUTOPILOT_SKIP_CLI_VERSION_CHECK !== "1") {
+        try {
+            const copilotMod = await import("../src/agents/copilot.mjs");
+            if (typeof copilotMod.checkCliVersion === "function") {
+                const r = copilotMod.checkCliVersion();
+                lines.push(copilotMod.describeCliVersionResult(r));
+            }
+        } catch { /* swallow — adapter import failure must not crash doctor */ }
+    }
 
     process.stdout.write(lines.join("\n") + "\n");
     if (!healthy) {
@@ -736,6 +756,28 @@ export async function cmdRun(flags) {
                 return 2;
             }
             throw err;
+        }
+    }
+
+    // Issue #105 — proactive Copilot CLI version check. The runner
+    // calls `copilot -p ... --output-format json` each iter; older
+    // Copilot CLI builds (< 1.0.0) reject `--output-format` with an
+    // opaque "unknown option" error from the failed iter-1 spawn.
+    // Probe the binary up-front and surface a friendlier upgrade
+    // hint to stderr before the loop starts. Skipped when the
+    // effective agent isn't Copilot (Claude has its own contract)
+    // or when `AUTOPILOT_SKIP_CLI_VERSION_CHECK=1` is set (test
+    // suites + power users who know their custom shim is fine).
+    // The check is warn-only — we never abort, so a fork or
+    // non-standard build still runs.
+    const effectiveAgentName = flags.agent || "copilot";
+    if (effectiveAgentName === "copilot" && process.env.AUTOPILOT_SKIP_CLI_VERSION_CHECK !== "1") {
+        const copilotMod = agent || await loadAgentByName("copilot");
+        if (copilotMod && typeof copilotMod.checkCliVersion === "function") {
+            const r = copilotMod.checkCliVersion();
+            if (!r.ok && (r.reason === "too-old" || r.reason === "missing")) {
+                process.stderr.write(`autopilot: ${copilotMod.describeCliVersionResult(r)}\n`);
+            }
         }
     }
 
@@ -1051,7 +1093,7 @@ export async function main(argv = process.argv.slice(2)) {
         case "list": return cmdList({ json: Boolean(flags.json), limit: flags.limit });
         case "replay": return cmdReplay(positional[0]);
         case "watch": return await cmdWatch(positional[0], { plain: flags.plain });
-        case "doctor": return cmdDoctor();
+        case "doctor": return await cmdDoctor();
         case "prune": return cmdPrune(flags);
         case "stats": return cmdStats();
         case "where": return cmdWhere();

--- a/packages/tui/src/agents/copilot.mjs
+++ b/packages/tui/src/agents/copilot.mjs
@@ -19,6 +19,7 @@
 // Stdlib-only. Pure ESM, `node:` prefix on stdlib imports.
 
 import process from "node:process";
+import { spawnSync as nodeSpawnSync } from "node:child_process";
 
 import { parseNdjsonLines } from "./_shared.mjs";
 
@@ -134,4 +135,152 @@ export function extractUsage(events) {
         }
     }
     return { input: null, output, premiumRequests };
+}
+
+// ─── CLI version compatibility (issue #105) ────────────────────────
+//
+// The Copilot CLI removed `--output-format json` somewhere in its
+// `0.0.x` line and re-added it in `1.0.0`. A user with an older build
+// running `autopilot copilot` sees an opaque
+//   error: unknown option '--output-format'
+// from the failed iter-1 spawn. The helpers below let `cmdRun` and
+// `cmdDoctor` probe `copilot --version` once at startup, compare
+// against `MIN_KNOWN_GOOD_CLI_VERSION`, and surface a friendlier
+// "please upgrade your Copilot CLI" message before the user has to
+// reverse-engineer the failure mode.
+//
+// The minimum version is phrased as "known supported" rather than a
+// hard semver floor — older 0.0.x builds may also work, but we have
+// not verified them, so the `too-old` warning is informational
+// rather than blocking. The runtime path warns and proceeds; doctor
+// reports the status without affecting its exit code (so a user
+// running doctor before installing Copilot CLI doesn't get a
+// scripting-unfriendly non-zero exit).
+
+/** First Copilot CLI release verified to support
+ *  `--output-format json`. Older 0.0.x builds may also work; this is
+ *  the floor we surface in user-facing warnings. */
+export const MIN_KNOWN_GOOD_CLI_VERSION = "1.0.0";
+
+/** Parse a Copilot CLI `--version` line such as
+ *    "GitHub Copilot CLI 1.0.40."
+ *  or a bare
+ *    "1.0.40"
+ *  into a `[major, minor, patch]` numeric tuple, or `null` if no
+ *  triple can be located. Pure / no I/O — exported for tests. */
+export function parseCliVersion(raw) {
+    if (typeof raw !== "string") return null;
+    const m = raw.match(/(\d+)\.(\d+)\.(\d+)/);
+    if (!m) return null;
+    const triple = [Number(m[1]), Number(m[2]), Number(m[3])];
+    if (triple.some((n) => !Number.isFinite(n) || n < 0)) return null;
+    return triple;
+}
+
+/** Compare two `[major, minor, patch]` triples. Returns -1 / 0 / 1.
+ *  Throws on non-array inputs so a caller can't pass a parse-failure
+ *  through unnoticed. Pure / no I/O — exported for tests. */
+export function compareCliVersion(a, b) {
+    if (!Array.isArray(a) || a.length !== 3 || !Array.isArray(b) || b.length !== 3) {
+        throw new TypeError("compareCliVersion: both args must be [major, minor, patch] triples");
+    }
+    for (let i = 0; i < 3; i++) {
+        if (a[i] < b[i]) return -1;
+        if (a[i] > b[i]) return 1;
+    }
+    return 0;
+}
+
+/** Default exec-fn for `checkCliVersion`. Wraps `spawnSync(bin,
+ *  ['--version'])` with a 2 s timeout and ENOENT/permission/timeout
+ *  detection so the caller can render a precise reason without
+ *  parsing error messages. Tests inject a stub directly. */
+function defaultVersionExec(bin) {
+    let r;
+    try {
+        r = nodeSpawnSync(bin, ["--version"], {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "pipe"],
+            timeout: 2000,
+        });
+    } catch (err) {
+        return { ok: false, reason: "exec-failed", error: err };
+    }
+    if (r.error) {
+        const code = r.error.code;
+        if (code === "ENOENT") return { ok: false, reason: "missing", error: r.error };
+        return { ok: false, reason: "exec-failed", error: r.error };
+    }
+    if (r.status !== 0) {
+        return { ok: false, reason: "exec-failed", stderr: typeof r.stderr === "string" ? r.stderr : "", status: r.status };
+    }
+    return { ok: true, stdout: typeof r.stdout === "string" ? r.stdout : "" };
+}
+
+/** Probe the Copilot CLI's `--version` output and compare against
+ *  `MIN_KNOWN_GOOD_CLI_VERSION`. Returns one of (all values, never
+ *  thrown — caller decides how loudly to react):
+ *
+ *    `{ ok: true,  version: [M,m,p], raw, bin }`
+ *      Version >= min.
+ *
+ *    `{ ok: false, reason: "missing",      bin, error }`
+ *      Binary not found on $PATH (ENOENT).
+ *
+ *    `{ ok: false, reason: "exec-failed",  bin, error?, stderr?, status? }`
+ *      Spawn raised, timed out, or returned non-zero. The user might
+ *      have a working binary that just refuses `--version` for some
+ *      reason — render this differently from "missing" so the user
+ *      knows to look at their PATH vs their binary.
+ *
+ *    `{ ok: false, reason: "unparseable",  bin, raw }`
+ *      Got output but no `M.m.p` triple — could be a fork or pre-1.0
+ *      build with a non-standard version string. Treat as
+ *      informational; we can't tell if it supports `--output-format`.
+ *
+ *    `{ ok: false, reason: "too-old",      bin, version, raw, min }`
+ *      Parsed a version triple < `MIN_KNOWN_GOOD_CLI_VERSION`. The
+ *      caller should warn the user to upgrade.
+ *
+ *  Resolves `bin` via `resolveBin({ env })` when not passed
+ *  explicitly so the legacy-env fallback path is honoured.
+ */
+export function checkCliVersion({ bin, exec = defaultVersionExec, env = process.env, stderr = process.stderr } = {}) {
+    const resolvedBin = bin || resolveBin({ env, stderr });
+    const r = exec(resolvedBin);
+    if (!r || r.ok === false) {
+        return { ok: false, reason: r?.reason ?? "exec-failed", bin: resolvedBin, error: r?.error ?? null, stderr: r?.stderr ?? "", status: r?.status };
+    }
+    const raw = (r.stdout || "").trim();
+    const parsed = parseCliVersion(raw);
+    if (!parsed) return { ok: false, reason: "unparseable", bin: resolvedBin, raw };
+    const min = parseCliVersion(MIN_KNOWN_GOOD_CLI_VERSION);
+    if (compareCliVersion(parsed, min) < 0) {
+        return { ok: false, reason: "too-old", bin: resolvedBin, version: parsed, raw, min };
+    }
+    return { ok: true, version: parsed, bin: resolvedBin, raw };
+}
+
+/** Compose a one-line, user-facing summary of a `checkCliVersion`
+ *  result. Pure / no I/O — `cmdRun` writes the result to stderr,
+ *  `cmdDoctor` writes it to stdout next to the other status lines. */
+export function describeCliVersionResult(result) {
+    if (!result || typeof result !== "object") return "copilot CLI: unknown";
+    if (result.ok) {
+        return `copilot CLI: ${result.version.join(".")} (>= ${MIN_KNOWN_GOOD_CLI_VERSION}, ok)`;
+    }
+    if (result.reason === "missing") {
+        return `copilot CLI: not found at ${result.bin} — install with \`npm i -g @github/copilot\` (>= ${MIN_KNOWN_GOOD_CLI_VERSION})`;
+    }
+    if (result.reason === "exec-failed") {
+        const detail = result.error?.message || result.stderr?.trim() || `exit ${result.status}`;
+        return `copilot CLI: \`${result.bin} --version\` failed (${detail})`;
+    }
+    if (result.reason === "unparseable") {
+        return `copilot CLI: at ${result.bin} but \`--version\` output is unrecognised (got: ${JSON.stringify(result.raw).slice(0, 80)})`;
+    }
+    if (result.reason === "too-old") {
+        return `copilot CLI: ${result.version.join(".")} is older than ${MIN_KNOWN_GOOD_CLI_VERSION} — upgrade with \`npm i -g @github/copilot\` to avoid \`unknown option '--output-format'\` (issue #105)`;
+    }
+    return `copilot CLI: unknown status (${result.reason ?? "?"})`;
 }

--- a/packages/tui/test/agents.test.mjs
+++ b/packages/tui/test/agents.test.mjs
@@ -292,3 +292,137 @@ test("agent metadata: claude adapter has the documented name + binEnvVar", () =>
     assert.equal(claude.defaultBin, "claude");
     assert.equal(claude.binEnvVar, "AUTOPILOT_CLAUDE_BIN");
 });
+
+// ─── Copilot CLI version probe (issue #105) ────────────────────────
+//
+// The runner spawns `copilot -p ... --output-format json`; older
+// 0.0.x builds reject the `--output-format` flag with a confusing
+// "unknown option" error. The adapter exports a small probe (parse,
+// compare, check, describe) so `cmdRun` and `cmdDoctor` can surface
+// a clear upgrade hint up-front. Helpers are pure where possible
+// and the I/O-bearing `checkCliVersion` accepts an injected
+// `exec`/`env`/`stderr` for the test seam.
+
+test("copilot.parseCliVersion: extracts the M.m.p triple from the documented Copilot CLI banner", () => {
+    assert.deepEqual(copilot.parseCliVersion("GitHub Copilot CLI 1.0.40."), [1, 0, 40]);
+    assert.deepEqual(copilot.parseCliVersion("GitHub Copilot CLI 1.0.40\n"), [1, 0, 40]);
+    assert.deepEqual(copilot.parseCliVersion("0.0.354"), [0, 0, 354]);
+    assert.deepEqual(copilot.parseCliVersion("v2.13.7-beta.1"), [2, 13, 7]);
+});
+
+test("copilot.parseCliVersion: returns null for non-string / un-parseable input", () => {
+    assert.equal(copilot.parseCliVersion(null), null);
+    assert.equal(copilot.parseCliVersion(undefined), null);
+    assert.equal(copilot.parseCliVersion(42), null);
+    assert.equal(copilot.parseCliVersion(""), null);
+    assert.equal(copilot.parseCliVersion("no version here"), null);
+    assert.equal(copilot.parseCliVersion("1.2"), null); // need three components
+});
+
+test("copilot.compareCliVersion: orders triples lexicographically and throws on bad input", () => {
+    assert.equal(copilot.compareCliVersion([1, 0, 0], [0, 9, 99]), 1);
+    assert.equal(copilot.compareCliVersion([0, 9, 99], [1, 0, 0]), -1);
+    assert.equal(copilot.compareCliVersion([1, 2, 3], [1, 2, 3]), 0);
+    assert.equal(copilot.compareCliVersion([1, 0, 40], [1, 0, 0]), 1);
+    assert.equal(copilot.compareCliVersion([0, 0, 354], [1, 0, 0]), -1);
+    assert.throws(() => copilot.compareCliVersion(null, [1, 0, 0]), TypeError);
+    assert.throws(() => copilot.compareCliVersion([1, 0, 0], "1.0.0"), TypeError);
+    assert.throws(() => copilot.compareCliVersion([1, 0], [1, 0, 0]), TypeError);
+});
+
+test("copilot.checkCliVersion: ok path returns the parsed triple + raw banner", () => {
+    const r = copilot.checkCliVersion({
+        bin: "/fake/copilot",
+        exec: () => ({ ok: true, stdout: "GitHub Copilot CLI 1.0.40.\n" }),
+    });
+    assert.equal(r.ok, true);
+    assert.deepEqual(r.version, [1, 0, 40]);
+    assert.equal(r.bin, "/fake/copilot");
+    assert.equal(r.raw, "GitHub Copilot CLI 1.0.40.");
+});
+
+test("copilot.checkCliVersion: too-old version reports the floor and the actual triple", () => {
+    const r = copilot.checkCliVersion({
+        bin: "/fake/copilot",
+        exec: () => ({ ok: true, stdout: "GitHub Copilot CLI 0.0.354.\n" }),
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "too-old");
+    assert.deepEqual(r.version, [0, 0, 354]);
+    assert.deepEqual(r.min, [1, 0, 0]);
+});
+
+test("copilot.checkCliVersion: missing binary surfaces reason='missing' (ENOENT)", () => {
+    const err = Object.assign(new Error("spawn /no/such ENOENT"), { code: "ENOENT" });
+    const r = copilot.checkCliVersion({
+        bin: "/no/such/copilot",
+        exec: () => ({ ok: false, reason: "missing", error: err }),
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "missing");
+    assert.equal(r.bin, "/no/such/copilot");
+});
+
+test("copilot.checkCliVersion: spawn failure (non-ENOENT) surfaces reason='exec-failed'", () => {
+    const r = copilot.checkCliVersion({
+        bin: "/fake/copilot",
+        exec: () => ({ ok: false, reason: "exec-failed", stderr: "permission denied", status: 126 }),
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "exec-failed");
+    assert.equal(r.stderr, "permission denied");
+    assert.equal(r.status, 126);
+});
+
+test("copilot.checkCliVersion: unparseable output surfaces reason='unparseable' with the raw text", () => {
+    const r = copilot.checkCliVersion({
+        bin: "/fake/copilot",
+        exec: () => ({ ok: true, stdout: "Copilot CLI nightly-build\n" }),
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "unparseable");
+    assert.equal(r.raw, "Copilot CLI nightly-build");
+});
+
+test("copilot.checkCliVersion: resolves bin via resolveBin when not passed explicitly", () => {
+    let observedBin = null;
+    const r = copilot.checkCliVersion({
+        env: { AUTOPILOT_COPILOT_BIN: "/from/env/copilot" },
+        exec: (bin) => { observedBin = bin; return { ok: true, stdout: "1.0.0\n" }; },
+        stderr: { write: () => true },
+    });
+    assert.equal(observedBin, "/from/env/copilot");
+    assert.equal(r.ok, true);
+    assert.equal(r.bin, "/from/env/copilot");
+});
+
+test("copilot.describeCliVersionResult: composes a one-line summary for each branch", () => {
+    assert.match(
+        copilot.describeCliVersionResult({ ok: true, version: [1, 0, 40], bin: "/fake/copilot", raw: "1.0.40" }),
+        /copilot CLI: 1\.0\.40 \(>= 1\.0\.0, ok\)/,
+    );
+    assert.match(
+        copilot.describeCliVersionResult({ ok: false, reason: "too-old", version: [0, 0, 354], min: [1, 0, 0], bin: "/fake/copilot", raw: "0.0.354" }),
+        /copilot CLI: 0\.0\.354 is older than 1\.0\.0.*issue #105/,
+    );
+    assert.match(
+        copilot.describeCliVersionResult({ ok: false, reason: "missing", bin: "/no/such/copilot" }),
+        /copilot CLI: not found at \/no\/such\/copilot.*npm i -g @github\/copilot/,
+    );
+    assert.match(
+        copilot.describeCliVersionResult({ ok: false, reason: "exec-failed", bin: "/fake/copilot", error: new Error("boom"), status: 1 }),
+        /copilot CLI: `\/fake\/copilot --version` failed \(boom\)/,
+    );
+    assert.match(
+        copilot.describeCliVersionResult({ ok: false, reason: "unparseable", bin: "/fake/copilot", raw: "weird build string" }),
+        /copilot CLI: at \/fake\/copilot but `--version` output is unrecognised/,
+    );
+    assert.match(
+        copilot.describeCliVersionResult(null),
+        /copilot CLI: unknown/,
+    );
+});
+
+test("copilot.MIN_KNOWN_GOOD_CLI_VERSION: pinned at 1.0.0 (issue #105)", () => {
+    assert.equal(copilot.MIN_KNOWN_GOOD_CLI_VERSION, "1.0.0");
+});

--- a/packages/tui/test/bin.test.mjs
+++ b/packages/tui/test/bin.test.mjs
@@ -156,6 +156,35 @@ test("bin doctor: healthy case exits 0 and prints all sections", () => {
     rmSync(dir, { recursive: true, force: true });
 });
 
+test("bin doctor: includes copilot CLI status line by default (issue #105)", () => {
+    const dir = tmp();
+    // Force the copilot probe through a known-bad path so the test
+    // is hermetic — whatever the real $PATH looks like on the host
+    // we get a deterministic "not found" / "unknown" line. We must
+    // NOT set AUTOPILOT_SKIP_CLI_VERSION_CHECK here since the whole
+    // point is to assert the line shows up by default; clear it
+    // explicitly to defend against parent shells that already set it.
+    const r = runBin(["doctor"], {
+        RALPH_TUI_RUNS_DIR: dir,
+        AUTOPILOT_COPILOT_BIN: "/nonexistent-copilot-for-doctor-test",
+        AUTOPILOT_SKIP_CLI_VERSION_CHECK: "",
+    });
+    assert.equal(r.status, 0, "doctor must stay informational on missing copilot");
+    assert.match(r.stdout, /copilot CLI:/);
+    rmSync(dir, { recursive: true, force: true });
+});
+
+test("bin doctor: AUTOPILOT_SKIP_CLI_VERSION_CHECK=1 suppresses the copilot CLI status line", () => {
+    const dir = tmp();
+    const r = runBin(["doctor"], {
+        RALPH_TUI_RUNS_DIR: dir,
+        AUTOPILOT_SKIP_CLI_VERSION_CHECK: "1",
+    });
+    assert.equal(r.status, 0);
+    assert.doesNotMatch(r.stdout, /copilot CLI:/);
+    rmSync(dir, { recursive: true, force: true });
+});
+
 test("bin doctor: unwritable runs root exits non-zero with path", () => {
     const dir = tmp();
     chmodSync(dir, 0o500);


### PR DESCRIPTION
Closes #105.

## What

Probe the Copilot CLI's `--version` output up-front and surface a
clear upgrade hint when the resolved binary is missing or older than
the floor that supports `--output-format json` (1.0.0).

## Why

The runner unconditionally drives `copilot -p ... --output-format
json` to consume Copilot CLI's JSONL event stream. Older `copilot`
builds (e.g. 0.0.354 — still installable today) reject
`--output-format` with `unknown option '--output-format'`, so the
loop crashes one iter in with a confusing error pointing at an
internal flag the user never typed.

Issue #105 lists three options: drop the flag and parse text,
pin a min version + warn, or probe `--help` and conditionally
include the flag. This PR takes option (2) — the issue itself
recommends it as the smallest, and it doesn't require dragging
the runner into a per-iter probe path.

## How

* New adapter exports in `packages/tui/src/agents/copilot.mjs`:
  - `MIN_KNOWN_GOOD_CLI_VERSION = "1.0.0"` (pinned constant).
  - `parseCliVersion(raw)` — pure parser for the documented banner
    (`"GitHub Copilot CLI 1.0.40."`) or a bare triple.
  - `compareCliVersion(a, b)` — pure ordering, throws on bad shape.
  - `checkCliVersion({ bin, exec, env, stderr })` — probes
    `<bin> --version` (2 s timeout) and classifies the outcome as
    `ok` / `missing` (ENOENT) / `exec-failed` (timeout / non-zero
    / spawn raise) / `unparseable` (no M.m.p in output) / `too-old`.
  - `describeCliVersionResult(result)` — composes a one-line
    user-facing summary for each branch.
* `cmdRun` calls `checkCliVersion` once after sibling-flag handling
  and before driver-mode detection, gated on the effective agent
  being copilot (explicit `--agent copilot` or the default when no
  `--agent` is passed). On `too-old` / `missing` it writes
  `describeCliVersionResult(...)` to stderr and continues —
  warn-only so a fork or non-standard build still runs.
* `cmdDoctor` appends the same `copilot CLI: …` line as a status
  row alongside `node:` and `tui version:`. Doctor's exit code
  stays gated on filesystem health (informational only) so a user
  running `autopilot doctor` before installing Copilot CLI doesn't
  get a non-zero exit.
* Both call sites honour `AUTOPILOT_SKIP_CLI_VERSION_CHECK=1`
  for tests + power users with a custom shim.
* `docs/quickstart.md` Prerequisites pin the `>= 1.0.0` floor
  next to the `npm i -g @github/copilot` install hint.
* CHANGELOG `## Unreleased` gains a `### Fixes` entry.

## Tests

* `packages/tui/test/agents.test.mjs` — unit coverage for the new
  surface (banner-parse, ordering, the five `checkCliVersion`
  branches via stub `exec`, `describeCliVersionResult` per
  branch, and the pinned `MIN_KNOWN_GOOD_CLI_VERSION` constant).
* `packages/tui/test/bin.test.mjs` — two new `bin doctor`
  integration tests:
  - `includes copilot CLI status line by default (issue #105)`
  - `AUTOPILOT_SKIP_CLI_VERSION_CHECK=1 suppresses the copilot
    CLI status line`

`npm test` 681 pass / 0 fail / 93 skipped (was 668 / 0 / 93).
`npm run check` clean.

## Sample output

    $ AUTOPILOT_COPILOT_BIN=/nonexistent node packages/tui/bin/tui.mjs doctor
    runs root: ...
               ok (writable)
    run index: ...
               ok (readable)
    runs found: 0
    node: v23.11.0
    tui version: 0.7.0
    copilot CLI: not found at /nonexistent — install with `npm i -g @github/copilot` (>= 1.0.0)

    $ AUTOPILOT_SKIP_CLI_VERSION_CHECK=1 node packages/tui/bin/tui.mjs doctor
    ... (no copilot CLI line)
